### PR TITLE
Improve `process_solution_file`

### DIFF
--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -1799,10 +1799,6 @@ class Cipher:
             else:
                 dictionaries = self.dictionaries_milp
 
-            def check_condition(comp_num, s):
-                return ("IN" not in s and "OUT" not in s) and \
-                    _before_brackets(s) == comp_num
-
         elif model_options.optimization == OPTIMIZATION.SAT:
             if not hasattr(self, 'dictionaries_sat'):
                 with open(model_options.path / (self.name + "_d.json")) as f:
@@ -1824,13 +1820,28 @@ class Cipher:
         # Recursively iterate through each subcipher
         for comp_num, comp in enumerate(self.nodes):
             if isinstance(comp, Cipher):
-                sub_results = {}
-                for s, solution_bit_value in results.items():
-                    if check_condition(comp_num, s):
-                        # Translate the results using the corresponding
-                        # dictionaries
-                        sub_results[dictionaries[comp_num][s]] = \
+                if model_options.optimization == OPTIMIZATION.MILP:
+                    # Build nested sub_results for the sub-cipher directly
+                    # from the parent's nested results entry for this comp_num
+                    sub_results = {}
+                    var_name = f"X{comp_num}"
+                    for s_ind, solution_bit_value in \
+                            results.get(var_name, {}).items():
+                        translated = dictionaries[comp_num][
+                            f"{var_name}[{s_ind}]"
+                        ]
+                        tr_name, tr_rest = translated.split('[', 1)
+                        tr_ind = int(tr_rest.rstrip(']'))
+                        sub_results.setdefault(tr_name, {})[tr_ind] = \
                             solution_bit_value
+                else:  # SAT
+                    sub_results = {}
+                    for s, solution_bit_value in results.items():
+                        if check_condition(comp_num, s):
+                            # Translate the results using the corresponding
+                            # dictionaries
+                            sub_results[dictionaries[comp_num][s]] = \
+                                solution_bit_value
 
                 new_node = current_node.children[depths[comp_num]]
 
@@ -1985,21 +1996,36 @@ class Cipher:
         ]
 
         # Sort the (messy and unordered) variable values correctly
-        for s, solution_bit_value in results.items():
-
-            # recover comp_num and comp
-            if model_options.optimization == OPTIMIZATION.MILP:
-                if "IN" in s or "OUT" in s:
-                    # if s is MILP_IN or MILP_OUT, we skip it
+        if model_options.optimization == OPTIMIZATION.MILP:
+            for var_name, var_dict in results.items():
+                if var_name in ("IN", "OUT"):
+                    # if var_name is MILP_IN or MILP_OUT, we skip it
                     continue
-                comp_num, s_ind = _before_brackets(s), _between_brackets(s)
+                comp_num = int(var_name[1:])
+                for s_ind, solution_bit_value in var_dict.items():
+                    translated_component = dictionaries[comp_num][
+                        f"{var_name}[{s_ind}]"
+                    ]
+                    # Draw the input nodes of each component
+                    bool1 = "IN" in translated_component
+                    # We also draw the output of the last component.
+                    bool2 = "OUT" in translated_component
 
-                translated_component = dictionaries[comp_num][f"X{comp_num}[{s_ind}]"]
-                # Draw the input nodes of each component
-                bool1 = "IN" in translated_component
-                # We also draw the output of the last component.
-                bool2 = "OUT" in translated_component
-            elif model_options.optimization == OPTIMIZATION.SAT:
+                    if bool1 and comp_num != 0:  # dont draw self.IN.in
+                        current_index = _between_brackets(translated_component)
+                        bit_ind = _from_grid(
+                            comp_num, current_index, input_side=True
+                        )
+                        bits_in[depths[comp_num]][bit_ind] = solution_bit_value
+                    elif bool2:
+                        current_index = _between_brackets(translated_component)
+                        bit_ind = _from_grid(
+                            comp_num, current_index, input_side=False
+                        )
+                        bits_out[depths[comp_num]][bit_ind] = solution_bit_value
+        elif model_options.optimization == OPTIMIZATION.SAT:
+            # NOTE: SAT-vars start at 1 while grid-indexing starts at 0
+            for s, solution_bit_value in results.items():
                 if s <= self.input_length + self.output_length:
                     # if s is SAT_IN or SAT_OUT, we skip it
                     continue
@@ -2026,34 +2052,24 @@ class Cipher:
                 # We also draw the output of the last component.
                 bool2 = comp.input_length < translated_component and \
                     translated_component <= comp.input_length + comp.output_length
