### PR TITLE
Solvers & Minimizers to class

### DIFF
--- a/src/civerly/benchmark.py
+++ b/src/civerly/benchmark.py
@@ -1,6 +1,5 @@
 r"""Benchmark CiVerLy."""
 
-from civerly.solvers import solve
 from civerly.solvers import SOLVING_STATUS
 from civerly.util import suppress_output
 from civerly.model_options import GRANULARITY
@@ -8,10 +7,6 @@ from civerly.model_options import OPTIMIZATION
 
 import shutil
 import time
-
-from civerly.solvers import get_objective_value
-from civerly.solvers import get_objective_bounds
-from civerly.solvers import optimize_sat
 
 
 def benchmark(CM=None, remove_files=False, only_models=False,
@@ -44,20 +39,21 @@ def benchmark(CM=None, remove_files=False, only_models=False,
         ....:   optimization=OPTIMIZATION.MILP,
         ....:   granularity=GRANULARITY.WORDWISE,
         ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
-        ....:   solver=SOLVER.SCIP,
+        ....:   milp_solver=SCIP_CVL(),
         ....:   path=path)
         sage: aes = [AES_CVL(R=r, name=f"{r}r-AES") for r in range(1, 10)]
         sage: CM = [(aes, model_options)]
         sage: benchmark(CM) # optional - scip
         ...
-        sage: import shutil
-        sage: shutil.rmtree("DOCTEST-Benchmark-AES-Models", ignore_errors=True)
     """
     for ciphers, model_options in CM:
         optimization = model_options.optimization.name
         mode = model_options.cryptanalysis.name
         granularity = model_options.granularity.name
-        solver = model_options.solver.name
+        if model_options.optimization == OPTIMIZATION.MILP:
+            solver = model_options.milp_solver.name
+        elif model_options.optimization == OPTIMIZATION.SAT:
+            solver = model_options.sat_solver.name
         if model_options.linear_layer_modeling:
             ll = model_options.linear_layer_modeling.name
         else:
@@ -110,24 +106,21 @@ def benchmark(CM=None, remove_files=False, only_models=False,
                     solve_start = time.time()
 
                     if model_options.optimization == OPTIMIZATION.MILP:
-                        name = f"{cipher.name}_{model_options.solver.name}"
+                        name = f"{cipher.name}_{model_options.milp_solver.name}"
                         log_file_name = model_options.path / f"{name}.log"
                         sol_file_name = model_options.path / (cipher.name + ".sol")
-                        status = solve(model_options.path / (cipher.name + ".mps"),
+                        status = model_options.milp_solver.solve(model_options.path / (cipher.name + ".mps"),
                                        sol_file_name,
-                                       solver=model_options.solver,
                                        time_limit=solving_time_limit,
                                        log_file_name=log_file_name)
                         solve_stop = time.time()
                         solve_time = round(solve_stop - solve_start, 2)
                         if status is None:
-                            obj = get_objective_value(sol_file_name,
-                                                      model_options.solver)
+                            obj = model_options.milp_solver.process_solution_file(sol_file_name)[1]
                             solve_time = f"{solve_time}s"
                         elif status == SOLVING_STATUS.TIMEOUT:
                             solve_time = f"{solving_time_limit}s$^{{\\dagger}}$"
-                            bounds = get_objective_bounds(log_file_name,
-                                                          model_options.solver)
+                            bounds = model_options.milp_solver.get_objective_bounds(log_file_name)
                             if bounds == [None, None]:
                                 obj = "-"
                             else:
@@ -136,7 +129,7 @@ def benchmark(CM=None, remove_files=False, only_models=False,
                             pass
 
                     elif model_options.optimization == OPTIMIZATION.SAT:
-                        benchmarks = optimize_sat(
+                        benchmarks = model_options.sat_solver.solve(
                             model_options.path / (cipher.name + ".cnf"),
                             model_options.path / (cipher.name + ".sat"),
                             model_options=model_options,
@@ -174,9 +167,8 @@ def benchmark(CM=None, remove_files=False, only_models=False,
                             s += f"[{row["W_MIN"]}, {row["W_MAX"]}]"
                             s += " & \\\\*"
                         else:
-                            bound = get_objective_value(
-                                model_options.path / (cipher.name + ".sat"),
-                                model_options.solver)
+                            bound = model_options.sat_solver.process_solution_file(
+                                model_options.path / (cipher.name + ".sat"))[1]
                             s += " & "
                             s += f"{bound} & \\cmark \\\\*"
                         table.append(s)

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -48,12 +48,10 @@ import glob
 from math import ceil, sqrt
 
 from civerly.component import Component
-from civerly.solvers import solve, get_objective_value
-from civerly.solvers import _process_solution_file, optimize_sat
 from civerly.model_options import OPTIMIZATION, GRANULARITY
 from civerly.model_options import CRYPTANALYSIS
 from civerly.model_options import InvalidModelOptionException
-from civerly.model_options import NoSolverWarning
+from civerly.solvers import NoSolverWarning
 from civerly.util import _before_brackets, _between_brackets
 from civerly.util import suppress_output, translate_sat_clause
 from civerly.trail import TrailNode
@@ -1474,38 +1472,35 @@ class Cipher:
         """
         if model_options.optimization == OPTIMIZATION.MILP:
             self.model(model_options)
-            if model_options.solver is None:
+            if model_options.milp_solver is None:
                 raise NoSolverWarning()
             else:
-                solve(
+                model_options.milp_solver.solve(
                     input_file_name=model_options.path / (self.name + ".mps"),
-                    output_file_name=model_options.path / (self.name + ".sol"),
-                    solver=model_options.solver
+                    output_file_name=model_options.path / (self.name + ".sol")
                 )
-                return get_objective_value(
-                    model_options.path / (self.name + ".sol"),
-                    model_options.solver
-                )
+                return model_options.milp_solver.process_solution_file(
+                    model_options.path / (self.name + ".sol")
+                )[1]
         elif model_options.optimization == OPTIMIZATION.SAT:
             self.model(model_options)
             if self._return_immediately_:
                 return
             else:
-                # if no solver has been selected, we generate all cnf-files
+                # if no sat_solver has been selected, we generate all cnf-files
                 # for the given solve_range
-                optimize_sat(
+                model_options.sat_solver.solve(
                     model_options.path / (self.name + ".cnf"),
                     model_options.path / (self.name + ".sat"),
                     model_options=model_options,
                     time_limit=None)
 
-                if model_options.solver is None:
+                if model_options.sat_solver is None:
                     raise NoSolverWarning()
                 else:
-                    return get_objective_value(
+                    return model_options.sat_solver.process_solution_file(
                         model_options.path / (self.name + ".sat"),
-                        model_options.solver
-                    )
+                    )[1]
         else:
             raise InvalidModelOptionException(
                 model_options.optimization, OPTIMIZATION
@@ -1634,16 +1629,18 @@ class Cipher:
         if model_options.optimization == OPTIMIZATION.MILP:
             milp_or_sat = "MILP"
             solution_file_name = model_options.path / (self.name + ".sol")
+            results, objective_value = model_options.milp_solver.process_solution_file(
+                solution_file_name)
         elif model_options.optimization == OPTIMIZATION.SAT:
             milp_or_sat = "SAT"
             solution_file_name = model_options.path / (self.name + ".sat")
+            results, objective_value = model_options.sat_solver.process_solution_file(
+                solution_file_name)
         else:
             raise InvalidModelOptionException(
                 model_options.optimization, OPTIMIZATION
             )
 
-        results, objective_value = _process_solution_file(
-            solution_file_name, model_options.solver)
 
         STRING = "\\documentclass{article}\n"
         STRING += "\\usepackage{amssymb}\n"
@@ -1748,16 +1745,19 @@ class Cipher:
         """
         if model_options.optimization == OPTIMIZATION.MILP:
             solution_file_name = model_options.path / (self.name + ".sol")
+            results = model_options.milp_solver.process_solution_file(
+                solution_file_name
+            )[0]
         elif model_options.optimization == OPTIMIZATION.SAT:
             solution_file_name = model_options.path / (self.name + ".sat")
+            results = model_options.sat_solver.process_solution_file(
+                solution_file_name
+            )[0]
         else:
             raise InvalidModelOptionException(
                 model_options.optimization, OPTIMIZATION
             )
 
-        results, _ = _process_solution_file(
-            solution_file_name, model_options.solver
-        )
         root_node = TrailNode(cipher_instance=self)
         self._draw_or_get_trail_rec(
             results, model_options, root_node, _report=False
@@ -1799,10 +1799,6 @@ class Cipher:
             else:
                 dictionaries = self.dictionaries_milp
 
-            def check_condition(comp_num, s):
-                return ("IN" not in s and "OUT" not in s) and \
-                    _before_brackets(s) == comp_num
-
         elif model_options.optimization == OPTIMIZATION.SAT:
             if not hasattr(self, 'dictionaries_sat'):
                 with open(model_options.path / (self.name + "_d.json")) as f:
@@ -1824,13 +1820,28 @@ class Cipher:
         # Recursively iterate through each subcipher
         for comp_num, comp in enumerate(self.nodes):
             if isinstance(comp, Cipher):
-                sub_results = {}
-                for s, solution_bit_value in results.items():
-                    if check_condition(comp_num, s):
-                        # Translate the results using the corresponding
-                        # dictionaries
-                        sub_results[dictionaries[comp_num][s]] = \
+                if model_options.optimization == OPTIMIZATION.MILP:
+                    # Build nested sub_results for the sub-cipher directly
+                    # from the parent's nested results entry for this comp_num
+                    sub_results = {}
+                    var_name = f"X{comp_num}"
+                    for s_ind, solution_bit_value in \
+                            results.get(var_name, {}).items():
+                        translated = dictionaries[comp_num][
+                            f"{var_name}[{s_ind}]"
+                        ]
+                        tr_name, tr_rest = translated.split('[', 1)
+                        tr_ind = int(tr_rest.rstrip(']'))
+                        sub_results.setdefault(tr_name, {})[tr_ind] = \
                             solution_bit_value
+                else:  # SAT
+                    sub_results = {}
+                    for s, solution_bit_value in results.items():
+                        if check_condition(comp_num, s):
+                            # Translate the results using the corresponding
+                            # dictionaries
+                            sub_results[dictionaries[comp_num][s]] = \
+                                solution_bit_value
 
                 new_node = current_node.children[depths[comp_num]]
 
@@ -1985,21 +1996,36 @@ class Cipher:
         ]
 
         # Sort the (messy and unordered) variable values correctly
-        for s, solution_bit_value in results.items():
-
-            # recover comp_num and comp
-            if model_options.optimization == OPTIMIZATION.MILP:
-                if "IN" in s or "OUT" in s:
-                    # if s is MILP_IN or MILP_OUT, we skip it
+        if model_options.optimization == OPTIMIZATION.MILP:
+            for var_name, var_dict in results.items():
+                if var_name in ("IN", "OUT"):
+                    # if var_name is MILP_IN or MILP_OUT, we skip it
                     continue
-                comp_num, s_ind = _before_brackets(s), _between_brackets(s)
+                comp_num = int(var_name[1:])
+                for s_ind, solution_bit_value in var_dict.items():
+                    translated_component = dictionaries[comp_num][
+                        f"{var_name}[{s_ind}]"
+                    ]
+                    # Draw the input nodes of each component
+                    bool1 = "IN" in translated_component
+                    # We also draw the output of the last component.
+                    bool2 = "OUT" in translated_component
 
-                translated_component = dictionaries[comp_num][f"X{comp_num}[{s_ind}]"]
-                # Draw the input nodes of each component
-                bool1 = "IN" in translated_component
-                # We also draw the output of the last component.
-                bool2 = "OUT" in translated_component
-            elif model_options.optimization == OPTIMIZATION.SAT:
+                    if bool1 and comp_num != 0:  # dont draw self.IN.in
+                        current_index = _between_brackets(translated_component)
+                        bit_ind = _from_grid(
+                            comp_num, current_index, input_side=True
+                        )
+                        bits_in[depths[comp_num]][bit_ind] = solution_bit_value
+                    elif bool2:
+                        current_index = _between_brackets(translated_component)
+                        bit_ind = _from_grid(
+                            comp_num, current_index, input_side=False
+                        )
+                        bits_out[depths[comp_num]][bit_ind] = solution_bit_value
+        elif model_options.optimization == OPTIMIZATION.SAT:
+            # NOTE: SAT-vars start at 1 while grid-indexing starts at 0
+            for s, solution_bit_value in results.items():
                 if s <= self.input_length + self.output_length:
                     # if s is SAT_IN or SAT_OUT, we skip it
                     continue
@@ -2026,34 +2052,24 @@ class Cipher:
                 # We also draw the output of the last component.
                 bool2 = comp.input_length < translated_component and \
                     translated_component <= comp.input_length + comp.output_length
-            else:
-                raise InvalidModelOptionException(
-                    model_options.optimization, OPTIMIZATION
-                )
 
-            # NOTE: For SAT we offset by -1 because SAT-vars start at 1
-            # while grid-indexing starts at 0
-            if bool1 and comp_num != 0:  # dont draw self.IN.in
-                if model_options.optimization == OPTIMIZATION.MILP:
-                    current_index = _between_brackets(translated_component)
-                elif model_options.optimization == OPTIMIZATION.SAT:
+                if bool1 and comp_num != 0:  # dont draw self.IN.in
                     current_index = translated_component - 1
-
-                bit_ind = _from_grid(
-                    comp_num, current_index, input_side=True
-                )
-                bits_in[depths[comp_num]][bit_ind] = solution_bit_value
-            elif bool2:
-                if model_options.optimization == OPTIMIZATION.MILP:
-                    current_index = _between_brackets(translated_component)
-                elif model_options.optimization == OPTIMIZATION.SAT:
+                    bit_ind = _from_grid(
+                        comp_num, current_index, input_side=True
+                    )
+                    bits_in[depths[comp_num]][bit_ind] = solution_bit_value
+                elif bool2:
                     current_index = translated_component - \
                         self.nodes[comp_num].input_length - 1
-
-                bit_ind = _from_grid(
-                    comp_num, current_index, input_side=False
-                )
-                bits_out[depths[comp_num]][bit_ind] = solution_bit_value
+                    bit_ind = _from_grid(
+                        comp_num, current_index, input_side=False
+                    )
+                    bits_out[depths[comp_num]][bit_ind] = solution_bit_value
+        else:
+            raise InvalidModelOptionException(
+                model_options.optimization, OPTIMIZATION
+            )
 
         # realign bits_in, bits_out by removing any 'None' entries
         bits_in = [

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -1799,6 +1799,10 @@ class Cipher:
             else:
                 dictionaries = self.dictionaries_milp
 
+            def check_condition(comp_num, s):
+                return ("IN" not in s and "OUT" not in s) and \
+                    _before_brackets(s) == comp_num
+
         elif model_options.optimization == OPTIMIZATION.SAT:
             if not hasattr(self, 'dictionaries_sat'):
                 with open(model_options.path / (self.name + "_d.json")) as f:
@@ -1820,28 +1824,13 @@ class Cipher:
         # Recursively iterate through each subcipher
         for comp_num, comp in enumerate(self.nodes):
             if isinstance(comp, Cipher):
-                if model_options.optimization == OPTIMIZATION.MILP:
-                    # Build nested sub_results for the sub-cipher directly
-                    # from the parent's nested results entry for this comp_num
-                    sub_results = {}
-                    var_name = f"X{comp_num}"
-                    for s_ind, solution_bit_value in \
-                            results.get(var_name, {}).items():
-                        translated = dictionaries[comp_num][
-                            f"{var_name}[{s_ind}]"
-                        ]
-                        tr_name, tr_rest = translated.split('[', 1)
-                        tr_ind = int(tr_rest.rstrip(']'))
-                        sub_results.setdefault(tr_name, {})[tr_ind] = \
+                sub_results = {}
+                for s, solution_bit_value in results.items():
+                    if check_condition(comp_num, s):
+                        # Translate the results using the corresponding
+                        # dictionaries
+                        sub_results[dictionaries[comp_num][s]] = \
                             solution_bit_value
-                else:  # SAT
-                    sub_results = {}
-                    for s, solution_bit_value in results.items():
-                        if check_condition(comp_num, s):
-                            # Translate the results using the corresponding
-                            # dictionaries
-                            sub_results[dictionaries[comp_num][s]] = \
-                                solution_bit_value
 
                 new_node = current_node.children[depths[comp_num]]
 
@@ -1996,36 +1985,21 @@ class Cipher:
         ]
 
         # Sort the (messy and unordered) variable values correctly
-        if model_options.optimization == OPTIMIZATION.MILP:
-            for var_name, var_dict in results.items():
-                if var_name in ("IN", "OUT"):
-                    # if var_name is MILP_IN or MILP_OUT, we skip it
-                    continue
-                comp_num = int(var_name[1:])
-                for s_ind, solution_bit_value in var_dict.items():
-                    translated_component = dictionaries[comp_num][
-                        f"{var_name}[{s_ind}]"
-                    ]
-                    # Draw the input nodes of each component
-                    bool1 = "IN" in translated_component
-                    # We also draw the output of the last component.
-                    bool2 = "OUT" in translated_component
+        for s, solution_bit_value in results.items():
 
-                    if bool1 and comp_num != 0:  # dont draw self.IN.in
-                        current_index = _between_brackets(translated_component)
-                        bit_ind = _from_grid(
-                            comp_num, current_index, input_side=True
-                        )
-                        bits_in[depths[comp_num]][bit_ind] = solution_bit_value
-                    elif bool2:
-                        current_index = _between_brackets(translated_component)
-                        bit_ind = _from_grid(
-                            comp_num, current_index, input_side=False
-                        )
-                        bits_out[depths[comp_num]][bit_ind] = solution_bit_value
-        elif model_options.optimization == OPTIMIZATION.SAT:
-            # NOTE: SAT-vars start at 1 while grid-indexing starts at 0
-            for s, solution_bit_value in results.items():
+            # recover comp_num and comp
+            if model_options.optimization == OPTIMIZATION.MILP:
+                if "IN" in s or "OUT" in s:
+                    # if s is MILP_IN or MILP_OUT, we skip it
+                    continue
+                comp_num, s_ind = _before_brackets(s), _between_brackets(s)
+
+                translated_component = dictionaries[comp_num][f"X{comp_num}[{s_ind}]"]
+                # Draw the input nodes of each component
+                bool1 = "IN" in translated_component
+                # We also draw the output of the last component.
+                bool2 = "OUT" in translated_component
+            elif model_options.optimization == OPTIMIZATION.SAT:
                 if s <= self.input_length + self.output_length:
                     # if s is SAT_IN or SAT_OUT, we skip it
                     continue
@@ -2052,24 +2026,34 @@ class Cipher:
                 # We also draw the output of the last component.
                 bool2 = comp.input_length < translated_component and \
                     translated_component <= comp.input_length + comp.output_length
+            else:
+                raise InvalidModelOptionException(
+                    model_options.optimization, OPTIMIZATION
+                )
 
-                if bool1 and comp_num != 0:  # dont draw self.IN.in
+            # NOTE: For SAT we offset by -1 because SAT-vars start at 1
+            # while grid-indexing starts at 0
+            if bool1 and comp_num != 0:  # dont draw self.IN.in
+                if model_options.optimization == OPTIMIZATION.MILP:
+                    current_index = _between_brackets(translated_component)
+                elif model_options.optimization == OPTIMIZATION.SAT:
                     current_index = translated_component - 1
-                    bit_ind = _from_grid(
-                        comp_num, current_index, input_side=True
-                    )
-                    bits_in[depths[comp_num]][bit_ind] = solution_bit_value
-                elif bool2:
+
+                bit_ind = _from_grid(
+                    comp_num, current_index, input_side=True
+                )
+                bits_in[depths[comp_num]][bit_ind] = solution_bit_value
+            elif bool2:
+                if model_options.optimization == OPTIMIZATION.MILP:
+                    current_index = _between_brackets(translated_component)
+                elif model_options.optimization == OPTIMIZATION.SAT:
                     current_index = translated_component - \
                         self.nodes[comp_num].input_length - 1
-                    bit_ind = _from_grid(
-                        comp_num, current_index, input_side=False
-                    )
-                    bits_out[depths[comp_num]][bit_ind] = solution_bit_value
-        else:
-            raise InvalidModelOptionException(
-                model_options.optimization, OPTIMIZATION
-            )
+
+                bit_ind = _from_grid(
+                    comp_num, current_index, input_side=False
+                )
+                bits_out[depths[comp_num]][bit_ind] = solution_bit_value
 
         # realign bits_in, bits_out by removing any 'None' entries
         bits_in = [

--- a/src/civerly/cipher_implementations/abc.py
+++ b/src/civerly/cipher_implementations/abc.py
@@ -86,8 +86,8 @@ class ABC_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   solve_range=(0, 10),
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-ABC-Models/")
             ....: )
             sage: abc_cipher.analyse(model_options)

--- a/src/civerly/cipher_implementations/aes.py
+++ b/src/civerly/cipher_implementations/aes.py
@@ -24,7 +24,7 @@ but the code below should be rather straightforward::
     ....:   optimization=OPTIMIZATION.MILP,
     ....:   granularity=GRANULARITY.WORDWISE,
     ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
-    ....:   solver=SOLVER.SCIP,
+    ....:   milp_solver=SCIP_CVL(),
     ....:   path=Path("./DOCTEST-AES-Models/"))
 
 Notice that we set ``sbox_modeling`` to ``None``, as we do not have to model
@@ -54,7 +54,7 @@ of MixColumn which requires solving a MILP itself::
     ....:     optimization=OPTIMIZATION.MILP,
     ....:     granularity=GRANULARITY.WORDWISE,
     ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
-    ....:     solver=SOLVER.SCIP,
+    ....:     milp_solver=SCIP_CVL(),
     ....:     path=Path("./DOCTEST-AES-Models/"))
     sage: aes.analyse(model_options) # doctest: +NORMALIZE_WHITESPACE
     2848 variables and 2977 constraints were written to
@@ -96,11 +96,10 @@ to the location specified above. As we cannot execute that step here,
 we simulate it to continue::
 
     sage: # optional - scip
-    sage: from civerly.solvers import solve
     sage: from pathlib import Path
     sage: input_file_name = Path("DOCTEST-AES-Models/MixColumn51845.mps")
     sage: output_file_name = Path("DOCTEST-AES-Models/MixColumn51845.sol")
-    sage: solve(input_file_name, output_file_name, SOLVER.SCIP)
+    sage: SCIP_CVL().solve(input_file_name, output_file_name)
 
 Notice that you do not have to keep the sage session alive while you
 solve the model externally. Again, this is something we have to
@@ -136,11 +135,10 @@ generating a report, you would copythe ``AES.sol`` file to the
 ``DOCTEST-AES-Models`` directory. Again, we have to simulate this::
 
     sage: # optional - scip
-    sage: from civerly.solvers import solve
     sage: from pathlib import Path
-    sage: solve(input_file_name=Path("DOCTEST-AES-Models/AES.mps"),
-    ....:       output_file_name=Path("DOCTEST-AES-Models/AES.sol"),
-    ....:       solver = SOLVER.SCIP)
+    sage: SCIP_CVL().solve(input_file_name=Path("DOCTEST-AES-Models/AES.mps"),
+    ....:       output_file_name=Path("DOCTEST-AES-Models/AES.sol")
+    ....: )
 
 And again, we simulate restarting CiVerLy::
 
@@ -154,9 +152,8 @@ Now, we first verify that the objective value is indeed 55::
     sage: from civerly.cipher_implementations.aes import AES_CVL
     sage: from civerly.model_options import *
     sage: from pathlib import Path
-    sage: from civerly.solvers import get_objective_value
     sage: sol_file_name = Path("DOCTEST-AES-Models/AES.sol")
-    sage: get_objective_value(sol_file_name, SOLVER.SCIP)
+    sage: SCIP_CVL().process_solution_file(sol_file_name)[1]
     55
 
 Which tells us that there are indeed 55 active S-boxes. To visualize
@@ -255,7 +252,7 @@ class AES_CVL:
                 ....:     optimization=OPTIMIZATION.MILP,
                 ....:     granularity=GRANULARITY.WORDWISE,
                 ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
-                ....:     solver=SOLVER.GLPK,
+                ....:     milp_solver=GLPK_CVL(),
                 ....:     path=path)
                 sage: aes.analyse(model_options) # optional - glpk
                 548 variables and 557 constraints were written to
@@ -267,7 +264,7 @@ class AES_CVL:
                 ....:     optimization=OPTIMIZATION.MILP,
                 ....:     granularity=GRANULARITY.WORDWISE,
                 ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
-                ....:     solver=SOLVER.GLPK,
+                ....:     milp_solver=GLPK_CVL(),
                 ....:     path=path)
                 sage: aes.analyse(model_options) # optional - glpk
                 544 variables and 545 constraints were written to
@@ -280,7 +277,7 @@ class AES_CVL:
                 ....:     optimization=OPTIMIZATION.MILP,
                 ....:     granularity=GRANULARITY.WORDWISE,
                 ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
-                ....:     solver=SOLVER.GUROBI,
+                ....:     milp_solver=GUROBI_CVL(),
                 ....:     path=path)
                 sage: aes.analyse(model_options) # optional - gurobi
                 2884 variables and 3085 constraints were written to
@@ -292,7 +289,7 @@ class AES_CVL:
                 ....:     optimization=OPTIMIZATION.MILP,
                 ....:     granularity=GRANULARITY.WORDWISE,
                 ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
-                ....:     solver=SOLVER.GUROBI,
+                ....:     milp_solver=GUROBI_CVL(),
                 ....:     path=path)
                 sage: aes.analyse(model_options) # optional - gurobi
                 2848 variables and 2977 constraints were written to
@@ -323,7 +320,7 @@ class AES_CVL:
                 ....:     optimization=OPTIMIZATION.MILP,
                 ....:     granularity=GRANULARITY.WORDWISE,
                 ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
-                ....:     solver=SOLVER.GUROBI,
+                ....:     milp_solver=GUROBI_CVL(),
                 ....:     path=path)
                 sage: # optional - gurobi
                 sage: cipher.analyse(model_options)

--- a/src/civerly/cipher_implementations/ascon.py
+++ b/src/civerly/cipher_implementations/ascon.py
@@ -42,8 +42,8 @@ class ASCON_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(7, 9),
             ....:   path=Path("./DOCTEST-Ascon-Models/"))
             sage: cipher.analyse(model_options=model_options)

--- a/src/civerly/cipher_implementations/chacha.py
+++ b/src/civerly/cipher_implementations/chacha.py
@@ -37,7 +37,7 @@ class ChachaQRF_CVL:
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   solve_range=(0, 8),
             ....:   path=Path("./DOCTEST-ChachaQRF-Models/"))
             sage: # optional - cryptominisat
@@ -62,7 +62,7 @@ class ChachaQRF_CVL:
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
-            ....:   solver=SOLVER.CADICAL,
+            ....:   sat_solver=CADICAL_CVL(),
             ....:   solve_range=(0, 8),
             ....:   path=Path("./DOCTEST-ChachaQRF-Models/"))
             sage: # optional - cadical
@@ -87,7 +87,7 @@ class ChachaQRF_CVL:
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   path=Path("./DOCTEST-ChachaQRF-Models/"))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
@@ -183,7 +183,7 @@ class Chacha_CVL:
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   solve_range=(0, 4),
             ....:   path=Path("./DOCTEST-Chacha-Models/"))
             sage: # optional - cryptominisat

--- a/src/civerly/cipher_implementations/craft.py
+++ b/src/civerly/cipher_implementations/craft.py
@@ -45,7 +45,7 @@ class CRAFT_CVL:
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.WORDWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
-            ....:   solver=SOLVER.SCIP,
+            ....:   milp_solver=SCIP_CVL(),
             ....:   path=Path("./DOCTEST-CRAFT-Models/"))
             sage: craft.analyse(model_options) # optional - scip
             5896 variables and 6121 constraints were written to
@@ -57,7 +57,7 @@ class CRAFT_CVL:
         modeling of the linear layer is useful. But first some cleanup::
 
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-CRAFT-Models") # optional - scip
+            sage: shutil.rmtree("DOCTEST-CRAFT-Models", ignore_errors=True) # optional - scip
 
         Now the improved modeling::
 
@@ -67,13 +67,13 @@ class CRAFT_CVL:
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.WORDWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
-            ....:   solver=SOLVER.SCIP,
+            ....:   milp_solver=SCIP_CVL(),
             ....:   path=Path("./DOCTEST-CRAFT-Models/"))
             sage: craft.analyse(model_options) # optional - scip
             5856 variables and 6041 constraints were written to
             'DOCTEST-CRAFT-Models/CRAFT.mps'
             36
-            sage: shutil.rmtree("DOCTEST-CRAFT-Models") # optional - scip
+            sage: shutil.rmtree("DOCTEST-CRAFT-Models", ignore_errors=True) # optional - scip
 
         Indeed, 36 active S-boxes is a much better bound.
 
@@ -88,13 +88,13 @@ class CRAFT_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.CONVEX_HULL,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   solver=SOLVER.SCIP,
+            ....:   milp_solver=SCIP_CVL(),
             ....:   path=Path("./DOCTEST-CRAFT-Models/"))
             sage: craft.analyse(model_options) # optional - scip
             7440 variables and 9057 constraints were written to
             'DOCTEST-CRAFT-Models/CRAFT.mps'
             8
-            sage: shutil.rmtree("DOCTEST-CRAFT-Models") # optional - scip
+            sage: shutil.rmtree("DOCTEST-CRAFT-Models", ignore_errors=True) # optional - scip
 
         Here the objective value is :math:`- \log_2(p)`, with :math:`p` being
         the differential probability (or respectively the linear correlation)
@@ -110,13 +110,13 @@ class CRAFT_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   solver=SOLVER.SCIP,
+            ....:   milp_solver=SCIP_CVL(),
             ....:   path=Path("./DOCTEST-CRAFT-Models/"))
             sage: craft.analyse(model_options) # optional - scip
             7728 variables and 8001 constraints were written to
             'DOCTEST-CRAFT-Models/CRAFT.mps'
             8
-            sage: shutil.rmtree("DOCTEST-CRAFT-Models") # optional - scip
+            sage: shutil.rmtree("DOCTEST-CRAFT-Models", ignore_errors=True) # optional - scip
 
 
         It is also possible to use SAT to model the cipher. The results should
@@ -132,8 +132,8 @@ class CRAFT_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-CRAFT-Models/"))
             sage: craft.analyse(model_options)
             7440 variables and 17201 clauses were written to
@@ -165,8 +165,8 @@ class CRAFT_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CADICAL,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CADICAL_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-CRAFT-Models/"))
             sage: craft.analyse(model_options)
             7440 variables and 17201 clauses were written to

--- a/src/civerly/cipher_implementations/des.py
+++ b/src/civerly/cipher_implementations/des.py
@@ -44,8 +44,8 @@ class DES_F_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(0, 4),
             ....:   path=Path("DOCTEST-DESF-Models"))
             sage: cipher.analyse(model_options=model_options)
@@ -67,8 +67,8 @@ class DES_F_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CADICAL,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CADICAL_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(0, 4),
             ....:   path=Path("DOCTEST-DESF-Models"))
             sage: cipher.analyse(model_options=model_options)
@@ -89,8 +89,8 @@ class DES_F_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.GUROBI,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   milp_solver=GUROBI_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("DOCTEST-DESF-Models"))
             sage: # optional - gurobi # optional - espresso
             sage: cipher.analyse(model_options=model_options)
@@ -224,8 +224,8 @@ class DES_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(0, 10),
             ....:   path=Path("DOCTEST-DES-Models"))
             sage: cipher.analyse(model_options=model_options)

--- a/src/civerly/cipher_implementations/gift.py
+++ b/src/civerly/cipher_implementations/gift.py
@@ -29,7 +29,7 @@ class GIFT_CVL:
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   solver=SOLVER.SCIP,
+            ....:   milp_solver=SCIP_CVL(),
             ....:   path=Path("./DOCTEST-GIFT-Models/")
             ....: )
             sage: gift_cipher.analyse(model_options) # optional - scip
@@ -37,7 +37,7 @@ class GIFT_CVL:
             'DOCTEST-GIFT-Models/GIFT.mps'
             3.4150374993
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-GIFT-Models", ignore_errors=True) # optional - scip
+            sage: shutil.rmtree("DOCTEST-GIFT-Models", ignore_errors=True)
 
             sage: from civerly.cipher_implementations.gift import GIFT_CVL
             sage: from civerly.model_options import *
@@ -48,8 +48,8 @@ class GIFT_CVL:
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.SCIP,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   milp_solver=SCIP_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-GIFT-Models/")
             ....: )
             sage: gift_cipher.analyse(model_options) # optional - scip # optional - espresso
@@ -57,7 +57,7 @@ class GIFT_CVL:
             'DOCTEST-GIFT-Models/GIFT.mps'
             3.4150374993
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-GIFT-Models", ignore_errors=True) # optional - scip # optional - espresso
+            sage: shutil.rmtree("DOCTEST-GIFT-Models", ignore_errors=True)
 
             sage: from civerly.cipher_implementations.gift import GIFT_CVL
             sage: from civerly.model_options import *
@@ -68,7 +68,7 @@ class GIFT_CVL:
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.DISTORTED_BALL,
-            ....:   solver=SOLVER.SCIP,
+            ....:   milp_solver=SCIP_CVL(),
             ....:   path=Path("./DOCTEST-GIFT-Models/")
             ....: )
             sage: gift_cipher.analyse(model_options) # optional - scip
@@ -76,7 +76,7 @@ class GIFT_CVL:
             'DOCTEST-GIFT-Models/GIFT.mps'
             3.4150374993
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-GIFT-Models", ignore_errors=True) # optional - scip
+            sage: shutil.rmtree("DOCTEST-GIFT-Models", ignore_errors=True)
 
         Model the cipher with SAT using different values for ``sat_precision``:
 
@@ -91,8 +91,8 @@ class GIFT_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-GIFT-Models/")
             ....: )
             sage: gift_cipher.analyse(model_options)
@@ -122,8 +122,8 @@ class GIFT_CVL:
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   solve_range=(0, 10),
             ....:   sat_precision=1,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-GIFT-Models/")
             ....: )
             sage: gift_cipher.analyse(model_options)
@@ -155,8 +155,8 @@ class GIFT_CVL:
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   solve_range=(0, 10),
             ....:   sat_precision=1,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=None,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=None,
             ....:   path=Path("./DOCTEST-GIFT-Models/")
             ....: )
             sage: gift_cipher.analyse(model_options)

--- a/src/civerly/cipher_implementations/hurdle.py
+++ b/src/civerly/cipher_implementations/hurdle.py
@@ -267,7 +267,7 @@ class HURDLE_CVL:
         # ....:     granularity=GRANULARITY.BITWISE,
         # ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
         # ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-        # ....:     minimizer=MINIMIZER.ESPRESSO,
+        # ....:     logic_minimizer=ESPRESSO_CVL(),
         # ....:     path=Path("./DOCTEST-HURDLE-Models/"))
         # sage: cipher.analyse(model_options)
 

--- a/src/civerly/cipher_implementations/present.py
+++ b/src/civerly/cipher_implementations/present.py
@@ -47,7 +47,7 @@ class PRESENT_CVL:
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.WORDWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
-            ....:   solver=SOLVER.SCIP,
+            ....:   milp_solver=SCIP_CVL(),
             ....:   path=Path("./DOCTEST-PRESENT-Models/"))
             sage: present_cipher.analyse(model_options) # optional - scip
             1284 variables and 1341 constraints were written to
@@ -92,7 +92,7 @@ class PRESENT_CVL:
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   solver=SOLVER.SCIP,
+            ....:   milp_solver=SCIP_CVL(),
             ....:   path=Path("./DOCTEST-PRESENT-Models/"))
             sage: present_cipher.analyse(model_options) # optional - scip
             5312 variables and 6081 constraints were written to
@@ -139,7 +139,7 @@ class PRESENT_CVL:
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   solver=SOLVER.GUROBI,
+            ....:   milp_solver=GUROBI_CVL(),
             ....:   path=Path("./DOCTEST-PRESENT-Models/"))
             sage: # optional - gurobi
             sage: present_cipher.analyse(model_options)
@@ -158,8 +158,8 @@ class PRESENT_CVL:
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.GUROBI,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   milp_solver=GUROBI_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-PRESENT-Models/"))
             sage: # optional - gurobi # optional - espresso
             sage: present_cipher.analyse(model_options)
@@ -178,7 +178,7 @@ class PRESENT_CVL:
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.DISTORTED_BALL,
-            ....:   solver=SOLVER.GUROBI,
+            ....:   milp_solver=GUROBI_CVL(),
             ....:   path=Path("./DOCTEST-PRESENT-Models/"))
             sage: # optional - gurobi
             sage: present_cipher.analyse(model_options) # long
@@ -206,8 +206,8 @@ class PRESENT_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-PRESENT-Models/"))
             sage: present_cipher.analyse(model_options)
             5312 variables and 13441 clauses were written to
@@ -235,8 +235,8 @@ class PRESENT_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CADICAL,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CADICAL_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-PRESENT-Models/"))
             sage: present_cipher.analyse(model_options)
             5312 variables and 13441 clauses were written to
@@ -268,8 +268,8 @@ class PRESENT_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-PRESENT-Models/"))
             sage: present_cipher.analyse(model_options)
             5312 variables and 12993 clauses were written to
@@ -297,8 +297,8 @@ class PRESENT_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-PRESENT-Models/"))
             sage: present_cipher.analyse(model_options)
             5312 variables and 12993 clauses were written to
@@ -324,8 +324,8 @@ class PRESENT_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-PRESENT-Models/"))
             sage: present_cipher.analyse(model_options)
             6512 variables and 16017 clauses were written to
@@ -356,8 +356,8 @@ class PRESENT_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=None,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=None,
             ....:   path=Path("./DOCTEST-PRESENT-Models/"))
             sage: present_cipher.analyse(model_options)
             Optimization problem for Espresso has been written to...

--- a/src/civerly/cipher_implementations/simon.py
+++ b/src/civerly/cipher_implementations/simon.py
@@ -83,8 +83,8 @@ class SIMON_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(16, 20),
             ....:   path=Path("./DOCTEST-Simon-Models/"))
             sage: cipher.analyse(model_options=model_options)
@@ -105,8 +105,8 @@ class SIMON_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(16, 20),
             ....:   path=Path("./DOCTEST-Simon-Models/"))
             sage: cipher.analyse(model_options=model_options)
@@ -127,8 +127,8 @@ class SIMON_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CADICAL,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CADICAL_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(16, 20),
             ....:   path=Path("./DOCTEST-Simon-Models/"))
             sage: cipher.analyse(model_options=model_options)
@@ -149,8 +149,8 @@ class SIMON_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CADICAL,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CADICAL_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(16, 20),
             ....:   path=Path("./DOCTEST-Simon-Models/"))
             sage: cipher.analyse(model_options=model_options)
@@ -175,8 +175,8 @@ class SIMON_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(10, 20),
             ....:   path=Path("./DOCTEST-Simon-Models/"))
             sage: cipher.analyse(model_options=model_options)
@@ -198,8 +198,8 @@ class SIMON_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(10, 20),
             ....:   path=Path("./DOCTEST-Simon-Models/"))
             sage: cipher.analyse(model_options=model_options)
@@ -221,8 +221,8 @@ class SIMON_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CADICAL,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CADICAL_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(10, 20),
             ....:   path=Path("./DOCTEST-Simon-Models/"))
             sage: cipher.analyse(model_options=model_options)
@@ -244,8 +244,8 @@ class SIMON_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CADICAL,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CADICAL_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(10, 20),
             ....:   path=Path("./DOCTEST-Simon-Models/"))
             sage: cipher.analyse(model_options=model_options)

--- a/src/civerly/cipher_implementations/simon_variants.py
+++ b/src/civerly/cipher_implementations/simon_variants.py
@@ -31,8 +31,8 @@ class SIMON_Variants_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(4, 10),
             ....:   path=Path("./DOCTEST-Simon-Variants-Models/"))
             sage: # optional - cryptominisat
@@ -54,8 +54,8 @@ class SIMON_Variants_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(4, 10),
             ....:   path=Path("./DOCTEST-Simon-Variants-Models/"))
             sage: # optional - cryptominisat
@@ -77,8 +77,8 @@ class SIMON_Variants_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(4, 10),
             ....:   path=Path("./DOCTEST-Simon-Variants-Models/"))
             sage: # optional - cryptominisat
@@ -100,8 +100,8 @@ class SIMON_Variants_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(8, 16),
             ....:   path=Path("./DOCTEST-Simon-Variants-Models/"))
             sage: # optional - cryptominisat
@@ -127,8 +127,8 @@ class SIMON_Variants_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(24, 26),
             ....:   path=Path("./DOCTEST-Simon-Variants-Models/"))
             sage: # optional - cryptominisat
@@ -149,8 +149,8 @@ class SIMON_Variants_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(24, 26),
             ....:   path=Path("./DOCTEST-Simon-Variants-Models/"))
             sage: # optional - cryptominisat
@@ -171,8 +171,8 @@ class SIMON_Variants_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(24, 26),
             ....:   path=Path("./DOCTEST-Simon-Variants-Models/"))
             sage: # optional - cryptominisat
@@ -200,8 +200,8 @@ class SIMON_Variants_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(4, 8),
             ....:   path=Path("./DOCTEST-Simon-Variants-Models/"))
             sage: # optional - cryptominisat

--- a/src/civerly/cipher_implementations/skinny.py
+++ b/src/civerly/cipher_implementations/skinny.py
@@ -278,7 +278,7 @@ class SKINNY_CVL:
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.WORDWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
-            ....:   solver=SOLVER.SCIP,
+            ....:   milp_solver=SCIP_CVL(),
             ....:   path=Path("./DOCTEST-SKINNY-Models/"))
             sage: skinny.analyse(model_options) # optional - scip
             22752 variables and 23505 constraints were written to
@@ -293,7 +293,7 @@ class SKINNY_CVL:
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.WORDWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
-            ....:   solver=SOLVER.SCIP,
+            ....:   milp_solver=SCIP_CVL(),
             ....:   path=Path("./DOCTEST-SKINNY-Models/"))
             sage: skinny.analyse(model_options) # optional - scip
             7136 variables and 7361 constraints were written to
@@ -309,7 +309,7 @@ class SKINNY_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   solver=SOLVER.SCIP,
+            ....:   milp_solver=SCIP_CVL(),
             ....:   path=Path("./DOCTEST-SKINNY-Models/"))
             sage: skinny.analyse(model_options) # optional - scip
             9312 variables and 9585 constraints were written to
@@ -324,7 +324,7 @@ class SKINNY_CVL:
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.WORDWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
-            ....:   solver=SOLVER.GUROBI,
+            ....:   milp_solver=GUROBI_CVL(),
             ....:   path=Path("./DOCTEST-SKINNY-Models/"))
             sage: skinny.analyse(model_options) # optional - gurobi
             22752 variables and 23505 constraints were written to
@@ -339,7 +339,7 @@ class SKINNY_CVL:
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.WORDWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
-            ....:   solver=SOLVER.GUROBI,
+            ....:   milp_solver=GUROBI_CVL(),
             ....:   path=Path("./DOCTEST-SKINNY-Models/"))
             sage: skinny.analyse(model_options) # optional - gurobi
             7136 variables and 7361 constraints were written to
@@ -355,7 +355,7 @@ class SKINNY_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   solver=SOLVER.GUROBI,
+            ....:   milp_solver=GUROBI_CVL(),
             ....:   path=Path("./DOCTEST-SKINNY-Models/"))
             sage: skinny.analyse(model_options) # optional - gurobi
             9312 variables and 9585 constraints were written to
@@ -375,8 +375,8 @@ class SKINNY_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(10, 20),
             ....:   path=Path("./DOCTEST-SKINNY-Models/"))
             sage: skinny.analyse(model_options)
@@ -399,8 +399,8 @@ class SKINNY_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CADICAL,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CADICAL_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(10, 20),
             ....:   path=Path("./DOCTEST-SKINNY-Models/"))
             sage: skinny.analyse(model_options)
@@ -423,7 +423,7 @@ class SKINNY_CVL:
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.WORDWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
-            ....:   solver=SOLVER.GUROBI,
+            ....:   milp_solver=GUROBI_CVL(),
             ....:   path=Path("./DOCTEST-SKINNY-Models/"))
             sage: skinny.analyse(model_options) # optional - gurobi
             7136 variables and 7521 constraints were written to
@@ -439,8 +439,8 @@ class SKINNY_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.GUROBI,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   milp_solver=GUROBI_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-SKINNY-Models/"))
             sage: skinny.analyse(model_options) # optional - gurobi # optional - espresso
             9264 variables and 10161 constraints were written to
@@ -456,8 +456,8 @@ class SKINNY_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.SCIP,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   milp_solver=SCIP_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-SKINNY-Models/"))
             sage: skinny.analyse(model_options) # optional - scip # optional - espresso
             9264 variables and 10161 constraints were written to
@@ -475,8 +475,8 @@ class SKINNY_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(4, 10),
             ....:   path=Path("./DOCTEST-SKINNY-Models/"))
             sage: skinny.analyse(model_options)
@@ -486,7 +486,7 @@ class SKINNY_CVL:
             [  4 ,  7] (trying w =   5) : SAT
             [  4 ,  5] (trying w =   4) : UNSAT
             5
-            sage: shutil.rmtree("DOCTEST-SKINNY-Models")
+            sage: shutil.rmtree("DOCTEST-SKINNY-Models") # optional - cryptominisat # optional - espresso
 
             sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
@@ -498,8 +498,8 @@ class SKINNY_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CADICAL,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CADICAL_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(4, 10),
             ....:   path=Path("./DOCTEST-SKINNY-Models/"))
             sage: skinny.analyse(model_options)
@@ -509,7 +509,7 @@ class SKINNY_CVL:
             [  4 ,  7] (trying w =   5) : SAT
             [  4 ,  5] (trying w =   4) : UNSAT
             5
-            sage: shutil.rmtree("DOCTEST-SKINNY-Models")
+            sage: shutil.rmtree("DOCTEST-SKINNY-Models") # optional - cadical # optional - espresso
 
         Remove the files:
 

--- a/src/civerly/cipher_implementations/speck.py
+++ b/src/civerly/cipher_implementations/speck.py
@@ -71,8 +71,8 @@ class SPECK_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-Speck-Models/"))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
@@ -97,8 +97,8 @@ class SPECK_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CADICAL,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CADICAL_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-Speck-Models/"))
             sage: # optional - cadical
             sage: cipher.analyse(model_options=model_options)
@@ -126,8 +126,8 @@ class SPECK_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-Speck-Models/"))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
@@ -151,8 +151,8 @@ class SPECK_CVL:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CADICAL,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CADICAL_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-Speck-Models/"))
             sage: # optional - cadical
             sage: cipher.analyse(model_options=model_options)

--- a/src/civerly/cipher_implementations/toy_ciphers/toy1.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy1.py
@@ -22,7 +22,7 @@ class Toy1:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   path=Path("./DOCTEST-Toy1-Models/"))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
@@ -50,7 +50,7 @@ class Toy1:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   path=Path("./DOCTEST-Toy1-Models/"))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
@@ -74,7 +74,7 @@ class Toy1:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   path=Path("./DOCTEST-Toy1-Models/"))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
@@ -104,31 +104,30 @@ class Toy1:
             sage: milp_model = cipher.model(model_options=model_options)
             474 variables and 346 constraints were written to
             'DOCTEST-Toy1-Models/Toy1.mps'
-            sage: from civerly.solvers import solve, get_objective_value
             sage: from pathlib import Path
-            sage: solve( # optional - gurobi
+            sage: GUROBI_CVL().solve( # optional - gurobi
             ....:   input_file_name=Path("DOCTEST-Toy1-Models/Toy1.mps"),
             ....:   output_file_name=Path("DOCTEST-Toy1-Models/Toy1.sol"),
-            ....:   solver=SOLVER.GUROBI)
-            sage: get_objective_value( # optional - gurobi
-            ....:   sol_file_name=Path("DOCTEST-Toy1-Models/Toy1.sol"),
-            ....:   solver=SOLVER.GUROBI)
+            ....: )
+            sage: GUROBI_CVL().process_solution_file( # optional - gurobi
+            ....:   solution_file_name=Path("DOCTEST-Toy1-Models/Toy1.sol"),
+            ....: )[1]
             0
-            sage: solve( # optional - scip
+            sage: SCIP_CVL().solve( # optional - scip
             ....:   input_file_name=Path("DOCTEST-Toy1-Models/Toy1.mps"),
             ....:   output_file_name=Path("DOCTEST-Toy1-Models/Toy1.sol"),
-            ....:   solver=SOLVER.SCIP)
-            sage: get_objective_value( # optional - scip
-            ....:   sol_file_name=Path("DOCTEST-Toy1-Models/Toy1.sol"),
-            ....:   solver=SOLVER.SCIP)
+            ....: )
+            sage: SCIP_CVL().process_solution_file( # optional - scip
+            ....:   solution_file_name=Path("DOCTEST-Toy1-Models/Toy1.sol"),
+            ....: )[1]
             0
-            sage: solve( # optional - glpk
+            sage: GLPK_CVL().solve( # optional - glpk
             ....:   input_file_name=Path("DOCTEST-Toy1-Models/Toy1.mps"),
             ....:   output_file_name=Path("DOCTEST-Toy1-Models/Toy1.sol"),
-            ....:   solver=SOLVER.GLPK)
-            sage: get_objective_value( # optional - glpk
-            ....:   sol_file_name=Path("DOCTEST-Toy1-Models/Toy1.sol"),
-            ....:   solver=SOLVER.GLPK)
+            ....: )
+            sage: GLPK_CVL().process_solution_file( # optional - glpk
+            ....:   solution_file_name=Path("DOCTEST-Toy1-Models/Toy1.sol"),
+            ....: )[1]
             0
 
             sage: from civerly.cipher_implementations.toy_ciphers.toy1 \
@@ -139,7 +138,7 @@ class Toy1:
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.BITWISE,
-            ....:   solver=SOLVER.GUROBI,
+            ....:   milp_solver=GUROBI_CVL(),
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   path=Path("./DOCTEST-Toy1-Models/"))
             sage: # optional - gurobi

--- a/src/civerly/cipher_implementations/toy_ciphers/toy10.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy10.py
@@ -29,8 +29,8 @@ class Toy10:
             ....:     granularity=GRANULARITY.BITWISE,
             ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:     solver=SOLVER.CRYPTOMINISAT,
-            ....:     minimizer=MINIMIZER.ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
             ....:     path=Path("./DOCTEST-Toy10-Models/")
             ....: )
             sage: cipher.analyse(model_options)
@@ -59,8 +59,8 @@ class Toy10:
             ....:     granularity=GRANULARITY.BITWISE,
             ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:     solver=SOLVER.CADICAL,
-            ....:     minimizer=MINIMIZER.ESPRESSO,
+            ....:     sat_solver=CADICAL_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
             ....:     path=Path("./DOCTEST-Toy10-Models/")
             ....: )
             sage: cipher.analyse(model_options)
@@ -89,8 +89,8 @@ class Toy10:
             ....:     granularity=GRANULARITY.BITWISE,
             ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:     solver=SOLVER.CRYPTOMINISAT,
-            ....:     minimizer=MINIMIZER.ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
             ....:     path=Path("./DOCTEST-Toy10-Models/")
             ....: )
             sage: cipher.analyse(model_options)
@@ -116,8 +116,8 @@ class Toy10:
             ....:     granularity=GRANULARITY.BITWISE,
             ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:     solver=SOLVER.GUROBI,
-            ....:     minimizer=MINIMIZER.ESPRESSO,
+            ....:     milp_solver=GUROBI_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
             ....:     path=Path("./DOCTEST-Toy10-Models/")
             ....: )
             sage: cipher.analyse(model_options) # optional - gurobi # optional - espresso

--- a/src/civerly/cipher_implementations/toy_ciphers/toy11.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy11.py
@@ -24,8 +24,8 @@ class Toy11:
             ....:     granularity=GRANULARITY.BITWISE,
             ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:     solver=SOLVER.GUROBI,
-            ....:     minimizer=MINIMIZER.ESPRESSO,
+            ....:     milp_solver=GUROBI_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
             ....:     path=Path("./DOCTEST-Toy11-Models/")
             ....: )
             sage: cipher.analyse(model_options) # optional - gurobi # optional - espresso
@@ -45,8 +45,8 @@ class Toy11:
             ....:     granularity=GRANULARITY.BITWISE,
             ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:     solver=SOLVER.CADICAL,
-            ....:     minimizer=MINIMIZER.ESPRESSO,
+            ....:     sat_solver=CADICAL_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
             ....:     path=Path("./DOCTEST-Toy11-Models/")
             ....: )
             sage: cipher.analyse(model_options)

--- a/src/civerly/cipher_implementations/toy_ciphers/toy2.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy2.py
@@ -22,7 +22,7 @@ class Toy2:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   path=Path("./DOCTEST-Toy2-Models/"))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
@@ -50,7 +50,7 @@ class Toy2:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   path=Path("./DOCTEST-Toy2-Models/"))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
@@ -77,7 +77,7 @@ class Toy2:
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   solver=SOLVER.GUROBI,
+            ....:   milp_solver=GUROBI_CVL(),
             ....:   path=Path("./DOCTEST-Toy2-Models/"))
             sage: # optional - gurobi
             sage: cipher.analyse(model_options=model_options)

--- a/src/civerly/cipher_implementations/toy_ciphers/toy3.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy3.py
@@ -26,8 +26,8 @@ class Toy3:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-Toy3-Models/"))
             sage: cipher.analyse(model_options)
             798 variables and 3591 clauses were written to
@@ -56,8 +56,8 @@ class Toy3:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-Toy3-Models/"))
             sage: cipher.analyse(model_options)
             Using existing file DOCTEST-Toy3-Models/espresso-5a255793_out.pla,
@@ -92,7 +92,7 @@ class Toy3:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   solver=SOLVER.GUROBI,
+            ....:   milp_solver=GUROBI_CVL(),
             ....:   path=Path("./DOCTEST-Toy3-Models/"))
             sage: # optional - gurobi
             sage: cipher.analyse(model_options)
@@ -119,8 +119,8 @@ class Toy3:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=None,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=None,
             ....:   path=Path("./DOCTEST-Toy3-Models/"))
             sage: cipher.analyse(model_options)
             Optimization problem for Espresso has been written to...

--- a/src/civerly/cipher_implementations/toy_ciphers/toy4.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy4.py
@@ -24,8 +24,8 @@ class Toy4:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-Toy4-Models/"))
             sage: cipher.analyse(model_options=model_options)
             288 variables and 1537 clauses were written to
@@ -54,8 +54,8 @@ class Toy4:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-Toy4-Models/"))
             sage: cipher.analyse(model_options=model_options)
             360 variables and 897 clauses were written to
@@ -85,7 +85,7 @@ class Toy4:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   solver=SOLVER.GUROBI, \
+            ....:   milp_solver=GUROBI_CVL(),
             ....:   path=Path("./DOCTEST-Toy4-Models/"))
             sage: # optional - gurobi
             sage: cipher.analyse(model_options)

--- a/src/civerly/cipher_implementations/toy_ciphers/toy5.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy5.py
@@ -21,8 +21,8 @@ class Toy5:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CADICAL,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CADICAL_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-Toy5-Models/"))
             sage: cipher.analyse(model_options)
             2940 variables and 13997 clauses were written to
@@ -51,8 +51,8 @@ class Toy5:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CADICAL,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CADICAL_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-Toy5-Models/"))
             sage: cipher.analyse(model_options)
             Using existing file DOCTEST-Toy5-Models/espresso-5a255793_out.pla,
@@ -83,7 +83,7 @@ class Toy5:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   solver=SOLVER.GUROBI,
+            ....:   milp_solver=GUROBI_CVL(),
             ....:   path=Path("./DOCTEST-Toy5-Models/"))
             sage: cipher.analyse(model_options)
             3404 variables and 4177 constraints were written to
@@ -93,7 +93,6 @@ class Toy5:
             Output file in: DOCTEST-Toy5-Models/Toy5.pdf
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
-
             sage: import shutil
             sage: shutil.rmtree("DOCTEST-Toy5-Models", ignore_errors=True)
 

--- a/src/civerly/cipher_implementations/toy_ciphers/toy6.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy6.py
@@ -17,7 +17,7 @@ class Toy6:
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   path=Path("./DOCTEST-Toy6-Models/"))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options)

--- a/src/civerly/cipher_implementations/toy_ciphers/toy7.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy7.py
@@ -22,8 +22,8 @@ class Toy7:
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(0, 8),
             ....:   path=Path("./DOCTEST-Toy7-Models/"))
             sage: cipher.analyse(model_options=model_options)

--- a/src/civerly/cipher_implementations/toy_ciphers/toy8.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy8.py
@@ -20,7 +20,7 @@ class Toy8:
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   path=Path("./DOCTEST-Toy8-Models/"))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)

--- a/src/civerly/cipher_implementations/toy_ciphers/toy9.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy9.py
@@ -20,8 +20,8 @@ class Toy9:
             ....:     optimization=OPTIMIZATION.MILP,
             ....:     granularity=GRANULARITY.BITWISE,
             ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:     solver=SOLVER.GUROBI,
-            ....:     minimizer=MINIMIZER.ESPRESSO,
+            ....:     milp_solver=GUROBI_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
             ....:     path=Path("./DOCTEST-Toy9-Models/")
             ....: )
             sage: cipher.analyse(model_options) # optional - gurobi # optional - espresso
@@ -40,8 +40,8 @@ class Toy9:
             ....:     optimization=OPTIMIZATION.SAT,
             ....:     granularity=GRANULARITY.BITWISE,
             ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:     solver=SOLVER.CRYPTOMINISAT,
-            ....:     minimizer=MINIMIZER.ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
             ....:     path=Path("./DOCTEST-Toy9-Models/")
             ....: )
             sage: cipher.analyse(model_options)

--- a/src/civerly/cipher_implementations/weak_present.py
+++ b/src/civerly/cipher_implementations/weak_present.py
@@ -32,8 +32,8 @@ class WEAK_PRESENT_CVL:
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.GUROBI,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   milp_solver=GUROBI_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path(dir_name)
             ....: )
             sage: weak_cipher.analyse(model_options) # optional - gurobi # optional - espresso
@@ -41,6 +41,29 @@ class WEAK_PRESENT_CVL:
             3.4150374993
             sage: import shutil
             sage: shutil.rmtree(dir_name) # optional - gurobi
+
+        Use SCIP solver::
+
+            sage: from civerly.cipher_implementations.weak_present \
+            ....:     import WEAK_PRESENT_CVL
+            sage: from civerly.model_options import *
+            sage: from pathlib import Path
+            sage: weak_cipher = WEAK_PRESENT_CVL(R=2)
+            sage: dir_name = "DOCTEST-WEAK_PRESENT-Models"
+            sage: model_options = MODEL_OPTIONS(
+            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:   optimization=OPTIMIZATION.MILP,
+            ....:   granularity=GRANULARITY.BITWISE,
+            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:   milp_solver=SCIP_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
+            ....:   path=Path(dir_name)
+            ....: )
+            sage: weak_cipher.analyse(model_options) # optional - scip # optional - espresso
+            2560 variables and 4417 constraints were written to ...
+            3.4150374993
+            sage: import shutil
+            sage: shutil.rmtree(dir_name) # optional - scip # optional - espresso
 
         Now for linear cryptanalysis the cipher with MILP:
 
@@ -55,8 +78,8 @@ class WEAK_PRESENT_CVL:
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.GUROBI,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   milp_solver=GUROBI_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path(dir_name)
             ....: )
             sage: weak_cipher.analyse(model_options) # optional - gurobi # optional - espresso

--- a/src/civerly/component.py
+++ b/src/civerly/component.py
@@ -2008,11 +2008,11 @@ class SBox_CVL(Component):
                 1
                 sage: in_diff  = vec_to_int(vector(
                 ....:   GF(2), 4,
-                ....:   [results['IN'][i] for i in range(4)]
+                ....:   [results[f"IN[{i}]"] for i in range(4)]
                 ....: ))
                 sage: out_diff = vec_to_int(vector(
                 ....:   GF(2), 4,
-                ....:   [results['OUT'][i] for i in range(4)]
+                ....:   [results[f"OUT[{i}]"] for i in range(4)]
                 ....: ))
                 sage: ddt = sb.difference_distribution_table()
                 sage: ddt[in_diff][out_diff]
@@ -2059,10 +2059,10 @@ class SBox_CVL(Component):
                 sage: objective_value
                 1
                 sage: in_diff  = vec_to_int(vector(
-                ....:   GF(2), 4, [results['IN'][i] for i in range(4)]
+                ....:   GF(2), 4, [results[f"IN[{i}]"] for i in range(4)]
                 ....: ))
                 sage: out_diff = vec_to_int(vector(
-                ....:   GF(2), 4, [results['OUT'][i] for i in range(4)]
+                ....:   GF(2), 4, [results[f"OUT[{i}]"] for i in range(4)]
                 ....: ))
                 sage: ddt = sb.difference_distribution_table()
                 sage: ddt[in_diff][out_diff]
@@ -2218,6 +2218,21 @@ class SBox_CVL(Component):
                 self._return_immediately_ = True
                 return
 
+            def _to_dict(res):
+                r"""
+                Instead of using a dictionary {'Z[0]': 1, 'Z[1]':2} use
+                {'Z':{0:1, 1:2}}, so we can easier iterate over
+                the Z[i]
+                """
+                my_res = dict()
+                for variable, value in res.items():
+                    var_name = variable.split("[")[0]
+                    var_index = variable.split("[")[1].split("]")[0]
+                    if var_name not in my_res:
+                        my_res[var_name] = dict()
+                    my_res[var_name][int(var_index)] = value
+                return my_res
+
             selected_inequations = {
                 prob: [] for prob in reduction_solution_files.keys()
             }
@@ -2228,6 +2243,7 @@ class SBox_CVL(Component):
                 )
 
                 results, _ = model_options.milp_solver.process_solution_file(s_file_sol)
+                results = _to_dict(results)
                 assert 'Z' in results and len(results) == 1, (
                     "ERROR: Unexpected variables in results. "
                     f"Found {results.keys()}, expected 'Z'"

--- a/src/civerly/component.py
+++ b/src/civerly/component.py
@@ -34,12 +34,12 @@ from civerly.util import _write_espresso_input
 from civerly.util import _read_espresso_output
 from civerly.util import reduction_algorithm_ST17
 from civerly.util import translate_sat_clause
-from civerly.solvers import solve, _process_solution_file, run_espresso
 from civerly.model_options import CRYPTANALYSIS, OPTIMIZATION
 from civerly.model_options import GRANULARITY, LINEAR_LAYER_MODELING
-from civerly.model_options import SBOX_MODELING, MINIMIZER
+from civerly.model_options import SBOX_MODELING
 from civerly.model_options import InvalidModelOptionException
 from civerly.largesboxes import largesboxes
+from civerly.solvers import ESPRESSO_CVL, NO_MILP_SOLVER_CVL, NO_LOGIC_MINIMIZER_CVL
 
 
 class Component(ABC):
@@ -147,8 +147,9 @@ class Component(ABC):
         r"""Initialize empty MILP or SAT model for this component."""
         if model_options.optimization == OPTIMIZATION.MILP:
             self.sum_arr_milp = []
-            self.milp = MixedIntegerLinearProgram(maximization=False,
-                                                  solver="GLPK")
+            self.milp = MixedIntegerLinearProgram(
+                maximization=False, solver="GLPK"
+            )
             self.MILP_IN = self.milp.new_variable(name="IN", binary=True)
             self.MILP_OUT = self.milp.new_variable(name="OUT", binary=True)
         elif model_options.optimization == OPTIMIZATION.SAT:
@@ -1007,8 +1008,8 @@ class AND_CVL(Component):
             ....:       optimization=OPTIMIZATION.SAT,
             ....:       granularity=GRANULARITY.BITWISE,
             ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:       solver=SOLVER.CRYPTOMINISAT,
-            ....:       minimizer=MINIMIZER.ESPRESSO,
+            ....:       sat_solver=CRYPTOMINISAT_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
             ....:       path=Path("./DOCTEST-ANDComponent-Models/"))
             ....:   with suppress_output():
             ....:       result = cipher.analyse(model_options)
@@ -1472,7 +1473,6 @@ class LinearLayer_CVL(Component):
 
             sage: from civerly.cipher import Cipher
             sage: from civerly.component import LinearLayer_CVL
-            sage: from civerly.solvers import optimize_sat
             sage: from civerly.model_options import *
             sage: from pathlib import Path
             sage: arr = [
@@ -1491,7 +1491,7 @@ class LinearLayer_CVL(Component):
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   path=Path("./DOCTEST-LL-SAT/"))
             sage: cipher = Cipher(4, 8, name="LL-doctest")
             sage: node = cipher.add_subcipher(
@@ -1533,7 +1533,7 @@ class LinearLayer_CVL(Component):
             48 variables and 110 clauses were written to
             'DOCTEST-LL-SAT/LL-doctest.cnf'
             sage: # optional - cryptominisat
-            sage: optimize_sat(
+            sage: model_options.sat_solver.solve(
             ....:   Path('DOCTEST-LL-SAT/LL-doctest.cnf'),
             ....:   Path('DOCTEST-LL-SAT/LL-doctest.sat'),
             ....:   model_options)
@@ -1982,7 +1982,6 @@ class SBox_CVL(Component):
                 sage: from civerly.model_options import *
                 sage: from civerly.solvers import *
                 sage: from civerly.util import suppress_output, vec_to_int
-                sage: from civerly.solvers import _process_solution_file
                 sage: sb = SBox(
                 ....:   (4, 0, 1, 8, 2, 5, 10, 7, 6, 9, 3, 11, 12, 13, 14, 15)
                 ....: )
@@ -1997,24 +1996,23 @@ class SBox_CVL(Component):
                 ....:   optimization=OPTIMIZATION.MILP,
                 ....:   granularity=GRANULARITY.BITWISE,
                 ....:   sbox_modeling=SBOX_MODELING.DISTORTED_BALL,
-                ....:   solver=SOLVER.GUROBI,
+                ....:   milp_solver=GUROBI_CVL(),
                 ....:   path=Path("./DOCTEST-ToySingleSBoxCipher-Models/"))
                 sage: # optional - gurobi
                 sage: with suppress_output():
                 ....:   milp = cipher.analyse(model_options)
-                sage: results, objective_value = _process_solution_file(
-                ....:   model_options.path / (cipher.name + ".sol"),
-                ....:   SOLVER.GUROBI,
+                sage: results, objective_value = model_options.milp_solver.process_solution_file(
+                ....:   model_options.path / (cipher.name + ".sol")
                 ....: )
                 sage: objective_value
                 1
                 sage: in_diff  = vec_to_int(vector(
                 ....:   GF(2), 4,
-                ....:   [results[f"IN[{i}]"] for i in range(4)]
+                ....:   [results['IN'][i] for i in range(4)]
                 ....: ))
                 sage: out_diff = vec_to_int(vector(
                 ....:   GF(2), 4,
-                ....:   [results[f"OUT[{i}]"] for i in range(4)]
+                ....:   [results['OUT'][i] for i in range(4)]
                 ....: ))
                 sage: ddt = sb.difference_distribution_table()
                 sage: ddt[in_diff][out_diff]
@@ -2032,8 +2030,6 @@ class SBox_CVL(Component):
                 sage: from civerly.component import SBox_CVL
                 sage: from civerly.model_options import *
                 sage: from civerly.util import suppress_output, vec_to_int
-                sage: from civerly.solvers import solve
-                sage: from civerly.solvers import _process_solution_file
                 sage: sb = SBox(
                 ....:   (4, 0, 1, 8, 2, 5, 10, 7, 6, 9, 3, 11, 12, 13, 14, 15)
                 ....: )
@@ -2048,27 +2044,25 @@ class SBox_CVL(Component):
                 ....:   optimization=OPTIMIZATION.MILP,
                 ....:   granularity=GRANULARITY.BITWISE,
                 ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-                ....:   solver=SOLVER.GUROBI,
+                ....:   milp_solver=GUROBI_CVL(),
                 ....:   path=Path("./DOCTEST-ToySingleSBoxCipher-Models/"))
                 sage:  # optional - gurobi
                 sage: with suppress_output():
                 ....:   milp = cipher.model(model_options)
-                sage: solve(
+                sage: model_options.milp_solver.solve(
                 ....:   input_file_name=model_options.path / (cipher.name + ".mps"),
                 ....:   output_file_name=model_options.path / (cipher.name + ".sol"),
-                ....:   solver=SOLVER.GUROBI
                 ....: )
-                sage: results, objective_value = _process_solution_file(
+                sage: results, objective_value = model_options.milp_solver.process_solution_file(
                 ....:   model_options.path / (cipher.name + ".sol"),
-                ....:   SOLVER.GUROBI
                 ....: )
                 sage: objective_value
                 1
                 sage: in_diff  = vec_to_int(vector(
-                ....:   GF(2), 4, [results[f"IN[{i}]"] for i in range(4)]
+                ....:   GF(2), 4, [results['IN'][i] for i in range(4)]
                 ....: ))
                 sage: out_diff = vec_to_int(vector(
-                ....:   GF(2), 4, [results[f"OUT[{i}]"] for i in range(4)]
+                ....:   GF(2), 4, [results['OUT'][i] for i in range(4)]
                 ....: ))
                 sage: ddt = sb.difference_distribution_table()
                 sage: ddt[in_diff][out_diff]
@@ -2078,7 +2072,7 @@ class SBox_CVL(Component):
                 sage: import shutil
                 sage: shutil.rmtree("./DOCTEST-ToySingleSBoxCipher-Models/")
         """
-        solver = model_options.solver
+        solver = model_options.milp_solver
 
         if model_options.cryptanalysis == CRYPTANALYSIS.DIFFERENTIAL:
             ddt = self.S.difference_distribution_table()
@@ -2206,12 +2200,14 @@ class SBox_CVL(Component):
                     milp_to_minimize_milp.set_objective(sum(Z))
                     with suppress_output():  # to avoid doctest failure
                         milp_to_minimize_milp.write_mps(str(s_file_mps))
-                    if solver:
-                        solve(input_file_name=s_file_mps, output_file_name=s_file_sol, solver=solver)
+                    if not isinstance(solver, NO_MILP_SOLVER_CVL):
+                        solver.solve(
+                            input_file_name=s_file_mps, output_file_name=s_file_sol
+                        )
                     else:  # Remember filename so we can tell the user to solve it
                         new_mps_files.append(s_file_mps)
 
-            if not solver:
+            if isinstance(solver, NO_MILP_SOLVER_CVL):
                 print(
                     "SBox MILPs have been written to "
                     f"{', '.join(new_mps_files)}. "
@@ -2222,21 +2218,6 @@ class SBox_CVL(Component):
                 self._return_immediately_ = True
                 return
 
-            def _to_dict(res):
-                r"""
-                Instead of using a dictionary {'Z[0]': 1, 'Z[1]':2} use
-                {'Z':{0:1, 1:2}}, so we can easier iterate over
-                the Z[i]
-                """
-                my_res = dict()
-                for variable, value in res.items():
-                    var_name = variable.split("[")[0]
-                    var_index = variable.split("[")[1].split("]")[0]
-                    if var_name not in my_res:
-                        my_res[var_name] = dict()
-                    my_res[var_name][int(var_index)] = value
-                return my_res
-
             selected_inequations = {
                 prob: [] for prob in reduction_solution_files.keys()
             }
@@ -2246,8 +2227,7 @@ class SBox_CVL(Component):
                     "former check or generation"
                 )
 
-                results, _ = _process_solution_file(s_file_sol, None)
-                results = _to_dict(results)
+                results, _ = model_options.milp_solver.process_solution_file(s_file_sol)
                 assert 'Z' in results and len(results) == 1, (
                     "ERROR: Unexpected variables in results. "
                     f"Found {results.keys()}, expected 'Z'"
@@ -2355,7 +2335,7 @@ class SBox_CVL(Component):
                     _write_espresso_input(
                         posset, esp_file_name, model_options.path
                     )
-                    if model_options.minimizer is None:
+                    if isinstance(model_options.logic_minimizer, NO_LOGIC_MINIMIZER_CVL):
                         print(
                             "Optimization problem for Espresso has been "
                             f"written to {esp_file_in}.\n"
@@ -2365,8 +2345,11 @@ class SBox_CVL(Component):
                         )
                         self._return_immediately_ = True
                         return
-                    elif model_options.minimizer == MINIMIZER.ESPRESSO:
-                        run_espresso(esp_file_in, esp_file_out)
+                    elif isinstance(model_options.logic_minimizer, ESPRESSO_CVL):
+                        model_options.logic_minimizer.solve(
+                            esp_file_in, esp_file_out
+                        )
+
                 clauses = _read_espresso_output(esp_file_out)
 
                 n_in, n_out = self.input_length, self.output_length
@@ -2406,7 +2389,6 @@ class SBox_CVL(Component):
             sage: from civerly.component import SBox_CVL
             sage: from civerly.model_options import *
             sage: from civerly.util import suppress_output, vec_to_int
-            sage: from civerly.solvers import _process_solution_file, solve
             sage: sb = SBox((4, 0, 1, 8, 2, 5, 10, 7, 6, 9, 3, 11, 12, 13, 14, 15))
             sage: sbox = SBox_CVL(sb, "s-box")
             sage: cipher = SBoxCipher(4, 4, name="ToySingleSBoxCipher")
@@ -2417,14 +2399,13 @@ class SBox_CVL(Component):
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   solver=SOLVER.CRYPTOMINISAT,
-            ....:   minimizer=MINIMIZER.ESPRESSO,
+            ....:   sat_solver=CRYPTOMINISAT_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   path=Path("./DOCTEST-ToySingleSBoxCipher-Models/"))
             sage: # optional - cryptominisat # optional - espresso
             sage: with suppress_output(): cipher.analyse(model_options)
-            sage: results, objective_value = _process_solution_file(
-            ....:   model_options.path / (cipher.name + ".sat"),
-            ....:   SOLVER.CRYPTOMINISAT
+            sage: results, objective_value = model_options.sat_solver.process_solution_file(
+            ....:   model_options.path / (cipher.name + ".sat")
             ....: )
             sage: objective_value
             1
@@ -2500,7 +2481,7 @@ class SBox_CVL(Component):
                 _write_espresso_input(
                     posset, esp_file_name, model_options.path
                 )
-                if model_options.minimizer is None:
+                if isinstance(model_options.logic_minimizer, NO_LOGIC_MINIMIZER_CVL):
                     print(
                         "Optimization problem for Espresso has been "
                         f"written to '{esp_file_in}'.\n"
@@ -2510,8 +2491,11 @@ class SBox_CVL(Component):
                     )
                     self._return_immediately_ = True
                     return
-                elif model_options.minimizer == MINIMIZER.ESPRESSO:
-                    run_espresso(esp_file_in, esp_file_out)
+                elif isinstance(model_options.logic_minimizer, ESPRESSO_CVL):
+                    model_options.logic_minimizer.solve(
+                        esp_file_in, esp_file_out
+                    )
+
             clauses = _read_espresso_output(esp_file_out)
 
             for clause in clauses:

--- a/src/civerly/model_options.py
+++ b/src/civerly/model_options.py
@@ -5,6 +5,14 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
+from civerly.solvers import SOLVER_CVL, LOGIC_MINIMIZER_CVL
+from civerly.solvers import MILP_SOLVER_CVL, SAT_SOLVER_CVL, LOGIC_MINIMIZER_CVL
+
+from civerly.solvers import NO_MILP_SOLVER_CVL, GUROBI_CVL, SCIP_CVL, GLPK_CVL
+from civerly.solvers import NO_SAT_SOLVER_CVL, CRYPTOMINISAT_CVL, CADICAL_CVL
+from civerly.solvers import NO_LOGIC_MINIMIZER_CVL, ESPRESSO_CVL
+
+
 
 class CRYPTANALYSIS(Enum):
     """
@@ -98,58 +106,6 @@ class SBOX_MODELING(Enum):
     LOGICAL_COND_ESPRESSO = 4  # For both MILP / SAT
 
 
-class SOLVER(Enum):
-    """
-    The solver to be (automatically) used by CiVerLy. Of course, CiVerLy does
-    not implement any solver but simply calls the corresponding solver.
-
-    Supported MILP solvers:
-
-    - SCIP: Open Source and reasonable performance.
-    - GLPK: Open Source but only weak performance.
-    - Gurobi: Commercial solver (license needed). Best performance.
-
-    Supported SAT solvers:
-
-    - CryptoMiniSat: Open Source solver.
-    - CaDiCal: Open Source solver.
-
-    .. NOTE::
-
-        If you are going to solve all models by yourself (e.g. on a different
-        machine), you can set this to ``None``.
-
-    .. WARNING::
-
-        Pick a solver only if it is installed on the same machine you are
-        running CiVerLy on.
-    """
-    # MILP solvers
-    SCIP = 1
-    GLPK = 2
-    GUROBI = 3
-
-    # SAT solvers
-    CRYPTOMINISAT = 4
-    CADICAL = 5
-
-
-class MINIMIZER(Enum):
-    """
-    The minimizer to be (automatically) called by CiVerLy, to minimize
-    boolean formulas and therefore to simplify MILP or SAT models.
-    Of course, CiVerLy does not implement any minimizer but simply
-    calls the corresponding minimizer externally.
-
-    Supported minimizers:
-
-        - Espresso: Used throughout the literature for this purpose.
-          Freely available on https://github.com/classabbyamp/espresso-logic
-
-    """
-    ESPRESSO = 1
-
-
 @dataclass(init=True, repr=False)
 class MODEL_OPTIONS:
     """
@@ -169,7 +125,9 @@ class MODEL_OPTIONS:
         - ``sbox_modeling`` -- see
           :class:`civerly.model_options.SBOX_MODELING`
 
-        - ``solver`` -- see :class:`civerly.model_options.SOLVER`
+        - ``milp_solver`` -- see :class:`civerly.solvers.MILP_SOLVER_CVL`
+        
+        - ``sat_solver`` -- see :class:`civerly.solvers.MILP_SOLVER_CVL`
 
         - ``solve_range`` -- tuple; The range of weights for which CiVerLy
           should generate models and solve them
@@ -195,7 +153,7 @@ class MODEL_OPTIONS:
         ....:     granularity=GRANULARITY.BITWISE,
         ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.CONVEX_HULL,
         ....:     sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-        ....:     solver=SOLVER.SCIP,
+        ....:     milp_solver=SCIP_CVL(),
         ....:     path=Path("./CiVerLy-Models/"))
         sage: model_options
         MODEL_OPTIONS:
@@ -204,8 +162,30 @@ class MODEL_OPTIONS:
             -> granularity : BITWISE
             -> linear_layer_modeling : CONVEX_HULL
             -> sbox_modeling : CONVEX_HULL
-            -> solver : SCIP
-            -> minimizer : None
+            -> milp_solver : <class 'civerly.solvers.SCIP_CVL'>
+            -> sat_solver : <class 'civerly.solvers.NO_SAT_SOLVER_CVL'>
+            -> logic_minimizer : <class 'civerly.solvers.NO_LOGIC_MINIMIZER_CVL'>
+            -> solve_range : None
+            -> sat_precision : 0
+            -> path : CiVerLy-Models
+        sage: model_options = MODEL_OPTIONS(
+        ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+        ....:     optimization=OPTIMIZATION.MILP,
+        ....:     granularity=GRANULARITY.BITWISE,
+        ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.CONVEX_HULL,
+        ....:     sbox_modeling=SBOX_MODELING.CONVEX_HULL,
+        ....:     milp_solver=None,
+        ....:     path=Path("./CiVerLy-Models/"))
+        sage: model_options
+        MODEL_OPTIONS:
+            -> cryptanalysis : DIFFERENTIAL
+            -> optimization : MILP
+            -> granularity : BITWISE
+            -> linear_layer_modeling : CONVEX_HULL
+            -> sbox_modeling : CONVEX_HULL
+            -> milp_solver : <class 'civerly.solvers.NO_MILP_SOLVER_CVL'>
+            -> sat_solver : <class 'civerly.solvers.NO_SAT_SOLVER_CVL'>
+            -> logic_minimizer : <class 'civerly.solvers.NO_LOGIC_MINIMIZER_CVL'>
             -> solve_range : None
             -> sat_precision : 0
             -> path : CiVerLy-Models
@@ -217,8 +197,9 @@ class MODEL_OPTIONS:
     granularity: GRANULARITY = None
     linear_layer_modeling: LINEAR_LAYER_MODELING = None
     sbox_modeling: SBOX_MODELING = None
-    solver: SOLVER = None
-    minimizer: MINIMIZER = None
+    milp_solver: MILP_SOLVER_CVL = None
+    sat_solver: SAT_SOLVER_CVL = None
+    logic_minimizer: LOGIC_MINIMIZER_CVL = None
     solve_range: tuple = None
     sat_precision: int = 0
     path: Path = None
@@ -229,6 +210,8 @@ class MODEL_OPTIONS:
         for attribute, value in self.__dict__.items():
             if isinstance(value, Enum):
                 string += f"\n\t-> {attribute} : {value.__dict__['_name_']}"
+            elif isinstance(value, SOLVER_CVL):
+                string += f"\n\t-> {attribute} : {type(value)}"
             elif not isinstance(value, bool):  # skip write_to_file
                 string += f"\n\t-> {attribute} : {value}"
         return string
@@ -237,6 +220,16 @@ class MODEL_OPTIONS:
         r"""
         This method will be executed right after the implicit __init__ method.
         """
+        # set self.{milp, sat}_solver to respective NoneSolver
+        if self.milp_solver is None:
+            self.milp_solver = NO_MILP_SOLVER_CVL()
+        
+        if self.sat_solver is None:
+            self.sat_solver = NO_SAT_SOLVER_CVL()
+        
+        if self.logic_minimizer is None:
+            self.logic_minimizer = NO_LOGIC_MINIMIZER_CVL()
+        
         if self.solve_range is None and self.optimization == OPTIMIZATION.SAT:
             self.solve_range = (0, 100)
         if self.path is None:
@@ -258,7 +251,7 @@ class MODEL_OPTIONS:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.CONVEX_HULL,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   solver=SOLVER.SCIP,
+            ....:   milp_solver=SCIP_CVL(),
             ....:   path=Path("./CiVerLy-Models/"))
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -266,7 +259,7 @@ class MODEL_OPTIONS:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   solver=SOLVER.SCIP,
+            ....:   milp_solver=SCIP_CVL(),
             ....:   path=Path("./CiVerLy-Models/"))
             Traceback (most recent call last):
             ...
@@ -281,7 +274,7 @@ class MODEL_OPTIONS:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.CONVEX_HULL,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   solver=SOLVER.SCIP,
+            ....:   milp_solver=SCIP_CVL(),
             ....:   path=Path("./CiVerLy-Models/"))
             Traceback (most recent call last):
             ...
@@ -427,36 +420,25 @@ class MODEL_OPTIONS:
                 "when using SAT modeling."
             )
 
-        # optimization.milp ==> solver.{None, gurobi, scip, glpk}
-        if self.optimization == OPTIMIZATION.MILP \
-                and self.solver not in (
-                    None,
-                    SOLVER.GUROBI,
-                    SOLVER.SCIP,
-                    SOLVER.GLPK
-                ):
+        # milp_solver.{None, gurobi, scip, glpk}
+        if not isinstance(self.milp_solver, MILP_SOLVER_CVL):
             raise InvalidModelOptionException(
-                self.solver,
+                self.milp_solver,
                 message="Solver modeling must be either None, "
-                "SOLVER.GUROBI, "
-                "SOLVER.SCIP or "
-                "SOLVER.GLPK "
+                "Gurobi, "
+                "Scip or "
+                "Glpk "
                 "when using MILP modeling."
             )
 
-        # optimization.sat ==> solver.{None, cadical, cryptominisat}
-        if self.optimization == OPTIMIZATION.SAT \
-                and self.solver not in (
-                    None,
-                    SOLVER.CRYPTOMINISAT,
-                    SOLVER.CADICAL
-                ):
+        # sat_solver.{None, cadical, cryptominisat}
+        if not isinstance(self.sat_solver, SAT_SOLVER_CVL):
             raise InvalidModelOptionException(
-                self.solver,
-                message="Solver modeling must be either None, "
-                "SOLVER.CRYPTOMINISAT or "
-                "SOLVER.CADICAL "
-                "when using MILP modeling."
+                self.sat_solver,
+                message="Solver must be either None, "
+                "CryptoMiniSat or "
+                "CaDiCal "
+                "when using SAT modeling."
             )
 
         # optimization.milp ==> sat_precision.None