-            else:
-                raise InvalidModelOptionException(
-                    model_options.optimization, OPTIMIZATION
-                )
 
-            # NOTE: For SAT we offset by -1 because SAT-vars start at 1
-            # while grid-indexing starts at 0
-            if bool1 and comp_num != 0:  # dont draw self.IN.in
-                if model_options.optimization == OPTIMIZATION.MILP:
-                    current_index = _between_brackets(translated_component)
-                elif model_options.optimization == OPTIMIZATION.SAT:
+                if bool1 and comp_num != 0:  # dont draw self.IN.in
                     current_index = translated_component - 1
-
-                bit_ind = _from_grid(
-                    comp_num, current_index, input_side=True
-                )
-                bits_in[depths[comp_num]][bit_ind] = solution_bit_value
-            elif bool2:
-                if model_options.optimization == OPTIMIZATION.MILP:
-                    current_index = _between_brackets(translated_component)
-                elif model_options.optimization == OPTIMIZATION.SAT:
+                    bit_ind = _from_grid(
+                        comp_num, current_index, input_side=True
+                    )
+                    bits_in[depths[comp_num]][bit_ind] = solution_bit_value
+                elif bool2:
                     current_index = translated_component - \
                         self.nodes[comp_num].input_length - 1
-
-                bit_ind = _from_grid(
-                    comp_num, current_index, input_side=False
-                )
-                bits_out[depths[comp_num]][bit_ind] = solution_bit_value
+                    bit_ind = _from_grid(
+                        comp_num, current_index, input_side=False
+                    )
+                    bits_out[depths[comp_num]][bit_ind] = solution_bit_value
+        else:
+            raise InvalidModelOptionException(
+                model_options.optimization, OPTIMIZATION
+            )
 
         # realign bits_in, bits_out by removing any 'None' entries
         bits_in = [

--- a/src/civerly/component.py
+++ b/src/civerly/component.py
@@ -2008,11 +2008,11 @@ class SBox_CVL(Component):
                 1
                 sage: in_diff  = vec_to_int(vector(
                 ....:   GF(2), 4,
-                ....:   [results[f"IN[{i}]"] for i in range(4)]
+                ....:   [results['IN'][i] for i in range(4)]
                 ....: ))
                 sage: out_diff = vec_to_int(vector(
                 ....:   GF(2), 4,
-                ....:   [results[f"OUT[{i}]"] for i in range(4)]
+                ....:   [results['OUT'][i] for i in range(4)]
                 ....: ))
                 sage: ddt = sb.difference_distribution_table()
                 sage: ddt[in_diff][out_diff]
@@ -2059,10 +2059,10 @@ class SBox_CVL(Component):
                 sage: objective_value
                 1
                 sage: in_diff  = vec_to_int(vector(
-                ....:   GF(2), 4, [results[f"IN[{i}]"] for i in range(4)]
+                ....:   GF(2), 4, [results['IN'][i] for i in range(4)]
                 ....: ))
                 sage: out_diff = vec_to_int(vector(
-                ....:   GF(2), 4, [results[f"OUT[{i}]"] for i in range(4)]
+                ....:   GF(2), 4, [results['OUT'][i] for i in range(4)]
                 ....: ))
                 sage: ddt = sb.difference_distribution_table()
                 sage: ddt[in_diff][out_diff]
@@ -2218,21 +2218,6 @@ class SBox_CVL(Component):
                 self._return_immediately_ = True
                 return
 
-            def _to_dict(res):
-                r"""
-                Instead of using a dictionary {'Z[0]': 1, 'Z[1]':2} use
-                {'Z':{0:1, 1:2}}, so we can easier iterate over
-                the Z[i]
-                """
-                my_res = dict()
-                for variable, value in res.items():
-                    var_name = variable.split("[")[0]
-                    var_index = variable.split("[")[1].split("]")[0]
-                    if var_name not in my_res:
-                        my_res[var_name] = dict()
-                    my_res[var_name][int(var_index)] = value
-                return my_res
-
             selected_inequations = {
                 prob: [] for prob in reduction_solution_files.keys()
             }
@@ -2243,7 +2228,6 @@ class SBox_CVL(Component):
                 )
 
                 results, _ = model_options.milp_solver.process_solution_file(s_file_sol)