@@ -464,8 +446,15 @@ class MODEL_OPTIONS:
                 and self.sat_precision != 0:
             raise InvalidModelOptionException(
                 self.sat_precision,
-                message="Sat precision is not unnecessary for "
+                message="Sat precision is unnecessary for "
                 "MILP optimization."
+            )
+
+        if not isinstance(self.logic_minimizer, LOGIC_MINIMIZER_CVL):
+            raise InvalidModelOptionException(
+                self.logic_minimizer,
+                message="logic_minimizer must be either NO_LOGIC_MINIMIZER_CVL or "
+                "ESPRESSO_CVL."
             )
 
         error = False
@@ -492,10 +481,6 @@ class MODEL_OPTIONS:
             error = True
             attr = self.sbox_modeling
             correct_enum = SBOX_MODELING
-        elif not isinstance(self.solver, (SOLVER, type(None))):
-            error = True
-            attr = self.solver
-            correct_enum = SOLVER
 
         if error:
             raise InvalidModelOptionException(
@@ -506,65 +491,10 @@ class MODEL_OPTIONS:
         return
 
 
-class NoSolverWarning(Warning):
-    r"""
-    Warning which will be thrown whenever :meth:`analyse` is called with
-    `model_options.solver = None`.
-
-    EXAMPLES::
-
-        sage: from civerly.model_options import *
-        sage: from civerly.util import suppress_output
-        sage: from civerly.cipher_implementations.aes import AES_CVL
-        sage: aes = AES_CVL(6)
-        sage: model_options = MODEL_OPTIONS(
-        ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-        ....:   optimization=OPTIMIZATION.MILP,
-        ....:   granularity=GRANULARITY.WORDWISE,
-        ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
-        ....:   solver=None,
-        ....:   path=Path("./DOCTEST-ModelOptions/"))
-        sage: with suppress_output():
-        ....:   aes.analyse(model_options)
-        Traceback (most recent call last):
-        ...
-        NoSolverWarning: No solver has been selected.
-        CiVerLy will return without solving.
-
-        sage: import shutil
-        sage: shutil.rmtree("DOCTEST-ModelOptions")
-
-
-    """
-    def __init__(self):
-        super().__init__(
-            "No solver has been selected. "
-            "CiVerLy will return without solving."
-        )
-
-
 class InvalidModelOptionException(Exception):
     r"""
     Exception which will be thrown whenever an invalid model option is given
     by the user.
-
-    TESTS::
-
-        sage: from civerly.model_options import InvalidModelOptionException
-        sage: from civerly.model_options import SOLVER
-        sage: solver = "WRONG_SOLVER"
-        sage: raise InvalidModelOptionException(solver, SOLVER)
-        Traceback (most recent call last):
-        ...
-        InvalidModelOptionException: Invalid solver WRONG_SOLVER!
-        sage: solver = "WRONG_SOLVER"
-        sage: raise InvalidModelOptionException(
-        ....:   solver, message="This solver does not exist."
-        ....: )
-        Traceback (most recent call last):
-        ...
-        InvalidModelOptionException: This solver does not exist.
-
 
     """
     def __init__(self, model_option, model_option_type=None, message=None):
@@ -585,8 +515,12 @@ class InvalidModelOptionException(Exception):
                 string = "linear layer modeling option"
             elif model_option_type is SBOX_MODELING:
                 string = "sbox modeling option"
-            elif model_option_type is SOLVER:
-                string = "solver"
+            # elif model_option_type is MILP_SOLVER_CVL:
+            #     string = "milp_solver"
+            # elif model_option_type is SAT_SOLVER_CVL:
+            #     string = "sat_solver"
+            # elif model_option_type is LOGIC_MINIMIZER_CVL:
+            #     string = "logic_minimizer"
 
             message = f"Invalid {string} {model_option}!"
 

--- a/src/civerly/sboxcipher.py
+++ b/src/civerly/sboxcipher.py
@@ -79,7 +79,6 @@ class SBoxCipher(Cipher):
                 sage: from civerly.component import SBox_CVL, XOR_CVL
                 sage: from civerly.component import RoundkeyXOR_CVL
                 sage: from civerly.model_options import *
-                sage: from civerly.solvers import solve, get_objective_value
                 sage: from sage.crypto.sboxes import PRESENT as present_S_sage
                 sage: from civerly.util import suppress_output
                 sage: name = "ToyFeistel"
@@ -114,14 +113,14 @@ class SBoxCipher(Cipher):
                 ....:   granularity=GRANULARITY.BITWISE,
                 ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
                 ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-                ....:   solver=SOLVER.GUROBI,
+                ....:   milp_solver=GUROBI_CVL(),
                 ....:   path=Path("./DOCTEST-ToyFeistelCipher-Models/"))
                 sage: # optional - gurobi
                 sage: with suppress_output():
                 ....:   milp = cipher.analyse(model_options)
-                sage: get_objective_value(
+                sage: model_options.milp_solver.process_solution_file(
                 ....:   model_options.path / (cipher.name + ".sol"),
-                ....:   SOLVER.GUROBI)
+                ....: )[1]
                 0
                 sage: R = 2
                 sage: cipher = SBoxCipher(2*n, 2*n, name=name+"Cipher")
@@ -137,14 +136,14 @@ class SBoxCipher(Cipher):
                 ....:   granularity=GRANULARITY.BITWISE,
                 ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
                 ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-                ....:   solver=SOLVER.GUROBI,
+                ....:   milp_solver=GUROBI_CVL(),
                 ....:   path=Path("./DOCTEST-ToyFeistelCipher-Models/"))
                 sage: # optional - gurobi
                 sage: with suppress_output():
                 ....:   milp = cipher.analyse(model_options)
-                sage: get_objective_value(
+                sage: model_options.milp_solver.process_solution_file(
                 ....:   model_options.path / (cipher.name + ".sol"),
-                ....:   SOLVER.GUROBI)
+                ....: )[1]
                 1
                 sage: import shutil
                 sage: shutil.rmtree(

--- a/src/civerly/solvers.py
+++ b/src/civerly/solvers.py
@@ -15,7 +15,6 @@ from enum import Enum
 from sage.sat.solvers.dimacs import DIMACS
 from civerly.util import _generate_constraints_sum_leq_int_LS24
 from civerly.util import suppress_output, _float_or_int
-from civerly.util import _to_dict
 
 
 class SOLVER_CVL:
@@ -432,7 +431,7 @@ class GUROBI_CVL(MILP_SOLVER_CVL):
             name = line[:line.index(" ")]
             value = __string_to_int_gurobi(line[line.index(" ")+1:])
             results[name] = value
-        return _to_dict(results), objective_value
+        return results, objective_value
 
 
 class SCIP_CVL(MILP_SOLVER_CVL):
@@ -461,12 +460,8 @@ class SCIP_CVL(MILP_SOLVER_CVL):
                 f"{output_file_name} "
                 "quit"
             ),