-                results = _to_dict(results)
                 assert 'Z' in results and len(results) == 1, (
                     "ERROR: Unexpected variables in results. "
                     f"Found {results.keys()}, expected 'Z'"

--- a/src/civerly/solvers.py
+++ b/src/civerly/solvers.py
@@ -15,6 +15,7 @@ from enum import Enum
 from sage.sat.solvers.dimacs import DIMACS
 from civerly.util import _generate_constraints_sum_leq_int_LS24
 from civerly.util import suppress_output, _float_or_int
+from civerly.util import _to_dict
 
 
 class SOLVER_CVL:
@@ -431,7 +432,7 @@ class GUROBI_CVL(MILP_SOLVER_CVL):
             name = line[:line.index(" ")]
             value = __string_to_int_gurobi(line[line.index(" ")+1:])
             results[name] = value
-        return results, objective_value
+        return _to_dict(results), objective_value
 
 
 class SCIP_CVL(MILP_SOLVER_CVL):
@@ -460,8 +461,12 @@ class SCIP_CVL(MILP_SOLVER_CVL):
                 f"{output_file_name} "
                 "quit"
             ),
-            "-s", "scip_settings.set", "-l", str(log_file_name)
+            "-s", "scip_settings.set",
         ]
+        # only add -l flag when log_file_name is set
+        if log_file_name is not None:
+            command += ["-l", str(log_file_name)]
+
         with suppress_output():
             process = subprocess.Popen(command)
             errno = process.wait()
@@ -538,7 +543,7 @@ class SCIP_CVL(MILP_SOLVER_CVL):
             name = line[:line.index("]")+1]
             results[name] = value
 
-        return results, objective_value
+        return _to_dict(results), objective_value
 
 
 class GLPK_CVL(MILP_SOLVER_CVL):
@@ -554,9 +559,13 @@ class GLPK_CVL(MILP_SOLVER_CVL):
             input_file_name, output_file_name, log_file_name, time_limit
         )
         command = [
-            "glpsol", str(input_file_name), "--log", str(log_file_name),
+            "glpsol", str(input_file_name),
             "-o", str(output_file_name)
         ]
+        # only add --log flag when log_file_name is set
+        if log_file_name is not None:
+            command += ["--log", str(log_file_name)]
+
         if time_limit is not None:
             command.insert(2, "--tmlim")
             command.insert(3, str(time_limit))
@@ -656,7 +665,7 @@ class GLPK_CVL(MILP_SOLVER_CVL):
             name = line[:i+1]
             value = line[i+1:i+2]
             results[name] = value
-        return results, objective_value
+        return _to_dict(results), objective_value
 
 
 class CRYPTOMINISAT_CVL(SAT_SOLVER_CVL):

--- a/src/civerly/util.py
+++ b/src/civerly/util.py
@@ -631,10 +631,8 @@ def reduction_algorithm_ST17(comp, posset, model_options, PROB=None):
     # STEP 3:
     # use the found solution to generate a minimial MILP that models the
     # component
-    for res in results.items():
-        Z_index = _between_brackets(res[0])
-
-        if res[1] != 0:
+    for Z_index, use in results['Z'].items():
+        if use != 0:
             final_choices.append(Z_index)
 
     for ic, ineq in enumerate(convex_constraints):
@@ -674,6 +672,20 @@ def reduction_algorithm_ST17(comp, posset, model_options, PROB=None):
         elif ineq.is_equation():
             comp.milp.add_constraint(sum(tmp_arr) + ineq.b() == 0)
     return
+
+
+def _to_dict(flat_results):
+    r"""
+    Convert a flat results dict ``{'Z[0]': 1, 'Z[1]': 2}`` to a nested one
+    ``{'Z': {0: 1, 1: 2}}``, grouping by variable name and using the
+    bracket index as an integer key.
+    """
+    nested = {}
+    for variable, value in flat_results.items():
+        var_name, rest = variable.split("[", 1)
+        var_index = int(rest.rstrip("]"))
+        nested.setdefault(var_name, {})[var_index] = value
+    return nested
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Inside `solver.SOLVER_CVL.process_solution_file`, a dictionary like `{'Z[0]' : 1, 'Z[1]': 2}` is created and processed with tedious string manipulation. Now, the method `_to_dict` (see `component.SBox_CVL._to_dict`) is used to return a dictionary like `{'Z' : {0: 1, 1: 2}}`.

Next to the main point that `_to_dict` is now applied inside `process_solution_file`, there are a few minor changes (such as setting the log-file flag of solvers only when a log file is specified).