-            "-s", "scip_settings.set",
+            "-s", "scip_settings.set", "-l", str(log_file_name)
         ]
-        # only add -l flag when log_file_name is set
-        if log_file_name is not None:
-            command += ["-l", str(log_file_name)]
-
         with suppress_output():
             process = subprocess.Popen(command)
             errno = process.wait()
@@ -543,7 +538,7 @@ class SCIP_CVL(MILP_SOLVER_CVL):
             name = line[:line.index("]")+1]
             results[name] = value
 
-        return _to_dict(results), objective_value
+        return results, objective_value
 
 
 class GLPK_CVL(MILP_SOLVER_CVL):
@@ -559,13 +554,9 @@ class GLPK_CVL(MILP_SOLVER_CVL):
             input_file_name, output_file_name, log_file_name, time_limit
         )
         command = [
-            "glpsol", str(input_file_name),
+            "glpsol", str(input_file_name), "--log", str(log_file_name),
             "-o", str(output_file_name)
         ]
-        # only add --log flag when log_file_name is set
-        if log_file_name is not None:
-            command += ["--log", str(log_file_name)]
-
         if time_limit is not None:
             command.insert(2, "--tmlim")
             command.insert(3, str(time_limit))
@@ -665,7 +656,7 @@ class GLPK_CVL(MILP_SOLVER_CVL):
             name = line[:i+1]
             value = line[i+1:i+2]
             results[name] = value
-        return _to_dict(results), objective_value
+        return results, objective_value
 
 
 class CRYPTOMINISAT_CVL(SAT_SOLVER_CVL):

--- a/src/civerly/solvers.py
+++ b/src/civerly/solvers.py
@@ -12,10 +12,993 @@ import shutil
 from pathlib import Path
 from enum import Enum
 
-from civerly.model_options import SOLVER, InvalidModelOptionException
 from sage.sat.solvers.dimacs import DIMACS
 from civerly.util import _generate_constraints_sum_leq_int_LS24
-from civerly.util import suppress_output
+from civerly.util import suppress_output, _float_or_int
+from civerly.util import _to_dict
+
+
+class SOLVER_CVL:
+    """
+    The solver to be (automatically) used by CiVerLy. Of course, CiVerLy does
+    not implement any solver but simply calls the corresponding solver.
+
+    Supported MILP solvers:
+
+    - SCIP: Open Source and reasonable performance.
+    - GLPK: Open Source but only weak performance.
+    - Gurobi: Commercial solver (license needed). Best performance.
+
+    Supported SAT solvers:
+
+    - CryptoMiniSat: Open Source solver.
+    - CaDiCal: Open Source solver.
+
+    .. NOTE::
+
+        If you are going to solve all models by yourself (e.g. on a different
+        machine), you can set this to ``None``.
+
+    .. WARNING::
+
+        Pick a solver only if it is installed on the same machine you are
+        running CiVerLy on.
+    """
+
+    def __init__(self):
+        self.name = "GenericSolver"
+        self.status = SOLVING_STATUS.SUCCESS  # default value
+
+        # overwritten for solvers not supporting log files
+        self.redirect_stdout = None
+
+    def solve(self, input_file_name, output_file_name,
+              log_file_name=None, time_limit=None):
+        """
+        Solve the given optimization problem. For MILP and minimizing, this
+        simply calls :meth:`invoke`, while for SAT the binary search method
+        (formerly `optimize_sat`) is called.
+        """
+        return self.invoke(
+            input_file_name, output_file_name,
+            log_file_name=log_file_name, time_limit=time_limit
+        )
+
+    def invoke(self, input_file_name, output_file_name,
+              log_file_name=None, time_limit=None):
+        """
+        Solve the given MILP or SAT instance externally.
+
+        INPUT:
+
+            - ``input_file_name``-- path to the file containing the MILP or SAT
+
+            - ``output_file_name``-- path of the file the solution is written to
+
+            - ``log_file_name``-- path to the solver's log file. Default based on
+            ``output_file_name`` and ``solver``.
+
+            - ``time_limit``-- integer (default ``None``); time limit in seconds
+
+        OUTPUT:
+
+            - Status, see :class:`civerly.solvers.SOLVING_STATUS`. Further, upon
+            successful execution either a ``.sol`` or a ``.sat`` file is created,
+            depending on ``solver``. The file will contain the solution, if one
+            is found.
+
+        .. NOTE::
+
+            This method is implemented for convenience in case a solver is
+            installed on the same machine as CiVerLy.
+        """
+        assert isinstance(input_file_name, Path)
+        assert isinstance(output_file_name, Path)
+
+        # default log file
+        if log_file_name is None:
+            parent_dir = output_file_name.parent
+            name = f"{output_file_name.stem}_{self.name}"
+            suffix = ".log"
+            log_file_name = parent_dir / (name + suffix)
+        else:
+            assert isinstance(log_file_name, Path)
+
+        # you can disable a solver by setting an environment variable
+        # with this we simulate that a solver is not installed albeit it is
+        # i.e. this is used for testing only
+        ENV_DISABLE_PREFIX = "CIVERLY_DISABLE_"
+        if ENV_DISABLE_PREFIX+self.name in os.environ:
+            raise ValueError(
+                f"{self.name} was disabled by setting environment variable "
+                f"{ENV_DISABLE_PREFIX+self.name}"
+            )
+
+    def process_solution_file(self, solution_file_name):
+        pass
+
+
+class MILP_SOLVER_CVL(SOLVER_CVL):
+    def __init__(self):
+        super().__init__()
+
+
+class SAT_SOLVER_CVL(SOLVER_CVL):
+    def __init__(self):
+        super().__init__()
+
+    def solve(self, input_file_name, output_file_name, model_options=None,
+              time_limit=None, benchmark=False):
+        """
+        Repeatedly solve SAT to determine the lowest possible weight.
+
+        Given a SAT with its corresponding ``sum_arr``, this method applies a
+        binary search to determine the lowest weight ``w`` for which this SAT is
+        solvable and solves it.
+
+        INPUT:
+
+            - ``input_file_name``-- path to the file containing the SAT
+
+            - ``output_file_name``-- path to the file the solution is written to
+
+            - ``model_options`` -- see
+            :class:`civerly.model_options.MODEL_OPTIONS`.
+            Used to retrieve the ``solver``, ``solve_range`` and
+            ``sat_precision``.
+
+            - ``time_limit``-- integer (default ``None``); time limit in seconds
+
+            - ``benchmark``-- (default ``False``); when set to ``True`` return
+            details about internal timing. This is used by
+            :meth:`civerly.benchmark.benchmark`.
+
+        OUTPUT:
+
+            - None, but upon successful execution a ``.sol`` file is created,
+            containing the solution (if found).
+
+        .. NOTE::
+
+            This method is implemented for convenience in case a solver is
+            installed on the same machine as CiVerLy.
+        """
+        assert isinstance(input_file_name, Path)
+        assert isinstance(output_file_name, Path)
+
+        if time_limit is not None:
+            end_time = int(time.time()+time_limit)
+
+        # shorten variable name
+        if model_options is not None:
+            pr = model_options.sat_precision
+        else:
+            pr = 0
+
+        benchmarks = []
+
+        def __get_sum_arr():
+            r"""
+            Implicit helper function to read and extract the sum_arr from the
+            corresponding json file.
+            """
+            sum_arr_file = input_file_name.parent / f"{input_file_name.stem}sum.json"
+            with open(sum_arr_file, 'r') as f:
+                file_content = json.load(f)
+
+                # Scale all weights by 10**sat_precision
+                # (and normalize again later)
+                sum_arr = [
+                    (weight, var)
+                    for weight, var in file_content
+                ]
+            return sum_arr
+
+        if model_options is not None:
+            # scale W_MIN, W_MAX too
+            W_MIN = int(model_options.solve_range[0] * 10**pr)
+            W_MAX = int(model_options.solve_range[1] * 10**pr)
+        else:
+            W_MIN, W_MAX = 0, 100
+
+        ALL_SAT, ALL_UNSAT = True, True
+        # ---------------------------------------------------------------
+        while W_MAX > W_MIN or ALL_UNSAT or ALL_SAT:
+            w = (W_MAX + W_MIN) // 2
+
+            # will be appended to benchmarks
+            row = {"bound": w}
+            row["W_MIN"] = W_MIN
+            row["W_MAX"] = W_MAX
+
+            sat = DIMACS()
+            sat.read(str(input_file_name))
+
+            print(
+                f"[{float(W_MIN/10**pr):{3+pr}.{pr}f} ,"
+                f"{float(W_MAX/10**pr):{3+pr}.{pr}f}] "
+                f"(trying w = {float(w/10**pr):{3+pr}.{pr}f}) :",  # noqa
+                end=" ",
+                flush=True
+            )
+            start = time.time()
+            sat_constraining_prob = _generate_constraints_sum_leq_int_LS24(
+                sat,
+                __get_sum_arr(),
+                int(w)  # cast to int as it is a float with .0 anyway
+            )
+            stop = time.time()
+            row["nvars"] = sat_constraining_prob.nvars()
+            row["nclauses"] = len(sat_constraining_prob.clauses())
+            row["t_model"] = stop - start
+
+            # temporary files with encoded weight w
+            name = f"{input_file_name.stem}_obj{w}"
+            tmp_cnf_file_name = input_file_name.parent / f"{name}.cnf"
+            tmp_sat_file_name = input_file_name.parent / f"{name}.sat"
+            sat_constraining_prob.write(tmp_cnf_file_name)
+            if time_limit is not None:
+                tmp_time_limit = end_time - int(time.time())
+                if tmp_time_limit < 0:
+                    return SOLVING_STATUS.TIMEOUT, (W_MIN/10**pr, W_MAX/10**pr)
+            else:
+                tmp_time_limit = None
+
+            start = time.time()
+            status = self.invoke(
+                tmp_cnf_file_name,
+                tmp_sat_file_name,
+                time_limit=tmp_time_limit
+            )
+            stop = time.time()
+            row["t_solve"] = stop - start
+
+            if status is not None:
+                if benchmark:
+                    row["result"] = status
+                    benchmarks.append(row)
+                    return benchmarks
+                else:
+                    e = f"{tmp_sat_file_name} could not be solved."
+                    raise AssertionError(e)
+
+            with open(tmp_sat_file_name, 'r') as f:
+                result = f.readlines()[0].strip("\n")
+
+            if result in ["UNSAT", "s UNSATISFIABLE"]:
+                row["result"] = "UNSAT"
+                benchmarks.append(row)
+                ALL_SAT = False
+                W_MIN, res = (w + 1), "UNSAT"
+                if W_MIN > W_MAX:
+                    # happens if all models are UNSAT
+                    print(res)
+                    W_MIN = W_MAX
+                    break
+            elif result in ["SAT", "s SATISFIABLE"]:
+                row["result"] = "SAT"
+                benchmarks.append(row)
+                ALL_UNSAT = False
+                W_MAX, res = w, "SAT"
+                if W_MAX == W_MIN:
+                    # happens if all models are SAT
+                    print(res)
+                    break
+            else:
+                e = f"{tmp_sat_file_name} does not have the expected format."
+                e += f" Expected: SAT/UNSAT, got: {result}."
+                raise AssertionError(e)
+
+            print(res)
+
+        # ---------------------------------------------------------------
+
+        # put solution in correct file
+        name = f"{input_file_name.stem}_obj{W_MIN}"
+        tmp_cnf_file_name = input_file_name.parent / f"{name}.cnf"
+        tmp_sat_file_name = input_file_name.parent / f"{name}.sat"
+        shutil.copyfile(tmp_cnf_file_name, input_file_name)
+        shutil.copyfile(tmp_sat_file_name, output_file_name)
+
+        # write optimization value into the sat file
+        with open(output_file_name, 'a') as f:
+            f.write(str(float(W_MIN/10**pr))+"\n")
+
+        if benchmark:
+            return benchmarks
+
+        if pr == 0:
+            return int(W_MIN)
+        return float(W_MIN/10**pr)
+
+
+class LOGIC_MINIMIZER_CVL(SOLVER_CVL):
+    """
+    The logic minimizer to be (automatically) called by CiVerLy, to minimize
+    boolean formulas and therefore to simplify MILP or SAT models.
+    Of course, CiVerLy does not implement any logic minimizer but simply
+    calls the corresponding logic minimizer externally.
+
+    Supported minimizers:
+
+        - Espresso: Used throughout the literature for this purpose.
+          Freely available on https://github.com/classabbyamp/espresso-logic
+
+    """
+    def __init__(self):
+        super().__init__()
+
+
+class GUROBI_CVL(MILP_SOLVER_CVL):
+    def __init__(self):
+        super().__init__()
+        self.name = "Gurobi"
+        self.timeout_string = r"Time limit reached"
+
+    def invoke(self, input_file_name, output_file_name,
+              log_file_name=None, time_limit=None):
+        r"""Invoke Gurobi solver via shell."""
+        super().invoke(
+            input_file_name, output_file_name, log_file_name, time_limit
+        )
+        command = [
+            "gurobi_cl", f"ResultFile={output_file_name}",
+            f"LogFile={log_file_name}", str(input_file_name)
+        ]
+        if time_limit is not None:
+            command.insert(2, f"TimeLimit={time_limit}")
+
+        with suppress_output():
+            process = subprocess.Popen(command)
+            errno = process.wait()
+
+        if errno != 0:
+            self.status = SOLVING_STATUS.ERROR
+
+        if time_limit is not None:
+            # check if the solver reported a time out by checking the log file
+            # for an according string
+            with open(log_file_name, 'r') as file:
+                content = file.read()
+            if re.search(self.timeout_string, content, re.MULTILINE):
+                self.status = SOLVING_STATUS.TIMEOUT
+
+        if self.status != SOLVING_STATUS.SUCCESS:
+            raise SolverException(self.status)
+        return
+
+    def get_objective_bounds(self, log_file_name):
+        """
+        Extract the bounds on the objective value from the log of an MILP solver.
+
+        This function shall be used when the MILP solver exceeds the given timeout.
+
+        INPUT:
+
+            - ``log_file_name``-- name of the log file
+        """
+        assert isinstance(log_file_name, Path)
+
+        regexp = r'Best objective (\S+), best bound (\S+), gap'
+
+        with open(log_file_name, 'r') as file:
+            content = file.read()
+
+        hit = re.search(regexp, content, re.MULTILINE)
+        if hit:
+            upper_bound = _float_or_int(hit.group(1))
+            lower_bound = _float_or_int(hit.group(2))
+            return lower_bound, upper_bound
+
+        warnings.warn(f"No objective bounds found in {log_file_name}")
+        return None, None
+
+    def process_solution_file(self, solution_file_name):
+        """
+        Parse a solution generated by Gurobi.
+
+        INPUT:
+
+            - ``solution_file_name``-- name of the file containing a solution
+
+        OUTPUT: The processed ``results`` and ``objective_value``.
+        """
+        assert isinstance(solution_file_name, Path)
+
+        with open(solution_file_name, "r") as f:
+            file_content = f.read().split("\n")
+
+        def __string_to_int_gurobi(str):
+            """
+            Remove rounding errors.
+
+            Solution values can deviate up to 1e-5 from integer solutions, see
+            https://support.gurobi.com/hc/en-us/articles/360012237872-Why-does-Gurobi-sometimes-return-non-integral-values-for-integer-variables
+            """
+            try:
+                return int(str)
+            except ValueError:
+                value_float = float(str)
+                value_int = int(round(value_float))
+                if abs(value_float - value_int) < 1e-5:
+                    return value_int
+                raise ValueError(f"Deviation from integer to high: {str}")
+        assert file_content != [''], "The model is UNSAT"
+
+        objective_value = file_content[0][file_content[0].index('=')+2:]
+        objective_value = _float_or_int(objective_value)
+        results = {}
+        for line in file_content[1:-1]:
+            name = line[:line.index(" ")]
+            value = __string_to_int_gurobi(line[line.index(" ")+1:])
+            results[name] = value
+        return _to_dict(results), objective_value
+
+
+class SCIP_CVL(MILP_SOLVER_CVL):
+    def __init__(self):
+        super().__init__()
+        self.name = "SCIP"
+        self.timeout_string = r"time limit reached"
+
+    def invoke(self, input_file_name, output_file_name,
+              log_file_name=None, time_limit=None):
+        r"""Invoke SCIP solver via shell."""
+        super().invoke(
+            input_file_name, output_file_name, log_file_name, time_limit
+        )
+        if time_limit is not None:
+            with open('scip_settings.set', 'w') as f:
+                f.write(f"write/printzeros = TRUE\nlimits/time = {time_limit}")
+        else:
+            with open('scip_settings.set', 'w') as f:
+                f.write('write/printzeros = TRUE')
+        command = [
+            "scip", "-c",
+            (
+                f"read {input_file_name} "
+                "optimize write solution "
+                f"{output_file_name} "
+                "quit"
+            ),
+            "-s", "scip_settings.set",
+        ]
+        # only add -l flag when log_file_name is set
+        if log_file_name is not None:
+            command += ["-l", str(log_file_name)]
+
+        with suppress_output():
+            process = subprocess.Popen(command)
+            errno = process.wait()
+
+        if errno != 0:
+            self.status = SOLVING_STATUS.ERROR
+
+        if time_limit is not None:
+            # check if the solver reported a time out by checking the log file
+            # for an according string
+            with open(log_file_name, 'r') as file:
+                content = file.read()
+            if re.search(self.timeout_string, content, re.MULTILINE):
+                self.status = SOLVING_STATUS.TIMEOUT
+
+        # clean up
+        Path("scip_settings.set").unlink(missing_ok=True)
+
+        return
+
+    def get_objective_bounds(self, log_file_name):
+        """
+        Extract the bounds on the objective value from
+        the log file of a MILP solver.
+
+        This function shall be used when the MILP solver
+        exceeds the given timeout.
+
+        INPUT:
+
+            - ``log_file_name``-- name of the log file
+
+        """
+        assert isinstance(log_file_name, Path)
+        regexp = r'Primal Bound\s*:\s*(\S+).*\nDual Bound\s*:\s*(\S+).*'
+
+        with open(log_file_name, 'r') as file:
+            content = file.read()
+
+        hit = re.search(regexp, content, re.MULTILINE)
+        if hit:
+            upper_bound = _float_or_int(hit.group(1))
+            lower_bound = _float_or_int(hit.group(2))
+            return lower_bound, upper_bound
+
+        warnings.warn(f"No objective bounds found in {log_file_name}")
+        return None, None
+
+    def process_solution_file(self, solution_file_name):
+        """
+        Parse a solution generated by SCIP.
+
+        INPUT:
+
+            - ``solution_file_name``-- name of the file containing a solution
+
+
+        OUTPUT: The processed ``results`` and ``objective_value``.
+        """
+        assert isinstance(solution_file_name, Path)
+
+        with open(solution_file_name, "r") as f:
+            file_content = f.read().split("\n")
+
+        if any(["infeasible" in line for line in file_content[:10]]):
+            raise ValueError("There is no solution found!")
+        results = {}
+        objective_value = file_content[1].strip(" ")
+        objective_value = objective_value[objective_value.index(":")+1:]
+        objective_value = _float_or_int(objective_value)
+        for line in file_content[2:-1]:
+            line = line[:line.index("(")].replace(" ", "")
+            value = int(round(float(line[line.index("]")+1:])))
+            name = line[:line.index("]")+1]
+            results[name] = value
+
+        return _to_dict(results), objective_value
+
+
+class GLPK_CVL(MILP_SOLVER_CVL):
+    def __init__(self):
+        super().__init__()
+        self.name = "GLPK"
+        self.timeout_string = r"TIME LIMIT EXCEEDED"
+
+    def invoke(self, input_file_name, output_file_name,
+              log_file_name=None, time_limit=None):
+        r"""Invoke GLPK solver via shell."""
+        super().invoke(
+            input_file_name, output_file_name, log_file_name, time_limit
+        )
+        command = [
+            "glpsol", str(input_file_name),
+            "-o", str(output_file_name)
+        ]
+        # only add --log flag when log_file_name is set
+        if log_file_name is not None:
+            command += ["--log", str(log_file_name)]
+
+        if time_limit is not None:
+            command.insert(2, "--tmlim")
+            command.insert(3, str(time_limit))
+
+        with suppress_output():
+            process = subprocess.Popen(command)
+            errno = process.wait()
+
+        if errno != 0:
+            self.status = SOLVING_STATUS.ERROR
+
+        if time_limit is not None:
+            # check if the solver reported a time out by checking the log file
+            # for an according string
+            with open(log_file_name, 'r') as file:
+                content = file.read()
+            if re.search(self.timeout_string, content, re.MULTILINE):
+                self.status = SOLVING_STATUS.TIMEOUT
+
+        return
+
+    def get_objective_bounds(self, log_file_name):
+        """
+        Extract the bounds on the objective value from the log of an MILP solver.
+
+        This function shall be used when the MILP solver exceeds the given timeout.
+
+        INPUT:
+
+            - ``log_file_name``-- name of the log file
+
+        """
+        assert isinstance(log_file_name, Path)
+        regexp = r'.*mip\s*=\s*(\S+)\s*>=\s*(\S+).*'
+
+        with open(log_file_name, 'r') as file:
+            content = file.read()
+
+        hit = re.search(regexp, content, re.MULTILINE)
+        if hit:
+            upper_bound = _float_or_int(hit.group(1))
+            lower_bound = _float_or_int(hit.group(2))
+            return lower_bound, upper_bound
+
+        warnings.warn(f"No objective bounds found in {log_file_name}")
+        return None, None
+
+    def process_solution_file(self, solution_file_name):
+        """
+        Parse a solution generated by GLPK.
+
+        INPUT:
+
+            - ``solution_file_name``-- name of the file containing a solution
+
+        OUTPUT: The processed ``results`` and ``objective_value``.
+        """
+        assert isinstance(solution_file_name, Path)
+
+        with open(solution_file_name, "r") as f:
+            file_content = f.read().split("\n")
+
+        if any(["INFEASIBLE" in line for line in file_content[-10:]]):
+            raise ValueError("There is no solution found!")
+
+        L, R = file_content[5].index("= ")+2, file_content[5].index("(")
+        objective_value = _float_or_int(file_content[5][L:R])
+
+        ind_start, ind_end = None, None
+        bs, be = False, False
+
+        # Cut off unnecessary lines
+        for i_line, line in enumerate(file_content):
+            if "No. Column name" in line:
+                ind_start = i_line
+                bs = True
+            if "Integer feasibility conditions" in line:
+                ind_end = i_line
+                be = True
+            if bs and be:
+                break
+        file_content = file_content[ind_start+2:ind_end]
+
+        file_content = [
+            line.replace(" ", "").replace("*", "")[:-2]
+            for line in file_content
+        ][:-1]
+        file_content = [
+            line[re.search(r'[A-Za-z]', line).start():]
+            for line in file_content
+        ]
+        file_content = [line.replace(" ", "") for line in file_content]
+
+        results = {}
+        for line in file_content:
+            i = line.index("]")
+            name = line[:i+1]
+            value = line[i+1:i+2]
+            results[name] = value
+        return _to_dict(results), objective_value
+
+
+class CRYPTOMINISAT_CVL(SAT_SOLVER_CVL):
+    def __init__(self):
+        super().__init__()
+        self.name = "CryptoMiniSat"
+
+    def invoke(self, input_file_name, output_file_name,
+              log_file_name=None, time_limit=None):
+        r"""Invoke CryptoMiniSat solver via shell."""
+        super().invoke(
+            input_file_name, output_file_name, log_file_name, time_limit
+        )
+        command = [
+            "cryptominisat5",
+            "--presimp", "1",
+            "--dumpresult", output_file_name,
+            input_file_name
+        ]
+        if time_limit is not None:
+            command.insert(1, "--maxtime")
+            command.insert(2, str(time_limit))
+
+        if log_file_name is not None:
+            self.redirect_stdout = open(log_file_name, 'a')
+
+        with suppress_output():
+            process = subprocess.Popen(
+                command, stdout=self.redirect_stdout,
+                stderr=self.redirect_stdout
+            )
+            errno = process.wait()
+
+        if log_file_name is not None:
+            self.redirect_stdout.close()
+
+        if errno != 0:
+            # 10: SAT, 20: UNSAT
+            if errno in [10, 20]:
+                pass
+            elif errno == 15:
+                self.status = SOLVING_STATUS.TIMEOUT
+            else:
+                self.status = SOLVING_STATUS.ERROR
+
+        return
+
+    def process_solution_file(self, solution_file_name):
+        """
+        Parse '.sat' files and recover the variable assignments as well as the
+        objective value.
+
+        INPUT:
+
+            - ``solution_file_name``-- name of the file containing a solution
+
+        OUTPUT: The processed ``results`` and ``objective_value``.
+
+        .. NOTE::
+
+            CiVerLy augments the standard file format convention for SAT output
+            files. Typically the first line holds the string 'SAT' or 'UNSAT',
+            while the variable assignments are given in the second line, in form of
+            the **sign** of the corresponding integer. Additionally, CiVerLy
+            writes the objective value into the second line, as an integer, which
+            is non-standard.
+        """
+        assert isinstance(solution_file_name, Path)
+
+        with open(solution_file_name, "r") as f:
+            file_content = f.read().split("\n")
+
+        if "UNSAT" in file_content[0]:
+            raise AssertionError("The model is UNSAT")
+
+        def __get_val(var):
+            if int(var) < 0:
+                return 0
+            elif int(var) > 0:
+                return 1
+            else:
+                raise AssertionError("Encountered 0 while parsing .sat")
+
+        results = file_content[1].split(" ")[:-1]
+        results = {abs(int(var)): __get_val(var) for var in results}
+        objective_value = _float_or_int(file_content[2])
+
+        return results, objective_value
+
+
+class CADICAL_CVL(SAT_SOLVER_CVL):
+    def __init__(self):
+        super().__init__()
+        self.name = "CaDiCal"
+
+    def invoke(self, input_file_name, output_file_name,
+              log_file_name=None, time_limit=None):
+        r"""Invoke CaDiCal solver via shell."""
+        super().invoke(
+            input_file_name, output_file_name, log_file_name, time_limit
+        )
+        command = [
+            "cadical",
+            str(input_file_name),
+            "-P1", # preprocess for 1 round
+            "--sat",
+            "-w", str(output_file_name)
+        ]
+        if time_limit is not None:
+            command.insert(2, "-t")
+            command.insert(3, str(time_limit))
+
+        if log_file_name is not None:
+            self.redirect_stdout = open(log_file_name, 'a')
+
+        with suppress_output():
+            process = subprocess.Popen(
+                command, stdout=self.redirect_stdout,
+                stderr=self.redirect_stdout
+            )
+            errno = process.wait()
+
+        if log_file_name is not None:
+            self.redirect_stdout.close()
+
+        if errno != 0:
+            # 10: SAT, 20: UNSAT
+            if errno in [10, 20]:
+                pass
+            else:
+                self.status = SOLVING_STATUS.ERROR
+
+        # if there was no error but there is no solution, we conclude that
+        # there was a time out
+        if self.status == SOLVING_STATUS.SUCCESS:
+            with open(output_file_name, 'r') as file:
+                line = file.readline().strip("\n")
+            if line == "c UNKNOWN":
+                self.status = SOLVING_STATUS.TIMEOUT
+
+        return
+
+    def process_solution_file(self, solution_file_name):
+        """
+        Parse a solution generated by CaDiCal.
+
+        INPUT:
+
+            - ``solution_file_name``-- name of the file containing a solution
+
+        OUTPUT: The processed ``results`` and ``objective_value``.
+        """
+        assert isinstance(solution_file_name, Path)
+
+        with open(solution_file_name, "r") as f:
+            file_content = f.read().split("\n")
+
+        if "UNSATISFIABLE" in file_content[0]:
+            raise AssertionError("The model is UNSAT")
+
+        file_content = [
+            line[2:] if len(line) > 0 and line[0] in ["v", "s"] else line
+            for line in file_content
+        ]
+        joined = ' '.join(file_content[1:-2])
+        file_content = [file_content[0], joined, file_content[-2]]
+
+        def __get_val(var):
+            if int(var) < 0:
+                return 0
+            elif int(var) > 0:
+                return 1
+            else:
+                raise AssertionError("Encountered 0 while parsing .sat")
+
+        results = file_content[1].split(" ")[:-1]
+        results = {abs(int(var)): __get_val(var) for var in results}
+        objective_value = _float_or_int(file_content[2])
+
+        return results, objective_value
+
+
+class ESPRESSO_CVL(LOGIC_MINIMIZER_CVL):
+    def __init__(self):
+        super().__init__()
+        self.name = "Espresso"
+
+    def invoke(self, input_file_name, output_file_name,
+               log_file_name=None, time_limit=None):
+        r"""Invoke Espresso logic minimizer via shell."""
+        super().invoke(
+            input_file_name, output_file_name,
+            log_file_name=None, time_limit=None
+        )
+        command = [
+            "espresso",
+            "-epos",
+            str(input_file_name)
+        ]
+
+        self.redirect_stdout = open(output_file_name, 'a')
+
+        # with suppress_output():
+        if True:
+            process = subprocess.Popen(
+                command, stdout=self.redirect_stdout,
+                stderr=self.redirect_stdout
+            )
+            errno = process.wait()
+
+        self.redirect_stdout.close()
+
+        # failure: errno 1
+        if errno != 0:
+            self.status = SOLVING_STATUS.ERROR
+
+        return
+
+
+class NO_MILP_SOLVER_CVL(MILP_SOLVER_CVL):
+    def solve(self, input_file_name, output_file_name, time_limit=None):
+        raise NoSolverWarning()
+
+    def process_solution_file(self, solution_file_name):
+        """
+        Internal helper method to process the solution file.
+
+        INPUT:
+
+            - ``solution_file_name``-- name of the file containing a solution
+            - ``solver`` -- the used solver, see
+            :class:`civerly.model_options.SOLVER`
+
+        OUTPUT: The processed ``results`` and ``objective_value``.
+        """
+        assert isinstance(solution_file_name, Path)
+
+        with open(solution_file_name, "r") as f:
+            file_content = f.read().split("\n")
+
+        # try to guess the solver
+        if "# Objective value" in file_content[0]:
+            return GUROBI_CVL().process_solution_file(solution_file_name)
+        elif "Problem:" in file_content[0] and "Rows:" in file_content[1]:
+            return GLPK_CVL().process_solution_file(solution_file_name)
+        elif "solution status" in file_content[0]:
+            return SCIP_CVL().process_solution_file(solution_file_name)
+        else:
+            raise ValueError("Unknown solution format")
+
+
+class NO_SAT_SOLVER_CVL(SAT_SOLVER_CVL):
+    def solve(self, input_file_name, output_file_name, model_options,
+              time_limit=None):
+        """
+        If no solver is selected, generate all cnf's in solve_range
+        and let user solve them externally.
+        """
+        assert isinstance(input_file_name, Path)
+        assert isinstance(output_file_name, Path)
+
+        # shorten variable name
+        pr = model_options.sat_precision
+
+        def __get_sum_arr():
+            r"""
+            Implicit helper function to read and extract the sum_arr from the
+            corresponding json file.
+            """
+            sum_arr_file = input_file_name.parent / f"{input_file_name.stem}sum.json"
+            with open(sum_arr_file, 'r') as f:
+                file_content = json.load(f)
+
+                # Scale all weights by 10**sat_precision
+                # (and normalize again later)
+                sum_arr = [
+                    (weight, var)
+                    for weight, var in file_content
+                ]
+            return sum_arr
+
+        # scale W_MIN, W_MAX too
+        W_MIN = int(model_options.solve_range[0] * 10**pr)
+        W_MAX = int(model_options.solve_range[1] * 10**pr)
+
+        for w in range(W_MIN, W_MAX):
+            sat = DIMACS()
+            sat.read(str(input_file_name))
+
+            sat_constraining_prob = _generate_constraints_sum_leq_int_LS24(
+                sat,
+                __get_sum_arr(),
+                w
+            )
+
+            # temporary files with encoded weight w
+            name = f"{input_file_name.stem}_obj{w/10**pr}"
+            tmp_cnf_file_name = input_file_name.parent / f"{name}.cnf"
+            sat_constraining_prob.write(tmp_cnf_file_name)
+        return
+
+    def process_solution_file(self, solution_file_name):
+        """
+        Internal helper method to process the solution file.
+
+        INPUT:
+
+            - ``solution_file_name``-- name of the file containing a solution
+            - ``solver`` -- the used solver, see
+            :class:`civerly.model_options.SOLVER`
+
+        OUTPUT: The processed ``results`` and ``objective_value``.
+        """
+        assert isinstance(solution_file_name, Path)
+
+        with open(solution_file_name, "r") as f:
+            file_content = f.read().split("\n")
+
+        # try to guess the solver
+        if "SATISFIABLE" in file_content[0]:  # also catches UNSATISFIABLE
+            return CADICAL_CVL().process_solution_file(solution_file_name)
+        elif "SAT" in file_content[0]:  # also catches UNSAT
+            return CRYPTOMINISAT_CVL().process_solution_file(solution_file_name)
+        else:
+            raise ValueError("Unknown solution format")
+
+
+class NO_LOGIC_MINIMIZER_CVL(LOGIC_MINIMIZER_CVL):
+    def __init__(self):
+        super().__init__()
+
+    def solve(self, input_file_name, output_file_name):
+        raise NoSolverWarning()
 
 
 class SOLVING_STATUS(Enum):
@@ -26,687 +1009,47 @@ class SOLVING_STATUS(Enum):
     ERROR = 3
 
 
-def solve(input_file_name, output_file_name, solver, time_limit=None,
-          log_file_name=None):
-    """
-    Solve the given MILP or SAT instance externally.
-
-    INPUT:
-
-        - ``input_file_name``-- path to the file containing the MILP or SAT
-
-        - ``output_file_name``-- path of the file the solution is written to
-
-        - ``solver`` -- see :class:`civerly.model_options.SOLVER`
-
-        - ``time_limit``-- integer (default ``None``); time limit in seconds
-
-        - ``log_file_name``-- path to the solver's log file. Default based on
-          ``output_file_name`` and ``solver``.
-
-    OUTPUT:
-
-        - Status, see :class:`civerly.solvers.SOLVING_STATUS`. Further, upon
-          successful execution either a ``.sol`` or a ``.sat`` file is created,
-          depending on ``solver``. The file will contain the solution, if one
-          is found.
-
-    .. NOTE::
-
-        This method is implemented for convenience in case a solver is
-        installed on the same machine as CiVerLy.
-    """
-    assert isinstance(input_file_name, Path)
-    assert isinstance(output_file_name, Path)
-    assert isinstance(solver, SOLVER)
-
-    # overwritten for solvers not supporting log files
-    redirect_stdout = None
-
-    # default return value
-    status = SOLVING_STATUS.SUCCESS
-
-    # default log file
-    if log_file_name is None:
-        parent_dir = output_file_name.parent
-        name = f"{output_file_name.stem}_{solver.name}"
-        suffix = ".log"
-        log_file_name = parent_dir / (name + suffix)
-    else:
-        assert isinstance(log_file_name, Path)
-
-    # you can disable a solver by setting an environment variable
-    # with this we simulate that a solver is not installed albeit it is
-    # i.e. this is used for testing only
-    ENV_DISABLE_PREFIX = "CIVERLY_DISABLE_"
-    if ENV_DISABLE_PREFIX+solver.name in os.environ:
-        raise ValueError(
-            f"{solver.name} was disabled by setting environment variable "
-            f"{ENV_DISABLE_PREFIX+solver.name}"
-        )
-    # ------------------------------------------------------
-    if solver == SOLVER.GUROBI:
-        command = [
-            "gurobi_cl",
-            f"ResultFile={output_file_name}",
-            f"LogFile={log_file_name}",
-            str(input_file_name)
-        ]
-        if time_limit is not None:
-            command.insert(2, f"TimeLimit={time_limit}")
-    # ------------------------------------------------------
-    elif solver == SOLVER.GLPK:
-        command = [
-            "glpsol",
-            str(input_file_name),
-            "--log", str(log_file_name),
-            "-o", str(output_file_name)
-        ]
-        if time_limit is not None:
-            command.insert(2, "--tmlim")
-            command.insert(3, str(time_limit))
-    # ------------------------------------------------------
-    elif solver == SOLVER.SCIP:
-        if time_limit is not None:
-            with open('scip_settings.set', 'w') as f:
-                f.write(f"write/printzeros = TRUE\nlimits/time = {time_limit}")
-        else:
-            with open('scip_settings.set', 'w') as f:
-                f.write('write/printzeros = TRUE')
-        command = [
-            "scip",
-            "-c",
-            (
-                f"read {input_file_name} "
-                "optimize write solution "
-                f"{output_file_name} "
-                "quit"
-            ),
-            "-s", "scip_settings.set",
-            "-l", str(log_file_name)
-        ]
-    # ------------------------------------------------------
-    elif solver == SOLVER.CRYPTOMINISAT:
-        command = [
-            "cryptominisat5",
-            "--presimp", "1",
-            "--dumpresult", output_file_name,
-            input_file_name
-        ]
-        if time_limit is not None:
-            command.insert(1, "--maxtime")
-            command.insert(2, str(time_limit))
-        redirect_stdout = open(log_file_name, 'a')
-    # ------------------------------------------------------
-    elif solver == SOLVER.CADICAL:
-        command = [
-            "cadical",
-            str(input_file_name),
-            "--flush",  # --flush to flush redundant clauses
-            "--sat",
-            "-w", str(output_file_name)
-        ]
-        if time_limit is not None:
-            command.insert(2, "-t")
-            command.insert(3, str(time_limit))
-        redirect_stdout = open(log_file_name, 'a')
-    # ------------------------------------------------------
-    else:
-        raise InvalidModelOptionException(solver, SOLVER)
-
-    with suppress_output():
-        process = subprocess.Popen(command, stdout=redirect_stdout,
-                                   stderr=redirect_stdout)
-        errno = process.wait()
-
-    if redirect_stdout is not None:
-        redirect_stdout.close()
-
-    if (errno != 0):
-        if solver == SOLVER.CRYPTOMINISAT:
-            # 10: SAT, 20: UNSAT
-            if errno in [10, 20]:
-                pass
-            elif errno == 15:
-                status = SOLVING_STATUS.TIMEOUT
-            else:
-                status = SOLVING_STATUS.ERROR
-        elif solver == SOLVER.CADICAL:
-            # 10: SAT, 20: UNSAT
-            if errno in [10, 20]:
-                pass
-            else:
-                status = SOLVING_STATUS.ERROR
-        else:
-            status = SOLVING_STATUS.ERROR
-
-    if time_limit is not None:
-        # check if the solver reported a time out by checking the log file for
-        # an according string
-        if solver == SOLVER.GUROBI:
-            regexp = r"Time limit reached"
-        elif solver == SOLVER.GLPK:
-            regexp = r"TIME LIMIT EXCEEDED"
-        elif solver == SOLVER.SCIP:
-            regexp = r"time limit reached"
-        # CRYPTOMINISAT: see errno above
-        # CADICAL: see below
-        else:
-            regexp = r"(?!)"  # never matches
-
-        with open(log_file_name, 'r') as file:
-            content = file.read()
-        if re.search(regexp, content, re.MULTILINE):
-            status = SOLVING_STATUS.TIMEOUT
-
-    if solver == SOLVER.CADICAL:
-        # if there was no error but there is no solution, we conclude that
-        # there was a time out
-        if status == SOLVING_STATUS.SUCCESS:
-            with open(output_file_name, 'r') as file:
-                line = file.readline().strip("\n")
-            if line == "c UNKNOWN":
-                status = SOLVING_STATUS.TIMEOUT
-
-    # clean up
-    if solver == SOLVER.SCIP:
-        Path("scip_settings.set").unlink(missing_ok=True)
-
-    # be silent on success
-    return status if status != SOLVING_STATUS.SUCCESS else None
-
-
-def optimize_sat(cnf_file_name, sat_file_name, model_options,
-                 time_limit=None, benchmark=False):
-    """
-    Repeatedly solve SAT to determine the lowest possible weight.
-
-    Given a SAT with its corresponding ``sum_arr``, this method applies a
-    binary search to determine the lowest weight ``w`` for which this SAT is
-    solvable and solves it.
-
-    INPUT:
-
-        - ``cnf_file_name``-- path to the file containing the SAT
-
-        - ``sat_file_name``-- path to the file the solution is written to
-
-        - ``model_options`` -- see
-          :class:`civerly.model_options.MODEL_OPTIONS`.
-          Used to retrieve the ``solver``, ``solve_range`` and
-          ``sat_precision``.
-
-        - ``time_limit``-- integer (default ``None``); time limit in seconds
-
-        - ``benchmark``-- (default ``False``); when set to ``True`` return
-          details about internal timing. This is used by
-          :meth:`civerly.benchmark.benchmark`.
-
-    OUTPUT:
-
-        - None, but upon successful execution a ``.sol`` file is created,
-          containing the solution (if found).
-
-    .. NOTE::
-
-        This method is implemented for convenience in case a solver is
-        installed on the same machine as CiVerLy.
-    """
-    assert isinstance(cnf_file_name, Path)
-    assert isinstance(sat_file_name, Path)
-
-    if time_limit is not None:
-        end_time = int(time.time()+time_limit)
-
-    # shorten variable name
-    pr = model_options.sat_precision
-
-    benchmarks = []
-
-    def __get_sum_arr():
-        r"""
-        Implicit helper function to read and extract the sum_arr from the
-        corresponding json file.
-        """
-        sum_arr_file = cnf_file_name.parent / f"{cnf_file_name.stem}sum.json"
-        with open(sum_arr_file, 'r') as f:
-            file_content = json.load(f)
-
-            # Scale all weights by 10**sat_precision
-            # (and normalize again later)
-            sum_arr = [
-                (weight, var)
-                for weight, var in file_content
-            ]
-        return sum_arr
-
-    # scale W_MIN, W_MAX too
-    W_MIN = int(model_options.solve_range[0] * 10**pr)
-    W_MAX = int(model_options.solve_range[1] * 10**pr)
-    # If no solver is selected, generate all cnf's in solve_range
-    # and let user solve them externally.
-    # ---------------------------------------------------------------
-    if model_options.solver is None:
-        for w in range(W_MIN, W_MAX):
-            sat = DIMACS()
-            sat.read(str(cnf_file_name))
-
-            sat_constraining_prob = _generate_constraints_sum_leq_int_LS24(
-                sat,
-                __get_sum_arr(),
-                w
-            )
-
-            # temporary files with encoded weight w
-            name = f"{cnf_file_name.stem}_obj{
-                w/10**pr
-            }"
-            tmp_cnf_file_name = cnf_file_name.parent / f"{name}.cnf"
-            tmp_sat_file_name = cnf_file_name.parent / f"{name}.sat"
-            sat_constraining_prob.write(tmp_cnf_file_name)
-        return
-    # ---------------------------------------------------------------
-
-    ALL_SAT, ALL_UNSAT = True, True
-    # ---------------------------------------------------------------
-    while W_MAX > W_MIN or ALL_UNSAT or ALL_SAT:
-        w = (W_MAX + W_MIN) // 2
-
-        # will be appended to benchmarks
-        row = {"bound": w}
-        row["W_MIN"] = W_MIN
-        row["W_MAX"] = W_MAX
-
-        sat = DIMACS()
-        sat.read(str(cnf_file_name))
-
-        print(
-            f"[{float(W_MIN/10**pr):{3+pr}.{pr}f} ,"
-            f"{float(W_MAX/10**pr):{3+pr}.{pr}f}] "
-            f"(trying w = {float(w/10**pr):{3+pr}.{pr}f}) :",  # noqa
-            end=" ",
-            flush=True
-        )
-        start = time.time()
-        sat_constraining_prob = _generate_constraints_sum_leq_int_LS24(
-            sat,
-            __get_sum_arr(),
-            int(w)  # cast to int as it is a float with .0 anyway
-        )
-        stop = time.time()
-        row["nvars"] = sat_constraining_prob.nvars()
-        row["nclauses"] = len(sat_constraining_prob.clauses())
-        row["t_model"] = stop - start
-
-        # temporary files with encoded weight w
-        name = f"{cnf_file_name.stem}_obj{w}"
-        tmp_cnf_file_name = cnf_file_name.parent / f"{name}.cnf"
-        tmp_sat_file_name = cnf_file_name.parent / f"{name}.sat"
-        sat_constraining_prob.write(tmp_cnf_file_name)
-        if time_limit is not None:
-            tmp_time_limit = end_time - int(time.time())
-            if tmp_time_limit < 0:
-                return SOLVING_STATUS.TIMEOUT, (W_MIN/10**pr, W_MAX/10**pr)
-        else:
-            tmp_time_limit = None
-
-        start = time.time()
-        status = solve(
-            tmp_cnf_file_name,
-            tmp_sat_file_name,
-            model_options.solver,
-            tmp_time_limit
-        )
-        stop = time.time()
-        row["t_solve"] = stop - start
-
-        if status is not None:
-            if benchmark:
-                row["result"] = status
-                benchmarks.append(row)
-                return benchmarks
-            else:
-                e = f"{tmp_sat_file_name} could not be solved."
-                raise AssertionError(e)
-
-        with open(tmp_sat_file_name, 'r') as f:
-            result = f.readlines()[0].strip("\n")
-
-        if result in ["UNSAT", "s UNSATISFIABLE"]:
-            row["result"] = "UNSAT"
-            benchmarks.append(row)
-            ALL_SAT = False
-            W_MIN, res = (w + 1), "UNSAT"
-            if W_MIN > W_MAX:
-                # happens if all models are UNSAT
-                print(res)
-                W_MIN = W_MAX
-                break
-        elif result in ["SAT", "s SATISFIABLE"]:
-            row["result"] = "SAT"
-            benchmarks.append(row)
-            ALL_UNSAT = False
-            W_MAX, res = w, "SAT"
-            if W_MAX == W_MIN:
-                # happens if all models are SAT
-                print(res)
-                break
-        else:
-            e = f"{tmp_sat_file_name} does not have the expected format."
-            e += f" Expected: SAT/UNSAT, got: {result}."
-            raise AssertionError(e)
-
-        print(res)
-
-    # ---------------------------------------------------------------
-
-    # put solution in correct file
-    name = f"{cnf_file_name.stem}_obj{W_MIN}"
-    tmp_cnf_file_name = cnf_file_name.parent / f"{name}.cnf"
-    tmp_sat_file_name = cnf_file_name.parent / f"{name}.sat"
-    shutil.copyfile(tmp_cnf_file_name, cnf_file_name)
-    shutil.copyfile(tmp_sat_file_name, sat_file_name)
-
-    # write optimization value into the sat file
-    with open(sat_file_name, 'a') as f:
-        f.write(str(float(W_MIN/10**pr))+"\n")
-
-    if benchmark:
-        return benchmarks
-
-    if pr == 0:
-        return int(W_MIN)
-    return float(W_MIN/10**pr)
-
-
-def run_espresso(esp_file_in, esp_file_out):
+class NoSolverWarning(Warning):
     r"""
-    Helper function to execute espresso.
-    """
-    os.popen(f"espresso -epos {esp_file_in} > {esp_file_out}").read()
-    return
-
-
-def _float_or_int(value):
-    """
-    Cast `value` to float or int if possible.
+    Warning which will be thrown whenever :meth:`analyse` is called with
+    `model_options.solver = None`.
 
     EXAMPLES::
 
-        sage: from civerly.solvers import _float_or_int
-        sage: _float_or_int(42.0)
-        42
-        sage: _float_or_int(42.5)
-        42.5
-        sage: _float_or_int("42.000")
-        42
-        sage: _float_or_int("42.001")
-        42.001
-        sage: _float_or_int("3.415037499300e+00")
-        3.4150374993
+        sage: from civerly.model_options import *
+        sage: from civerly.util import suppress_output
+        sage: from civerly.cipher_implementations.aes import AES_CVL
+        sage: aes = AES_CVL(6)
+        sage: model_options = MODEL_OPTIONS(
+        ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+        ....:   optimization=OPTIMIZATION.MILP,
+        ....:   granularity=GRANULARITY.WORDWISE,
+        ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
+        ....:   milp_solver=None,
+        ....:   sat_solver=None,
+        ....:   path=Path("./DOCTEST-ModelOptions/"))
+        sage: with suppress_output():
+        ....:   aes.analyse(model_options)
+        Traceback (most recent call last):
+        ...
+        NoSolverWarning: No solver has been selected.
+        CiVerLy will return without solving.
+
+        sage: import shutil
+        sage: shutil.rmtree("DOCTEST-ModelOptions")
+
+
     """
-    value = float(value)
-    if value.is_integer() or abs(value - int(round(value))) < 1e-8:
-        value = int(round(value))
-    else:
-        value = round(value, 10)
-    return value
+    def __init__(self):
+        super().__init__(
+            "No solver has been selected. "
+            "CiVerLy will return without solving."
+        )
 
 
-def get_objective_bounds(log_file_name, solver):
-    """
-    Extract the bounds on the objective value from the log of an MILP solver.
-
-    This function shall be used when the MILP solver exceeds the given timeout.
-
-    INPUT:
-
-        - ``log_file_name``-- name of the log file
-        - ``solver`` -- the used solver, see
-          :class:`civerly.model_options.SOLVER`
-    """
-    assert isinstance(log_file_name, Path)
-
-    if solver == SOLVER.GUROBI:
-        regexp = r'Best objective (\S+), best bound (\S+), gap'
-    elif solver == SOLVER.GLPK:
-        regexp = r'.*mip\s*=\s*(\S+)\s*>=\s*(\S+).*'
-    elif solver == SOLVER.SCIP:
-        regexp = r'Primal Bound\s*:\s*(\S+).*\nDual Bound\s*:\s*(\S+).*'
-    else:
-        raise InvalidModelOptionException(solver, SOLVER)
-
-    with open(log_file_name, 'r') as file:
-        content = file.read()
-
-    hit = re.search(regexp, content, re.MULTILINE)
-    if hit:
-        upper_bound = _float_or_int(hit.group(1))
-        lower_bound = _float_or_int(hit.group(2))
-        return lower_bound, upper_bound
-
-    warnings.warn(f"No objective bounds found in {log_file_name}")
-    return None, None
-
-
-def get_objective_value(sol_file_name, solver):
-    """
-    Extract the objective value from the specified solution file.
-
-    INPUT:
-
-        - ``sol_file_name``-- name of the file containing a solution
-        - ``solver`` -- the used solver, see
-          :class:`civerly.model_options.SOLVER`
-    """
-    assert isinstance(sol_file_name, Path)
-    _, objective_value = _process_solution_file(sol_file_name, solver)
-    return objective_value
-
-
-def _process_solution_file(solution_file_name, solver):
-    """
-    Internal helper method to process the solution file.
-
-    INPUT:
-
-        - ``solution_file_name``-- name of the file containing a solution
-        - ``solver`` -- the used solver, see
-          :class:`civerly.model_options.SOLVER`
-
-    OUTPUT: The processed ``results`` and ``objective_value``.
-    """
-    assert isinstance(solution_file_name, Path)
-
-    with open(solution_file_name, "r") as f:
-        file_content = f.read().split("\n")
-
-    # try to guess the solver
-    if solver is None:
-        if "# Objective value" in file_content[0]:
-            solver = SOLVER.GUROBI
-        elif "Problem:" in file_content[0] and "Rows:" in file_content[1]:
-            solver = SOLVER.GLPK
-        elif "solution status" in file_content[0]:
-            solver = SOLVER.SCIP
-        elif "SATISFIABLE" in file_content[0]:  # also catches UNSATISFIABLE
-            solver = SOLVER.CADICAL
-        elif "SAT" in file_content[0]:  # also catches UNSAT
-            solver = SOLVER.CRYPTOMINISAT
-        else:
-            raise ValueError("Unknown solution format")
-
-    if solver == SOLVER.GUROBI:
-        return __parse_gurobi(file_content)
-    elif solver == SOLVER.GLPK:
-        return __parse_glpk(file_content)
-    elif solver == SOLVER.SCIP:
-        return __parse_scip(file_content)
-    elif solver == SOLVER.CRYPTOMINISAT:
-        return __parse_cryptominisat(file_content)
-    elif solver == SOLVER.CADICAL:
-        return __parse_cadical(file_content)
-    else:
-        raise InvalidModelOptionException(solver, SOLVER)
-
-
-def __parse_cryptominisat(file_content):
-    r"""
-    Parse '.sat' files and recovers the variable assignments as well as the
-    objective value.
-
-    .. NOTE::
-
-        CiVerLy augments the standard file format convention for SAT output
-        files. Typically the first line holds the string 'SAT' or 'UNSAT',
-        while the variable assignments are given in the second line, in form of
-        the **sign** of the corresponding integer. Additionally, CiVerLy
-        writes the objective value into the second line, as an integer, which
-        is non-standard.
-    """
-    assert "UNSAT" not in file_content[0], "The model is UNSAT"
-
-    def __get_val(var):
-        if int(var) < 0:
-            return 0
-        elif int(var) > 0:
-            return 1
-        else:
-            raise AssertionError("Encountered 0 while parsing .sat")
-
-    results = file_content[1].split(" ")[:-1]
-    results = {abs(int(var)): __get_val(var) for var in results}
-    objective_value = _float_or_int(file_content[2])
-
-    return results, objective_value
-
-
-def __parse_cadical(file_content):
-    """Parse a solution generated by CaDiCal."""
-    assert "UNSATISFIABLE" not in file_content[0], "The model is UNSAT"
-
-    file_content = [
-        line[2:] if len(line) > 0 and line[0] in ["v", "s"] else line
-        for line in file_content
-    ]
-    joined = ' '.join(file_content[1:-2])
-    file_content = [file_content[0], joined, file_content[-2]]
-    return __parse_cryptominisat(file_content)
-
-
-def __parse_gurobi(file_content):
-    """Parse a solution generated by Gurobi."""
-    def __string_to_int_gurobi(str):
-        """
-        Remove rounding errors.
-
-        Solution values can deviate up to 1e-5 from integer solutions, see
-        https://support.gurobi.com/hc/en-us/articles/360012237872-Why-does-Gurobi-sometimes-return-non-integral-values-for-integer-variables
-        """
-        try:
-            return int(str)
-        except ValueError:
-            value_float = float(str)
-            value_int = int(round(value_float))
-            if abs(value_float - value_int) < 1e-5:
-                return value_int
-            raise ValueError(f"Deviation from integer to high: {str}")
-    assert file_content != [''], "The model is UNSAT"
-
-    objective_value = file_content[0][file_content[0].index('=')+2:]
-    objective_value = _float_or_int(objective_value)
-    results = {}
-    for line in file_content[1:-1]:
-        name = line[:line.index(" ")]
-        value = __string_to_int_gurobi(line[line.index(" ")+1:])
-        results[name] = value
-    return results, objective_value
-
-
-def __parse_scip(file_content):
-    """Parse a solution generated by SCIP."""
-    if not all(["infeasible" not in line for line in file_content[:10]]):
-        raise ValueError("There is no solution found!")
-    results = {}
-    objective_value = file_content[1].strip(" ")
-    objective_value = objective_value[objective_value.index(":")+1:]
-    objective_value = _float_or_int(objective_value)
-    for line in file_content[2:-1]:
-        line = line[:line.index("(")].replace(" ", "")
-        value = int(round(float(line[line.index("]")+1:])))
-        name = line[:line.index("]")+1]
-        results[name] = value
-
-    return results, objective_value
-
-
-def __parse_glpk(file_content):
-    """Parse a solution generated by GLPK."""
-    if any(["INFEASIBLE" in line for line in file_content[-10:]]):
-        raise ValueError("There is no solution found!")
-
-    L, R = file_content[5].index("= ")+2, file_content[5].index("(")
-    objective_value = _float_or_int(file_content[5][L:R])
-
-    ind_start, ind_end = None, None
-    bs, be = False, False
-
-    # Cut off unnecessary lines
-    for i_line, line in enumerate(file_content):
-        if "No. Column name" in line:
-            ind_start = i_line
-            bs = True
-        if "Integer feasibility conditions" in line:
-            ind_end = i_line
-            be = True
-        if bs and be:
-            break
-    file_content = file_content[ind_start+2:ind_end]
-
-    file_content = [
-        line.replace(" ", "").replace("*", "")[:-2]
-        for line in file_content
-    ][:-1]
-    file_content = [
-        line[re.search(r'[A-Za-z]', line).start():]
-        for line in file_content
-    ]
-    file_content = [line.replace(" ", "") for line in file_content]
-
-    results = {}
-    for line in file_content:
-        i = line.index("]")
-        name = line[:i+1]
-        value = line[i+1:i+2]
-        results[name] = value
-    return results, objective_value
-
-
-def __parse_other_solver(file_content):
-    r"""
-    Parse a solution generated by another solver.
-
-    .. NOTE::
-
-       For future development
-
-    It is possible to extend the functionality of CiVerLy by supporting
-    additional solvers. For this, a seperate parse function is necessary, which
-    handles the ``.sol`` file.
-
-    This parser function is required to take the following input:
-
-    INPUT:
-
-    - ``file_content`` -- A list of strings, which is the result of
-      ``f.read().split("\n")`` of the given solution file.
-
-    OUTPUT:
-
-    - ``results`` -- A dictionary of the form { <variable> : <value>, ...}
-      which contains the solution values.
-
-    - ``objective_value`` -- integer; Contains the achieved objective value.
-    """
-    e = "This method is a placeholder for future extensions of CiVerLy!"
-    raise NotImplementedError(e)
+class SolverException(Exception):
+    def __init__(self, e):
+        if e == SOLVING_STATUS.TIMEOUT:
+            super().__init__("Solver / Minimizer timed out.")
+        elif e == SOLVING_STATUS.ERROR:
+            super().__init__("Solver / Minimizer raised an external error.")

--- a/src/civerly/util.py
+++ b/src/civerly/util.py
@@ -311,6 +311,32 @@ def _before_brackets(st):
     return int(st[1: st.index('[')], 10)
 
 
+def _float_or_int(value):
+    """
+    Cast `value` to float or int if possible.
+
+    EXAMPLES::
+
+        sage: from civerly.solvers import _float_or_int
+        sage: _float_or_int(42.0)
+        42
+        sage: _float_or_int(42.5)
+        42.5
+        sage: _float_or_int("42.000")
+        42
+        sage: _float_or_int("42.001")
+        42.001
+        sage: _float_or_int("3.415037499300e+00")
+        3.4150374993
+    """
+    value = float(value)
+    if value.is_integer() or abs(value - int(round(value))) < 1e-8:
+        value = int(round(value))
+    else:
+        value = round(value, 10)
+    return value
+
+
 def _generate_constraints_sum_leq_int_LS24(sat, sum_arr, num):
     r"""
     Helper method to implement a sequential counter in SAT, in order to model
@@ -344,10 +370,10 @@ def _generate_constraints_sum_leq_int_LS24(sat, sum_arr, num):
         ....:           sat, [(1, cl) for cl in range(1, NUM_CLAUSES+1)], bound
         ....:       )
         ....:       _ = new_sat.write(path / 'constraints.cnf')
-        ....:       solve(
+        ....:       CRYPTOMINISAT_CVL().invoke(
         ....:           path / 'constraints.cnf',
         ....:           path / 'constraints.sat',
-        ....:           SOLVER.CRYPTOMINISAT)
+        ....:       )
         ....:       with open(path /'constraints.sat') as f:
         ....:           status = f.readlines()[0].strip('\n')
         ....:           f.close()
@@ -508,7 +534,7 @@ def reduction_algorithm_ST17(comp, posset, model_options, PROB=None):
     MILP-constraints as a MILP itself. Intended to be used internally.
     """
     from civerly.component import SBox_CVL, LinearLayer_CVL
-    from civerly.solvers import solve, _process_solution_file
+    from civerly.solvers import NO_MILP_SOLVER_CVL
 
     assert isinstance(comp, (SBox_CVL, LinearLayer_CVL))
 
@@ -580,14 +606,13 @@ def reduction_algorithm_ST17(comp, posset, model_options, PROB=None):
         with suppress_output():
             milp_to_minimize_milp.write_mps(str(file_mps))
 
-        if model_options.solver:
-            solve(
+        if not isinstance(model_options.milp_solver, NO_MILP_SOLVER_CVL):
+            model_options.milp_solver.solve(
                 input_file_name=file_mps,
                 output_file_name=file_sol,
-                solver=model_options.solver
             )
         else:
-            # if there is no solver in model_options, the user has to solve
+            # if there is no milp_solver set in model_options, the user has to solve
             # the MILP manually
             if isinstance(comp, SBox_CVL):
                 comp_in_print = "SBox"
@@ -601,15 +626,13 @@ def reduction_algorithm_ST17(comp, posset, model_options, PROB=None):
             comp._return_immediately_ = True
             return
     final_choices = []  # solution of reduction algorithm
-    results, _ = _process_solution_file(file_sol, None)
+    results, _ = model_options.milp_solver.process_solution_file(file_sol)
 
     # STEP 3:
     # use the found solution to generate a minimial MILP that models the
     # component
-    for res in results.items():
-        Z_index = _between_brackets(res[0])
-
-        if res[1] != 0:
+    for Z_index, use in results['Z'].items():
+        if use != 0:
             final_choices.append(Z_index)
 
     for ic, ineq in enumerate(convex_constraints):
@@ -649,6 +672,20 @@ def reduction_algorithm_ST17(comp, posset, model_options, PROB=None):
         elif ineq.is_equation():
             comp.milp.add_constraint(sum(tmp_arr) + ineq.b() == 0)
     return
+
+
+def _to_dict(flat_results):
+    r"""
+    Convert a flat results dict ``{'Z[0]': 1, 'Z[1]': 2}`` to a nested one
+    ``{'Z': {0: 1, 1: 2}}``, grouping by variable name and using the
+    bracket index as an integer key.
+    """
+    nested = {}
+    for variable, value in flat_results.items():
+        var_name, rest = variable.split("[", 1)
+        var_index = int(rest.rstrip("]"))
+        nested.setdefault(var_name, {})[var_index] = value
+    return nested
 
 
 @contextlib.contextmanager

--- a/src/civerly/util.py
+++ b/src/civerly/util.py
@@ -631,8 +631,10 @@ def reduction_algorithm_ST17(comp, posset, model_options, PROB=None):
     # STEP 3:
     # use the found solution to generate a minimial MILP that models the
     # component
-    for Z_index, use in results['Z'].items():
-        if use != 0:
+    for res in results.items():
+        Z_index = _between_brackets(res[0])
+
+        if res[1] != 0:
             final_choices.append(Z_index)
 
     for ic, ineq in enumerate(convex_constraints):
@@ -672,20 +674,6 @@ def reduction_algorithm_ST17(comp, posset, model_options, PROB=None):
         elif ineq.is_equation():
             comp.milp.add_constraint(sum(tmp_arr) + ineq.b() == 0)
     return
-
-
-def _to_dict(flat_results):
-    r"""
-    Convert a flat results dict ``{'Z[0]': 1, 'Z[1]': 2}`` to a nested one
-    ``{'Z': {0: 1, 1: 2}}``, grouping by variable name and using the
-    bracket index as an integer key.
-    """
-    nested = {}
-    for variable, value in flat_results.items():
-        var_name, rest = variable.split("[", 1)
-        var_index = int(rest.rstrip("]"))
-        nested.setdefault(var_name, {})[var_index] = value
-    return nested
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Changes:

Solvers and Minimizers are contained in subclasses of MILPSolver, SATSolver or Minimizer, implementing their own solve / process-solution-file / ... methods. 
- Remove `SOLVER` enum class and replace with respective solver class: `SOLVER.GUROBI` -> `GUROBI_CVL()`
- split up model options for solver: `solver` -> `sat_solver`, `milp_solver`
- change doctests accordingly

Todos:
- [ ] Rewrite the workings of `LOGICAL_COND_ESPRESSO` compared to `LOGICAL_COND`, as this is already specified by the `logic_minimizer` model option.
- [ ] Add cadical as minimizer option




_Important:_ This PR changes the way the `model_options` struct is initialised. Instead of the previous
```
sage: model_options = MODEL_OPTIONS(
....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
....:     optimization=OPTIMIZATION.MILP,
....:     granularity=GRANULARITY.BITWISE,
....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
....:     solver=SOLVER.GUROBI,
....:     path=Path("./DOCTEST-Toy9-Models/")
....: )
```
we now do
```
sage: model_options = MODEL_OPTIONS(
....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
....:     optimization=OPTIMIZATION.MILP,
....:     granularity=GRANULARITY.BITWISE,
....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
....:     milp_solver=GUROBI_CVL(),
....:     logic_minimizer=ESPRESSO_CVL(),
....:     path=Path("./DOCTEST-Toy9-Models/")
....: )
```