### PR TITLE
Trail representation

### DIFF
--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -1610,6 +1610,23 @@ class Cipher:
         else:
             return grid_out
 
+    def read_results(self, model_options):
+        r"""
+        """
+        if model_options.optimization == OPTIMIZATION.MILP:
+            solution_file_name = model_options.path / (self.name + ".sol")
+            return model_options.milp_solver.process_solution_file(
+                solution_file_name) #, "MILP"
+        elif model_options.optimization == OPTIMIZATION.SAT:
+            solution_file_name = model_options.path / (self.name + ".sat")
+            return model_options.sat_solver.process_solution_file(
+                solution_file_name) #, "SAT"
+        else:
+            raise InvalidModelOptionException(
+                model_options.optimization, OPTIMIZATION
+            )
+
+
     def generate_report(self, model_options):
         """
         Generates a ``.tex`` file that contains the state matrices of active
@@ -1626,21 +1643,7 @@ class Cipher:
         tex_file_name = model_options.path / (self.name + ".tex")
         pdf_file_name = model_options.path / (self.name + ".pdf")
 
-        if model_options.optimization == OPTIMIZATION.MILP:
-            milp_or_sat = "MILP"
-            solution_file_name = model_options.path / (self.name + ".sol")
-            results, objective_value = model_options.milp_solver.process_solution_file(
-                solution_file_name)
-        elif model_options.optimization == OPTIMIZATION.SAT:
-            milp_or_sat = "SAT"
-            solution_file_name = model_options.path / (self.name + ".sat")
-            results, objective_value = model_options.sat_solver.process_solution_file(
-                solution_file_name)
-        else:
-            raise InvalidModelOptionException(
-                model_options.optimization, OPTIMIZATION
-            )
-
+        results, objective_value = self.read_results(model_options)
 
         STRING = "\\documentclass{article}\n"
         STRING += "\\usepackage{amssymb}\n"
@@ -1671,6 +1674,10 @@ class Cipher:
 
         name = self.name.replace('_', '\\_')
         STRING += f"\\title{{{granularity} {cryptanalysis} trail through "
+        if model_options.optimization == OPTIMIZATION.MILP:
+            milp_or_sat = "MILP"
+        elif model_options.optimization == OPTIMIZATION.SAT:
+            milp_or_sat = "SAT"
         STRING += f"\\texttt{{{name}}} found by {milp_or_sat}}}\n\n"
         STRING += "\\author{\\texttt{CiVerLy}}\n"
         STRING += "\\begin{document}\n"

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -1659,77 +1659,98 @@ class Cipher:
 
         OUTPUT: None, but writes a PDF file.
         """
-
-        tex_file_name = model_options.path / (self.name + ".tex")
-        pdf_file_name = model_options.path / (self.name + ".pdf")
-
+        # 1. Get results
         results, objective_value = self.read_results(model_options)
 
-        STRING = "\\documentclass{article}\n"
+        # 2. Construct TrailNode tree
+        root_node = TrailNode(self, model_options, results)
+
+        # 3. Verify correctness
+        root_node.verify_correctness()
+
+        # 4. Generate LaTeX string
+        string  = self._latex_header(model_options, objective_value)
+        string += root_node.to_latex(model_options)
+        string += "\\end{document}\n"
+
+        # 5. Write to .tex file and compile to PDF
+        self._write_and_compile_tex(string, model_options)
+
+    def get_trail(self, model_options):
+        r"""
+        After solving a MILP or SAT, converts the solution values to a
+        trail-like output as a ``TrailNode`` tree. Similar to
+        ``self.generate_report``, but returns the tree instead of a PDF.
+        """
+        results, _ = self.read_results(model_options)
+        root_node = TrailNode(self, model_options, results)
+        root_node.verify_correctness()
+        return root_node
+
+    def _latex_header(self, model_options, objective_value) -> str:
+        r"""
+        Returns the LaTeX preamble and document header for a trail report.
+        """
+        cryptanalysis_map = {
+            CRYPTANALYSIS.DIFFERENTIAL: "differential",
+            CRYPTANALYSIS.LINEAR:       "linear",
+        }
+        granularity_map = {
+            GRANULARITY.WORDWISE: "Wordwise",
+            GRANULARITY.BITWISE:  "Bitwise",
+        }
+        opt_map = {
+            OPTIMIZATION.MILP: "MILP",
+            OPTIMIZATION.SAT:  "SAT",
+        }
+        for val, enum in [
+            (model_options.cryptanalysis, CRYPTANALYSIS),
+            (model_options.granularity,   GRANULARITY),
+            (model_options.optimization,  OPTIMIZATION),
+        ]:
+            if val not in {CRYPTANALYSIS.DIFFERENTIAL, CRYPTANALYSIS.LINEAR,
+                           GRANULARITY.WORDWISE, GRANULARITY.BITWISE,
+                           OPTIMIZATION.MILP, OPTIMIZATION.SAT}:
+                raise InvalidModelOptionException(val, enum)
+
+        cryptanalysis = cryptanalysis_map[model_options.cryptanalysis]
+        granularity   = granularity_map[model_options.granularity]
+        milp_or_sat   = opt_map[model_options.optimization]
+        name = self.name.replace('_', '\\_')
+
+        # define \statematrix as empty command so sub-ciphers can renewcommand
+        STRING  = "\\documentclass{article}\n"
         STRING += "\\usepackage{amssymb}\n"
         STRING += "\\usepackage{tikz}\n\\usepackage[margin=2cm]{geometry}\n"
         STRING += "\\usetikzlibrary{arrows}\n"
-
-        # define as empty command, in order to 'renewcommand' throughout the
-        # sections
         STRING += "\\newcommand*{\\statematrix}[2]{}\n"
-
-        if model_options.cryptanalysis == CRYPTANALYSIS.DIFFERENTIAL:
-            cryptanalysis = "differential"
-        elif model_options.cryptanalysis == CRYPTANALYSIS.LINEAR:
-            cryptanalysis = "linear"
-        else:
-            raise InvalidModelOptionException(
-                model_options.cryptanalysis, CRYPTANALYSIS
-            )
-
-        if model_options.granularity == GRANULARITY.WORDWISE:
-            granularity = "Wordwise"
-        elif model_options.granularity == GRANULARITY.BITWISE:
-            granularity = "Bitwise"
-        else:
-            raise InvalidModelOptionException(
-                model_options.granularity, GRANULARITY
-            )
-
-        name = self.name.replace('_', '\\_')
         STRING += f"\\title{{{granularity} {cryptanalysis} trail through "
-        if model_options.optimization == OPTIMIZATION.MILP:
-            milp_or_sat = "MILP"
-        elif model_options.optimization == OPTIMIZATION.SAT:
-            milp_or_sat = "SAT"
         STRING += f"\\texttt{{{name}}} found by {milp_or_sat}}}\n\n"
         STRING += "\\author{\\texttt{CiVerLy}}\n"
         STRING += "\\begin{document}\n"
         STRING += "\\maketitle\n"
 
         if model_options.granularity == GRANULARITY.WORDWISE:
-            STRING += "Total number of active SBoxes:"
-            STRING += f"${objective_value}$ \n"
+            STRING += f"Total number of active SBoxes: ${objective_value}$ \n"
         elif model_options.granularity == GRANULARITY.BITWISE:
-            if model_options.cryptanalysis == CRYPTANALYSIS.DIFFERENTIAL:
-                cryptanalysis_obj_value = "differential probability"
-            elif model_options.cryptanalysis == CRYPTANALYSIS.LINEAR:
-                cryptanalysis_obj_value = "linear correlation"
-            STRING += f"Maximal {cryptanalysis_obj_value}: "
-            STRING += f"$2^{{-{objective_value}}}$\n"
+            obj_label = {
+                CRYPTANALYSIS.DIFFERENTIAL: "differential probability",
+                CRYPTANALYSIS.LINEAR:       "linear correlation",
+            }[model_options.cryptanalysis]
+            STRING += f"Maximal {obj_label}: $2^{{-{objective_value}}}$\n"
 
-        ###################################
-        root_node = TrailNode(cipher_instance=self)
-        STRING += self._draw_or_get_trail_rec(
-            results=results,
-            current_node=root_node,
-            model_options=model_options,
-            _report=True
-        )
-        ###################################
-        STRING += "\\end{document}\n"
+        return STRING
 
-        root_node.verify_correctness()  # Throws Error when incorrect
+    def _write_and_compile_tex(self, string, model_options) -> None:
+        r"""
+        Writes ``string`` to a ``.tex`` file and compiles it to PDF via
+        ``pdflatex``, then removes auxiliary build files.
+        """
+        tex_file_name = model_options.path / (self.name + ".tex")
+        pdf_file_name = model_options.path / (self.name + ".pdf")
 
         with open(tex_file_name, 'w') as f:
-            f.write(STRING)
-            f.close()
+            f.write(string)
 
         with suppress_output():
             process = subprocess.Popen([
@@ -1746,199 +1767,34 @@ class Cipher:
 
         with suppress_output():
             prefix = str(model_options.path)
-            patterns = [
-                "/*.synctex.gz",
-                "/*.fls",
-                "/*.aux",
-                "/*.log",
-                "/*.fdb_latexmk"
-            ]
-            for pattern in patterns:
-                for file_matching_pattern in glob.glob(prefix + pattern):
-                    subprocess.Popen(
-                        ["rm", "-f", file_matching_pattern]
-                    ).wait()
+            for pattern in ["/*.synctex.gz", "/*.fls", "/*.aux",
+                            "/*.log", "/*.fdb_latexmk"]:
+                for f in glob.glob(prefix + pattern):
+                    subprocess.Popen(["rm", "-f", f]).wait()
 
         print(f"Output file in: {pdf_file_name}")
 
-        return
-
-    def get_trail(self, model_options):
+    def _latex_section(self, trail_node, model_options) -> str:
         r"""
-        After solving a MILP or SAT, it will convert the solution values to a
-        trail-like output, in form of a list. This is very similar to
-        ``self.generate_report``, however the content is in form of a list
-        rather than a pdf file.
+        Generate the LaTeX/tikz section string for this cipher, using the
+        pre-built ``trail_node`` (which holds ``bits_in`` and ``bits_out``).
+        Called by ``TrailNode.to_latex``.
         """
-        results, _ = self.read_results(model_options)
+        from civerly.aeslike import AESlike
 
-        root_node = TrailNode(cipher_instance=self)
-        self._draw_or_get_trail_rec(
-            results, model_options, root_node, _report=False
-        )
-        root_node.verify_correctness()  # Throws Error when incorrect
+        depths    = self._dfs_traversal()
+        divide_by = self.wordsize if model_options.granularity == GRANULARITY.WORDWISE else 1
 
-        return root_node
-
-    def _draw_or_get_trail_rec(self, results, model_options,
-                               current_node, _report=False):
-        r"""
-        Helper function for both ``get_trail`` and ``generate_report``, in
-        which the main recursion steps are performed. Should only be used
-        internally.
-
-        There are multiple case distinctions made:
-
-            - ``generate_report``/``get_trail``
-            - MILP/SAT
-            - AESlike/Cipher
-
-        The difference between ``_draw_trail_tikz`` for ``AESlike`` and for
-        ``SBoxCipher`` is the alignment, as the ``AESlike`` internal state is
-        arranged in form of a rectangle, while generic ``SBoxCipher`` objects
-        use a state where each word is on the same row.
-        """
-
-        STRING = self._rec_helpfunc(
-            results=results,
-            model_options=model_options,
-            current_node=current_node,
-            _report=_report
-        )
-
-        if model_options.optimization == OPTIMIZATION.MILP:
-            if not hasattr(self, 'dictionaries_milp'):
-                with open(model_options.path / (self.name + "_d.json")) as f:
-                    dictionaries = json.load(f)
-            else:
-                dictionaries = self.dictionaries_milp
-
-        elif model_options.optimization == OPTIMIZATION.SAT:
-            if not hasattr(self, 'dictionaries_sat'):
-                with open(model_options.path / (self.name + "_d.json")) as f:
-                    dictionaries = json.load(f)
-            else:
-                dictionaries = self.dictionaries_sat
-
-            def check_condition(comp_num, s):
-                return s > self.input_length + self.output_length and \
-                    s in dictionaries[comp_num].keys()
-
-        else:
-            raise InvalidModelOptionException(
-                model_options.optimization, OPTIMIZATION
-            )
-
-        depths = self._dfs_traversal()
-
-        # Recursively iterate through each subcipher
-        for comp_num, comp in enumerate(self.nodes):
-            if isinstance(comp, Cipher):
-                if model_options.optimization == OPTIMIZATION.MILP:
-                    # Build nested sub_results for the sub-cipher directly
-                    # from the parent's nested results entry for this comp_num
-                    sub_results = {}
-                    var_name = f"X{comp_num}"
-                    for s_ind, solution_bit_value in \
-                            results.get(var_name, {}).items():
-                        translated = dictionaries[comp_num][
-                            f"{var_name}[{s_ind}]"
-                        ]
-                        tr_name, tr_rest = translated.split('[', 1)
-                        tr_ind = int(tr_rest.rstrip(']'))
-                        sub_results.setdefault(tr_name, {})[tr_ind] = \
-                            solution_bit_value
-                else:  # SAT
-                    sub_results = {}
-                    for s, solution_bit_value in results.items():
-                        if check_condition(comp_num, s):
-                            # Translate the results using the corresponding
-                            # dictionaries
-                            sub_results[dictionaries[comp_num][s]] = \
-                                solution_bit_value
-
-                new_node = current_node.children[depths[comp_num]]
-
-                output = comp._draw_or_get_trail_rec(
-                    results=sub_results,
-                    model_options=model_options,
-                    current_node=new_node,
-                    _report=_report
-                )
-                if _report:
-                    STRING += output
-
-        return STRING
-
-    def _rec_helpfunc(self, results, model_options, current_node,
-                      _report=False):
-        r"""
-        Internal helper function that generates a well-aligned grid of the
-        cipher components and returns either the corresponding latex code or
-        the trail as a list.
-
-        INPUT:
-
-            - ``results`` -- a list containing the variable assignments for the
-              given optimization problem
-
-            - ``model_options`` -- the model_options enum containing the
-              relevant metadata
-
-            - ``current_node`` -- Of type ``TrailNode``, used to generate the
-              tree structure to double-check the reports coherence.
-
-            Optionally:
-
-            - ``_report`` -- bool; Indicates whether this is called by
-              :meth:`generate_report` or not. In case it is, return ``STRING``
-
-        OUTPUT:
-
-            - Either a string containing the latex code for the trail or a list
-              containing the trail itself
-        """
-        # NOTE for clarification:
-        # - ``bits``   : Array initialized with None entries, which will be
-        #   filled with the bit values.
-        # - ``nibbles``: Array which aligns the bits to the left and groups
-        #   them into nibbles of size ``self._wrd``.
-        # ------------------------------------------------- #
-
-        if model_options.granularity == GRANULARITY.WORDWISE:
-            divide_by = self.wordsize
-        elif model_options.granularity == GRANULARITY.BITWISE:
-            divide_by = 1
-        else:
-            raise InvalidModelOptionException(
-                model_options.granularity, GRANULARITY
-            )
-
-        # load dictionaries (e.g. when generating report in a new session after
-        # models where solved externally)
-        if not hasattr(self, 'dictionaries'):
-            with open(model_options.path / (self.name + "_d.json")) as f:
-                dictionaries = json.load(f)
-
-        ##################################################
-        depths = self._dfs_traversal()
-
-        # Amount of space (in tikz units) between:
-        #   -> each of the layers
-        #   -> in- and output of the layers
         space_between_layers = 3
         space_between_in_out = 2
-        ##################################################
 
-        STRING = f"\\section{{{self.name.replace('_', '\\_')}}}\n"
+        # Local copies so nibble-padding below does not mutate the node
+        bits_in  = [row[:] for row in trail_node.bits_in]
+        bits_out = [row[:] for row in trail_node.bits_out]
+
+        STRING  = f"\\section{{{self.name.replace('_', '\\_')}}}\n"
         STRING += "\\begingroup\n"
 
-        # Distinction between how a statematrix looks like, depending on:
-        # -> if self is AESlike: statematrix is rectangular, based on
-        #    self.rows and self.cols
-        # -> if not, statematrix will not be used and the state is arranged
-        #    in one row.
-        from civerly.aeslike import AESlike
         if isinstance(self, AESlike):
             STRING += "\\renewcommand{\\statematrix}[2]{\n"
             STRING += f"\t\\draw (#1, #2) rectangle (#1 + {self.cols}, #2 + {self.rows});\n"
@@ -1951,8 +1807,6 @@ class Cipher:
         scale = sqrt((-0.75 + self._wrd/4) * 4)
 
         STRING += "\\begin{center}\n"
-
-        # Resize the drawings such that everything fits on the page
         if isinstance(self, AESlike):
             STRING += "\t\\resizebox{0.7\\textwidth}{!}{\\begin{tikzpicture}\n"
         else:
@@ -1961,119 +1815,7 @@ class Cipher:
             else:
                 STRING += "\t\\resizebox{!}{0.8\\textheight}{\\begin{tikzpicture}\n"
 
-        max_width_in = max([
-            sum(
-                self.nodes[w].input_length
-                for w in range(len(self.nodes))
-                if depths[w] == depth
-            )
-            for depth in range(max(depths)+1)
-        ])
-        max_width_out = max([
-            sum(
-                self.nodes[w].output_length
-                for w in range(len(self.nodes))
-                if depths[w] == depth
-            )
-            for depth in range(max(depths)+1)
-        ])
-
-        bits_in = [
-            [None for _ in range(max_width_in // divide_by)]
-            for _ in range(max(depths)+1)
-        ]
-        bits_out = [
-            [None for _ in range(max_width_out // divide_by)]
-            for _ in range(max(depths)+1)
-        ]
-
-        # Sort the (messy and unordered) variable values correctly
-        if model_options.optimization == OPTIMIZATION.MILP:
-            for var_name, var_dict in results.items():
-                if var_name in ("IN", "OUT"):
-                    # if var_name is MILP_IN or MILP_OUT, we skip it
-                    continue
-                comp_num = int(var_name[1:])
-                for s_ind, solution_bit_value in var_dict.items():
-                    translated_component = dictionaries[comp_num][
-                        f"{var_name}[{s_ind}]"
-                    ]
-                    # Draw the input nodes of each component
-                    bool1 = "IN" in translated_component
-                    # We also draw the output of the last component.
-                    bool2 = "OUT" in translated_component
-
-                    if bool1 and comp_num != 0:  # dont draw self.IN.in
-                        current_index = _between_brackets(translated_component)
-                        bit_ind = self._from_grid(
-                            comp_num, current_index, model_options, input_side=True
-                        )
-                        bits_in[depths[comp_num]][bit_ind] = solution_bit_value
-                    elif bool2:
-                        current_index = _between_brackets(translated_component)
-                        bit_ind = self._from_grid(
-                            comp_num, current_index, model_options, input_side=False
-                        )
-                        bits_out[depths[comp_num]][bit_ind] = solution_bit_value
-        elif model_options.optimization == OPTIMIZATION.SAT:
-            # NOTE: SAT-vars start at 1 while grid-indexing starts at 0
-            for s, solution_bit_value in results.items():
-                if s <= self.input_length + self.output_length:
-                    # if s is SAT_IN or SAT_OUT, we skip it
-                    continue
-                comp_num = 0
-                try:
-                    # determine correct comp_num based on s being in
-                    # dictionaries[comp_num]
-                    while str(s) not in dictionaries[comp_num].keys():
-                        comp_num += 1
-                except IndexError as error:
-                    # if the variable comes from the summation logic that bound
-                    # the objective value, we skip it this is the case when s
-                    # was added into the sat after the last component,
-                    # i.e. when s > max(dictionaries[-1].keys())
-                    if s > int(max(dictionaries[comp_num - 1].keys())):
-                        continue
-                    else:
-                        raise error
-
-                translated_component = dictionaries[comp_num][str(s)]
-                comp = self.nodes[comp_num]
-                # Draw the input nodes of each component
-                bool1 = translated_component <= comp.input_length
-                # We also draw the output of the last component.
-                bool2 = comp.input_length < translated_component and \
-                    translated_component <= comp.input_length + comp.output_length
-
-                if bool1 and comp_num != 0:  # dont draw self.IN.in
-                    current_index = translated_component - 1
-                    bit_ind = self._from_grid(
-                        comp_num, current_index, model_options, input_side=True
-                    )
-                    bits_in[depths[comp_num]][bit_ind] = solution_bit_value
-                elif bool2:
-                    current_index = translated_component - \
-                        self.nodes[comp_num].input_length - 1
-                    bit_ind = self._from_grid(
-                        comp_num, current_index, model_options, input_side=False
-                    )
-                    bits_out[depths[comp_num]][bit_ind] = solution_bit_value
-        else:
-            raise InvalidModelOptionException(
-                model_options.optimization, OPTIMIZATION
-            )
-
-        # realign bits_in, bits_out by removing any 'None' entries
-        bits_in = [
-            [entry for entry in bits_in_row if entry is not None]
-            for bits_in_row in bits_in
-        ]
-        bits_out = [
-            [entry for entry in bits_out_row if entry is not None]
-            for bits_out_row in bits_out
-        ]
-
-        # draw state arrays
+        # Draw state arrays / component structure
         if isinstance(self, AESlike):
             for layer in range(max(depths)+1):
                 x_pos = (layer % 4) * (self.cols + 2)
@@ -2083,16 +1825,14 @@ class Cipher:
                 STRING += "{\\huge $\\stackrel{ \\scriptsize "
                 STRING += f"\\textrm{{{self.nodes[depths.index(layer)].name}}}"
                 STRING += "}{\\longrightarrow}$};\n"
-        else:  # if this is SBoxCipher
-
+        else:  # SBoxCipher
             for (a, b), (x, y) in self.edges:
-                xx = self._from_grid(a, x//divide_by, model_options, input_side=False)
-                yy = self._from_grid(b, y//divide_by, model_options, input_side=True)
+                xx = self._from_grid(a, x//divide_by, model_options=model_options, input_side=False)
+                yy = self._from_grid(b, y//divide_by, model_options=model_options, input_side=True)
 
                 top_a = -depths[a] * (space_between_layers + space_between_in_out)
                 bot_b = -(depths[b] * (space_between_layers + space_between_in_out) - space_between_in_out + 1)
 
-                # Connection between nodes
                 if b == self.nodes.index(self.OUT):
                     STRING += "\t\t\\draw[thin, dashed, ->] "
                 else:
@@ -2102,7 +1842,6 @@ class Cipher:
                 STRING += f"({scale * divide_by * (0.5 + yy)/self._wrd}, "
                 STRING += f"{bot_b});\n"
 
-            # Draw the component as a box
             for a, na in enumerate(self.nodes):
                 if isinstance(na, Cipher.__Special_Node):
                     continue
@@ -2110,68 +1849,50 @@ class Cipher:
                 top = -depths[a] * (space_between_layers + space_between_in_out)
                 bot = -depths[a] * (space_between_layers + space_between_in_out) - space_between_in_out + 1
 
-                if na.input_length > 0:  # for most nodes
-                    corner_a = (scale * divide_by * self._from_grid(a, 0, model_options, input_side=True)/self._wrd, top)
-                else:  # if na is C_CVL or similar
-                    corner_a = (scale * divide_by * self._from_grid(a, na.output_length//(2*divide_by), model_options, input_side=False)/self._wrd, top)
+                if na.input_length > 0:
+                    corner_a = (scale * divide_by * self._from_grid(a, 0, model_options=model_options, input_side=True)/self._wrd, top)
+                else:
+                    corner_a = (scale * divide_by * self._from_grid(a, na.output_length//(2*divide_by), model_options=model_options, input_side=False)/self._wrd, top)
 
-                corner_b = (scale * divide_by * self._from_grid(a, 0, input_side=False)/self._wrd, bot)
-                corner_c = (scale * divide_by * (self._from_grid(a, (na.output_length-1)//divide_by, model_options, input_side=False) + 1)/self._wrd, bot)
+                corner_b = (scale * divide_by * self._from_grid(a, 0, model_options=model_options, input_side=False)/self._wrd, bot)
+                corner_c = (scale * divide_by * (self._from_grid(a, (na.output_length-1)//divide_by, model_options=model_options, input_side=False) + 1)/self._wrd, bot)
 
-                if na.input_length > 0:  # for most nodes
-                    corner_d = (scale * divide_by * (self._from_grid(a, (na.input_length-1)//divide_by, model_options, input_side=True) + 1)/self._wrd, top)
-                else:  # if na is C_CVL or similar
-                    corner_d = (scale * divide_by * (self._from_grid(a, na.output_length//(2*divide_by), model_options, input_side=False) + 1)/self._wrd, top)
+                if na.input_length > 0:
+                    corner_d = (scale * divide_by * (self._from_grid(a, (na.input_length-1)//divide_by, model_options=model_options, input_side=True) + 1)/self._wrd, top)
+                else:
+                    corner_d = (scale * divide_by * (self._from_grid(a, na.output_length//(2*divide_by), model_options=model_options, input_side=False) + 1)/self._wrd, top)
 
                 mid_point = tuple(sum(x)/4 for x in zip(*[corner_a, corner_b, corner_c, corner_d]))
 
                 STRING += f"\t\t\\draw[very thick] {corner_a} -- {corner_b} -- {corner_c} -- {corner_d} -- {corner_a};\n"
                 STRING += f"\t\t\\node[] at {mid_point} {{\\tiny ${na.name.replace('_', '\\_')}$}};\n"
 
-        # Selecting correct arrays depending on granularities
+        # Convert raw bits to display arrays based on granularity
         if model_options.granularity == GRANULARITY.WORDWISE:
-            arr_in = bits_in
+            arr_in  = bits_in
             arr_out = bits_out
-
         elif model_options.granularity == GRANULARITY.BITWISE:
+            for i in range(max(depths)+1):  # pad to word boundary
+                bits_in[i]  += [0] * (-len(bits_in[i])  % self._wrd)
+                bits_out[i] += [0] * (-len(bits_out[i]) % self._wrd)
 
-            for i in range(max(depths)+1):  # pad with zeros
-                bits_in[i] += [0]*(-len(bits_in[i]) % self._wrd)
-                bits_out[i] += [0]*(-len(bits_out[i]) % self._wrd)
-
-            # Instead of representing each bit on its own, we combine them to
-            # nibbles, for a more concise representation.
-            nibbles_in = [
-                [None for _ in range(len(bits_in[depth])//self._wrd)]
-                for depth in range(max(depths)+1)
-            ]
-            nibbles_out = [
-                [None for _ in range(len(bits_out[depth])//self._wrd)]
-                for depth in range(max(depths)+1)
-            ]
-
-            for depth in range(max(depths)+1):
-                nibbles_in[depth] = [
-                    sum([
-                        bits_in[depth][i:i+self._wrd][j] << (self._wrd-1-j)
-                        for j in range(self._wrd)
-                    ])
-                    for i in range(0, len(bits_in[depth]), self._wrd)
+            # Group bits into words for display
+            nibbles_in  = [[None] * (len(bits_in[d])  // self._wrd) for d in range(max(depths)+1)]
+            nibbles_out = [[None] * (len(bits_out[d]) // self._wrd) for d in range(max(depths)+1)]
+            for d in range(max(depths)+1):
+                nibbles_in[d]  = [
+                    sum(bits_in[d][i:i+self._wrd][j]  << (self._wrd-1-j) for j in range(self._wrd))
+                    for i in range(0, len(bits_in[d]),  self._wrd)
                 ]
-                nibbles_out[depth] = [
-                    sum([
-                        bits_out[depth][i:i+self._wrd][j] << (self._wrd-1-j)
-                        for j in range(self._wrd)
-                    ])
-                    for i in range(0, len(bits_out[depth]), self._wrd)
+                nibbles_out[d] = [
+                    sum(bits_out[d][i:i+self._wrd][j] << (self._wrd-1-j) for j in range(self._wrd))
+                    for i in range(0, len(bits_out[d]), self._wrd)
                 ]
-
-            arr_in = nibbles_in
+            arr_in  = nibbles_in
             arr_out = nibbles_out
 
-        # fill in values
+        # Fill in values
         bool_finished_arrin = False
-        # Fill the layers with the nibble values
         for j, arr_layer in enumerate(arr_in + arr_out):
             # restart the counter after we iterated through arr_in
             if j >= len(arr_in):
@@ -2202,12 +1923,10 @@ class Cipher:
                             STRING += f"{-(j // 4) * (self.rows + 1) + self.rows - (i % self.rows) - 0.5})"
                             STRING += f"{{ {tikz_entry} }};\n"
 
-                    else:  # if this is SBoxCipher
+                    else:  # SBoxCipher
                         if j == len(arr_out) - 1 and bool_finished_arrin:
                             continue  # skip self.OUT.out
 
-                        # compute the correct depth at which we draw, depending
-                        # on whether we draw from arr_in or arr_out
                         computed_draw_depth = j * (space_between_layers + space_between_in_out)
                         if bool_finished_arrin:
                             computed_draw_depth += space_between_in_out
@@ -2232,25 +1951,9 @@ class Cipher:
                             STRING += f"{{{tikz_entry}}};\n"
 
         STRING += "\t\\end{tikzpicture}}\n\\end{center}\n\\endgroup\n"
+        return STRING
 
-        # Construct the tree structure of subciphers for
-        # civerly.trail.verify_correctness()
-        current_node.name = self.name
-        current_node.children = [
-            TrailNode(cipher_instance=self.nodes[depths[r]])
-            for r, row in enumerate(bits_out)
-        ]
-        for i in range(1, len(bits_out)):
-            current_node.children[i - 1].right = current_node.children[i]
 
-        for i in range(0, len(bits_out)):
-            current_node.children[i].input = bits_in[i]
-            current_node.children[i].output = bits_out[i]
-
-        if _report:
-            return STRING
-        else:
-            return
 
     def _copy_over_dictionaries_recursively(self, prev, model_options):
         r"""

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -72,7 +72,7 @@ class CipherNotValidException(Exception):
 
 
 class Cipher:
-    class __Special_Node:
+    class __Special_Node(Component):
         r"""
         A special "component" representing the input or output of
         ``cipher_instance``, which is not directly accessible from the outside.

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -1610,6 +1610,26 @@ class Cipher:
         else:
             return grid_out
 
+    def _from_grid(self, node_num, current_index, model_options, input_side=True):
+        r"""
+        Recovers ``(node_num, current_index)`` from grid.
+        """
+        if model_options.granularity == GRANULARITY.WORDWISE:
+            divide_by = self.wordsize
+        elif model_options.granularity == GRANULARITY.BITWISE:
+            divide_by = 1
+        grid = self._construct_grid(divide_by=divide_by, input_side=input_side)
+
+        for grid_row in grid:
+            if (node_num, current_index) in grid_row:
+                return grid_row.index((node_num, current_index))
+
+        # ------------------------ if nothing was found
+        raise AssertionError(
+            f"{(self.nodes[node_num].name, node_num)}[{current_index}] "
+            "is not found in grid!"
+        )
+
     def read_results(self, model_options):
         r"""
         """
@@ -1750,20 +1770,7 @@ class Cipher:
         ``self.generate_report``, however the content is in form of a list
         rather than a pdf file.
         """
-        if model_options.optimization == OPTIMIZATION.MILP:
-            solution_file_name = model_options.path / (self.name + ".sol")
-            results = model_options.milp_solver.process_solution_file(
-                solution_file_name
-            )[0]
-        elif model_options.optimization == OPTIMIZATION.SAT:
-            solution_file_name = model_options.path / (self.name + ".sat")
-            results = model_options.sat_solver.process_solution_file(
-                solution_file_name
-            )[0]
-        else:
-            raise InvalidModelOptionException(
-                model_options.optimization, OPTIMIZATION
-            )
+        results, _ = self.read_results(model_options)
 
         root_node = TrailNode(cipher_instance=self)
         self._draw_or_get_trail_rec(
@@ -1923,28 +1930,6 @@ class Cipher:
         space_between_in_out = 2
         ##################################################
 
-        grid_in = self._construct_grid(divide_by=divide_by, input_side=True)
-        grid_out = self._construct_grid(divide_by=divide_by, input_side=False)
-
-        def _from_grid(node_num, current_index, input_side=True):
-            r"""
-            Recovers ``(node_num, current_index)`` from grid.
-            """
-            if input_side:
-                used_grid = grid_in
-            else:
-                used_grid = grid_out
-
-            for grid_row in used_grid:
-                if (node_num, current_index) in grid_row:
-                    return grid_row.index((node_num, current_index))
-
-            # ------------------------ if nothing was found
-            raise AssertionError(
-                f"{(self.nodes[node_num].name, node_num)}[{current_index}] "
-                "is not found in grid!"
-            )
-
         STRING = f"\\section{{{self.name.replace('_', '\\_')}}}\n"
         STRING += "\\begingroup\n"
 
@@ -2020,14 +2005,14 @@ class Cipher:
 
                     if bool1 and comp_num != 0:  # dont draw self.IN.in
                         current_index = _between_brackets(translated_component)
-                        bit_ind = _from_grid(
-                            comp_num, current_index, input_side=True
+                        bit_ind = self._from_grid(
+                            comp_num, current_index, model_options, input_side=True
                         )
                         bits_in[depths[comp_num]][bit_ind] = solution_bit_value
                     elif bool2:
                         current_index = _between_brackets(translated_component)
-                        bit_ind = _from_grid(
-                            comp_num, current_index, input_side=False
+                        bit_ind = self._from_grid(
+                            comp_num, current_index, model_options, input_side=False
                         )
                         bits_out[depths[comp_num]][bit_ind] = solution_bit_value
         elif model_options.optimization == OPTIMIZATION.SAT:
@@ -2062,15 +2047,15 @@ class Cipher:
 
                 if bool1 and comp_num != 0:  # dont draw self.IN.in
                     current_index = translated_component - 1
-                    bit_ind = _from_grid(
-                        comp_num, current_index, input_side=True
+                    bit_ind = self._from_grid(
+                        comp_num, current_index, model_options, input_side=True
                     )
                     bits_in[depths[comp_num]][bit_ind] = solution_bit_value
                 elif bool2:
                     current_index = translated_component - \
                         self.nodes[comp_num].input_length - 1
-                    bit_ind = _from_grid(
-                        comp_num, current_index, input_side=False
+                    bit_ind = self._from_grid(
+                        comp_num, current_index, model_options, input_side=False
                     )
                     bits_out[depths[comp_num]][bit_ind] = solution_bit_value
         else:
@@ -2101,8 +2086,8 @@ class Cipher:
         else:  # if this is SBoxCipher
 
             for (a, b), (x, y) in self.edges:
-                xx = _from_grid(a, x//divide_by, input_side=False)
-                yy = _from_grid(b, y//divide_by, input_side=True)
+                xx = self._from_grid(a, x//divide_by, model_options, input_side=False)
+                yy = self._from_grid(b, y//divide_by, model_options, input_side=True)
 
                 top_a = -depths[a] * (space_between_layers + space_between_in_out)
                 bot_b = -(depths[b] * (space_between_layers + space_between_in_out) - space_between_in_out + 1)
@@ -2126,17 +2111,17 @@ class Cipher:
                 bot = -depths[a] * (space_between_layers + space_between_in_out) - space_between_in_out + 1
 
                 if na.input_length > 0:  # for most nodes
-                    corner_a = (scale * divide_by * _from_grid(a, 0, input_side=True)/self._wrd, top)
+                    corner_a = (scale * divide_by * self._from_grid(a, 0, model_options, input_side=True)/self._wrd, top)
                 else:  # if na is C_CVL or similar
-                    corner_a = (scale * divide_by * _from_grid(a, na.output_length//(2*divide_by), input_side=False)/self._wrd, top)
+                    corner_a = (scale * divide_by * self._from_grid(a, na.output_length//(2*divide_by), model_options, input_side=False)/self._wrd, top)
 
-                corner_b = (scale * divide_by * _from_grid(a, 0, input_side=False)/self._wrd, bot)
-                corner_c = (scale * divide_by * (_from_grid(a, (na.output_length-1)//divide_by, input_side=False) + 1)/self._wrd, bot)
+                corner_b = (scale * divide_by * self._from_grid(a, 0, input_side=False)/self._wrd, bot)
+                corner_c = (scale * divide_by * (self._from_grid(a, (na.output_length-1)//divide_by, model_options, input_side=False) + 1)/self._wrd, bot)
 
                 if na.input_length > 0:  # for most nodes
-                    corner_d = (scale * divide_by * (_from_grid(a, (na.input_length-1)//divide_by, input_side=True) + 1)/self._wrd, top)
+                    corner_d = (scale * divide_by * (self._from_grid(a, (na.input_length-1)//divide_by, model_options, input_side=True) + 1)/self._wrd, top)
                 else:  # if na is C_CVL or similar
-                    corner_d = (scale * divide_by * (_from_grid(a, na.output_length//(2*divide_by), input_side=False) + 1)/self._wrd, top)
+                    corner_d = (scale * divide_by * (self._from_grid(a, na.output_length//(2*divide_by), model_options, input_side=False) + 1)/self._wrd, top)
 
                 mid_point = tuple(sum(x)/4 for x in zip(*[corner_a, corner_b, corner_c, corner_d]))
 

--- a/src/civerly/trail.py
+++ b/src/civerly/trail.py
@@ -2,11 +2,14 @@ from sage.modules.free_module_element import vector
 from sage.rings.finite_rings.finite_field_constructor import GF
 from civerly.util import vec_to_int
 
+import json
+from civerly.component import Component
+from civerly.model_options import OPTIMIZATION, GRANULARITY
+from civerly.util import _between_brackets
 
 class TrailNode:
-    # def __init__(self, input_length, output_length, name=None) -> None:
-    def __init__(self, cipher_instance) -> None:
-        self.children = []
+    def __init__(self, cipher_instance, model_options, results) -> None:
+        self.children : list[TrailNode] = []
         self.right = None
         self.input = None
         self.output = None
@@ -14,6 +17,180 @@ class TrailNode:
         self.name = cipher_instance.name
         self.input_length = cipher_instance.input_length
         self.output_length = cipher_instance.output_length
+
+        if model_options.optimization == OPTIMIZATION.MILP:
+            if not hasattr(self.cipher_instance, 'dictionaries_milp'):
+                with open(model_options.path / (self.cipher_instance.name + "_d.json")) as f:
+                    dictionaries = json.load(f)
+            else:
+                dictionaries = self.cipher_instance.dictionaries_milp
+
+        elif model_options.optimization == OPTIMIZATION.SAT:
+            if not hasattr(self.cipher_instance, 'dictionaries_sat'):
+                with open(model_options.path / (self.cipher_instance.name + "_d.json")) as f:
+                    dictionaries = json.load(f)
+            else:
+                dictionaries = self.cipher_instance.dictionaries_sat
+
+            def check_condition(comp_num, s):
+                return s > self.cipher_instance.input_length + self.cipher_instance.output_length and \
+                    s in dictionaries[comp_num].keys()
+
+        depths = self.cipher_instance._dfs_traversal()
+
+        ################################################
+        nodes = self.cipher_instance.nodes
+        max_width_in = max([
+            sum(
+                nodes[w].input_length
+                for w in range(len(nodes))
+                if depths[w] == depth
+            )
+            for depth in range(max(depths)+1)
+        ])
+        max_width_out = max([
+            sum(
+                nodes[w].output_length
+                for w in range(len(nodes))
+                if depths[w] == depth
+            )
+            for depth in range(max(depths)+1)
+        ])
+
+        if model_options.granularity == GRANULARITY.WORDWISE:
+            divide_by = self.cipher_instance.wordsize
+        elif model_options.granularity == GRANULARITY.BITWISE:
+            divide_by = 1
+
+        bits_in = [
+            [None for _ in range(max_width_in // divide_by)]
+            for _ in range(max(depths)+1)
+        ]
+        bits_out = [
+            [None for _ in range(max_width_out // divide_by)]
+            for _ in range(max(depths)+1)
+        ]
+
+        # Sort the (messy and unordered) variable values correctly
+        if model_options.optimization == OPTIMIZATION.MILP:
+            for var_name, var_dict in results.items():
+                if var_name in ("IN", "OUT"):
+                    # if var_name is MILP_IN or MILP_OUT, we skip it
+                    continue
+                comp_num = int(var_name[1:])
+                for s_ind, solution_bit_value in var_dict.items():
+                    translated_component = dictionaries[comp_num][
+                        f"{var_name}[{s_ind}]"
+                    ]
+                    # Draw the input nodes of each component
+                    bool1 = "IN" in translated_component
+                    # We also draw the output of the last component.
+                    bool2 = "OUT" in translated_component
+
+                    if bool1 and comp_num != 0:  # dont draw self.IN.in
+                        current_index = _between_brackets(translated_component)
+                        bit_ind = self.cipher_instance._from_grid(
+                            comp_num, current_index, model_options, input_side=True
+                        )
+                        bits_in[depths[comp_num]][bit_ind] = solution_bit_value
+                    elif bool2:
+                        current_index = _between_brackets(translated_component)
+                        bit_ind = self.cipher_instance._from_grid(
+                            comp_num, current_index, model_options, input_side=False
+                        )
+                        bits_out[depths[comp_num]][bit_ind] = solution_bit_value
+        elif model_options.optimization == OPTIMIZATION.SAT:
+            # NOTE: SAT-vars start at 1 while grid-indexing starts at 0
+            for s, solution_bit_value in results.items():
+                if s <= self.cipher_instance.input_length + self.cipher_instance.output_length:
+                    # if s is SAT_IN or SAT_OUT, we skip it
+                    continue
+                comp_num = 0
+                try:
+                    # determine correct comp_num based on s being in
+                    # dictionaries[comp_num]
+                    while str(s) not in dictionaries[comp_num].keys():
+                        comp_num += 1
+                except IndexError as error:
+                    # if the variable comes from the summation logic that bound
+                    # the objective value, we skip it this is the case when s
+                    # was added into the sat after the last component,
+                    # i.e. when s > max(dictionaries[-1].keys())
+                    if s > int(max(dictionaries[comp_num - 1].keys())):
+                        continue
+                    else:
+                        raise error
+
+                translated_component = dictionaries[comp_num][str(s)]
+                comp = nodes[comp_num]
+                # Draw the input nodes of each component
+                bool1 = translated_component <= comp.input_length
+                # We also draw the output of the last component.
+                bool2 = comp.input_length < translated_component and \
+                    translated_component <= comp.input_length + comp.output_length
+
+                if bool1 and comp_num != 0:  # dont draw self.IN.in
+                    current_index = translated_component - 1
+                    bit_ind = self.cipher_instance._from_grid(
+                        comp_num, current_index, model_options, input_side=True
+                    )
+                    bits_in[depths[comp_num]][bit_ind] = solution_bit_value
+                elif bool2:
+                    current_index = translated_component - \
+                        nodes[comp_num].input_length - 1
+                    bit_ind = self.cipher_instance._from_grid(
+                        comp_num, current_index, model_options, input_side=False
+                    )
+                    bits_out[depths[comp_num]][bit_ind] = solution_bit_value
+
+        # realign bits_in, bits_out by removing any 'None' entries
+        bits_in = [
+            [entry for entry in bits_in_row if entry is not None]
+            for bits_in_row in bits_in
+        ]
+        bits_out = [
+            [entry for entry in bits_out_row if entry is not None]
+            for bits_out_row in bits_out
+        ]
+
+        self.input = bits_out[0]
+        self.output = bits_out[-1]
+        ################################################
+    
+        # Recursively iterate through each subcipher
+        for comp_num, comp in enumerate(nodes):
+            if not isinstance(comp, Component):
+                if model_options.optimization == OPTIMIZATION.MILP:
+                    # Build nested sub_results for the sub-cipher directly
+                    # from the parent's nested results entry for this comp_num
+                    sub_results = {}
+                    var_name = f"X{comp_num}"
+                    for s_ind, solution_bit_value in \
+                            results.get(var_name, {}).items():
+                        translated = dictionaries[comp_num][
+                            f"{var_name}[{s_ind}]"
+                        ]
+                        tr_name, tr_rest = translated.split('[', 1)
+                        tr_ind = int(tr_rest.rstrip(']'))
+                        sub_results.setdefault(tr_name, {})[tr_ind] = \
+                            solution_bit_value
+                else:  # SAT
+                    sub_results = {}
+                    for s, solution_bit_value in results.items():
+                        if check_condition(comp_num, s):
+                            # Translate the results using the corresponding
+                            # dictionaries
+                            sub_results[dictionaries[comp_num][s]] = \
+                                solution_bit_value
+
+                self.children.append(TrailNode(
+                        self.cipher_instance.nodes[depths[comp_num]],
+                        model_options=model_options,
+                        results=sub_results
+                ))
+        ########################################################################
+
+        
 
     def _to_hex(self) -> str:
         string = ""

--- a/src/civerly/trail.py
+++ b/src/civerly/trail.py
@@ -93,7 +93,7 @@ class TrailNode:
                 try:
                     # determine correct comp_num based on s being in
                     # dictionaries[comp_num]
-                    while str(s) not in dictionaries[comp_num].keys():
+                    while s not in dictionaries[comp_num].keys():
                         comp_num += 1
                 except IndexError as error:
                     # if the variable comes from the summation logic that bound
@@ -105,7 +105,7 @@ class TrailNode:
                     else:
                         raise error
 
-                translated_component = dictionaries[comp_num][str(s)]
+                translated_component = dictionaries[comp_num][s]
                 comp = nodes[comp_num]
                 # Draw the input nodes of each component
                 bool1 = translated_component <= comp.input_length

--- a/src/civerly/trail.py
+++ b/src/civerly/trail.py
@@ -8,68 +8,52 @@ from civerly.model_options import OPTIMIZATION, GRANULARITY
 from civerly.util import _between_brackets
 
 class TrailNode:
-    def __init__(self, cipher_instance, model_options, results) -> None:
+    def __init__(self, cipher_instance, model_options, results,
+                 _parent_depth=None) -> None:
         self.children : list[TrailNode] = []
         self.right = None
         self.input = None
         self.output = None
+        self.bits_in = None
+        self.bits_out = None
+        self._parent_depth = _parent_depth
         self.cipher_instance = cipher_instance
         self.name = cipher_instance.name
         self.input_length = cipher_instance.input_length
         self.output_length = cipher_instance.output_length
 
-        if model_options.optimization == OPTIMIZATION.MILP:
-            if not hasattr(self.cipher_instance, 'dictionaries_milp'):
-                with open(model_options.path / (self.cipher_instance.name + "_d.json")) as f:
-                    dictionaries = json.load(f)
-            else:
-                dictionaries = self.cipher_instance.dictionaries_milp
+        # obtain dictionaries
+        opt_to_attr = {OPTIMIZATION.MILP: 'dictionaries_milp', OPTIMIZATION.SAT: 'dictionaries_sat'}
+        attr = opt_to_attr[model_options.optimization]
+        if hasattr(self.cipher_instance, attr):
+            dictionaries = getattr(self.cipher_instance, attr)
+        else:
+            with open(model_options.path / (self.name + "_d.json")) as f:
+                dictionaries = json.load(f)
 
-        elif model_options.optimization == OPTIMIZATION.SAT:
-            if not hasattr(self.cipher_instance, 'dictionaries_sat'):
-                with open(model_options.path / (self.cipher_instance.name + "_d.json")) as f:
-                    dictionaries = json.load(f)
-            else:
-                dictionaries = self.cipher_instance.dictionaries_sat
-
+        if model_options.optimization == OPTIMIZATION.SAT:
             def check_condition(comp_num, s):
                 return s > self.cipher_instance.input_length + self.cipher_instance.output_length and \
                     s in dictionaries[comp_num].keys()
 
         depths = self.cipher_instance._dfs_traversal()
+        nodes = self.cipher_instance.nodes
 
         ################################################
-        nodes = self.cipher_instance.nodes
-        max_width_in = max([
-            sum(
-                nodes[w].input_length
-                for w in range(len(nodes))
-                if depths[w] == depth
-            )
-            for depth in range(max(depths)+1)
-        ])
-        max_width_out = max([
-            sum(
-                nodes[w].output_length
-                for w in range(len(nodes))
-                if depths[w] == depth
-            )
-            for depth in range(max(depths)+1)
-        ])
+        depth_range = range(max(depths) + 1)
+        max_width_in = max(
+            sum(n.input_length for n, d in zip(nodes, depths) if d == depth)
+            for depth in depth_range
+        )
+        max_width_out = max(
+            sum(n.output_length for n, d in zip(nodes, depths) if d == depth)
+            for depth in depth_range
+        )
 
-        if model_options.granularity == GRANULARITY.WORDWISE:
-            divide_by = self.cipher_instance.wordsize
-        elif model_options.granularity == GRANULARITY.BITWISE:
-            divide_by = 1
+        divide_by = self.cipher_instance.wordsize if model_options.granularity == GRANULARITY.WORDWISE else 1
 
-        bits_in = [
-            [None for _ in range(max_width_in // divide_by)]
-            for _ in range(max(depths)+1)
-        ]
-        bits_out = [
-            [None for _ in range(max_width_out // divide_by)]
-            for _ in range(max(depths)+1)
-        ]
+        bits_in  = [[None] * (max_width_in  // divide_by) for _ in depth_range]
+        bits_out = [[None] * (max_width_out // divide_by) for _ in depth_range]
 
         # Sort the (messy and unordered) variable values correctly
         if model_options.optimization == OPTIMIZATION.MILP:
@@ -144,53 +128,53 @@ class TrailNode:
                     bits_out[depths[comp_num]][bit_ind] = solution_bit_value
 
         # realign bits_in, bits_out by removing any 'None' entries
-        bits_in = [
-            [entry for entry in bits_in_row if entry is not None]
-            for bits_in_row in bits_in
-        ]
-        bits_out = [
-            [entry for entry in bits_out_row if entry is not None]
-            for bits_out_row in bits_out
-        ]
+        bits_in  = [[e for e in row if e is not None] for row in bits_in]
+        bits_out = [[e for e in row if e is not None] for row in bits_out]
 
-        self.input = bits_out[0]
+        self.bits_in  = bits_in
+        self.bits_out = bits_out
+        self.input  = bits_out[0]
         self.output = bits_out[-1]
         ################################################
-    
-        # Recursively iterate through each subcipher
-        for comp_num, comp in enumerate(nodes):
-            if not isinstance(comp, Component):
-                if model_options.optimization == OPTIMIZATION.MILP:
-                    # Build nested sub_results for the sub-cipher directly
-                    # from the parent's nested results entry for this comp_num
-                    sub_results = {}
-                    var_name = f"X{comp_num}"
-                    for s_ind, solution_bit_value in \
-                            results.get(var_name, {}).items():
-                        translated = dictionaries[comp_num][
-                            f"{var_name}[{s_ind}]"
-                        ]
-                        tr_name, tr_rest = translated.split('[', 1)
-                        tr_ind = int(tr_rest.rstrip(']'))
-                        sub_results.setdefault(tr_name, {})[tr_ind] = \
-                            solution_bit_value
-                else:  # SAT
-                    sub_results = {}
-                    for s, solution_bit_value in results.items():
-                        if check_condition(comp_num, s):
-                            # Translate the results using the corresponding
-                            # dictionaries
-                            sub_results[dictionaries[comp_num][s]] = \
-                                solution_bit_value
 
+        # Iterate through each subcipher
+        for comp_num, comp in enumerate(nodes):
+            if model_options.optimization == OPTIMIZATION.MILP:
+                # Build nested sub_results for the sub-cipher directly
+                # from the parent's nested results entry for this comp_num
+                sub_results = {}
+                var_name = f"X{comp_num}"
+                for s_ind, solution_bit_value in \
+                        results.get(var_name, {}).items():
+                    translated = dictionaries[comp_num][
+                        f"{var_name}[{s_ind}]"
+                    ]
+                    tr_name, tr_rest = translated.split('[', 1)
+                    tr_ind = int(tr_rest.rstrip(']'))
+                    sub_results.setdefault(tr_name, {})[tr_ind] = \
+                        solution_bit_value
+            else:  # SAT
+                sub_results = {}
+                for s, solution_bit_value in results.items():
+                    if check_condition(comp_num, s):
+                        # Translate the results using the corresponding
+                        # dictionaries
+                        sub_results[dictionaries[comp_num][s]] = \
+                            solution_bit_value
+            # recurse
+            if not isinstance(comp, Component):
                 self.children.append(TrailNode(
-                        self.cipher_instance.nodes[depths[comp_num]],
-                        model_options=model_options,
-                        results=sub_results
+                    comp,
+                    model_options=model_options,
+                    results=sub_results,
+                    _parent_depth=depths[comp_num]
                 ))
+
+        # link siblings
+        for i in range(len(self.children) - 1):
+            self.children[i].right = self.children[i + 1]
         ########################################################################
 
-        
 
     def _to_hex(self) -> str:
         string = ""
@@ -221,21 +205,20 @@ class TrailNode:
                 string += "\n" + child.__repr__(_depth+1)
         return string
 
+    def to_latex(self, model_options) -> str:
+        string = self.cipher_instance._latex_section(self, model_options)
+        for child in self.children:
+            string += child.to_latex(model_options)
+        return string
+
     def verify_correctness(self):
         r"""
-        Performs a coherence check of the report. It takes each of the
-        intermediate states and checks whether the inputs and outputs match.
-        For that, we build up a tree-like data structure where each displayed
-        layer in the report is represented by a node in the tree.
-        Each node in that tree has the following keys:
+        Performs a coherence check of the report. For each sub-cipher child,
+        it verifies that the intermediate states seen from the parent cipher
+        and from the sub-cipher itself agree.
 
-        - ``children`` -- list of nodes; The children nodes of ``node``
-        - ``right`` -- node; the right sibling-node
-        - ``val`` -- list; the values stored in that node.
-
-        As an example, we assume the report to contain the following values in
-        the states of the ExampleRound cipher (on a wordwise level, for
-        simplicity). We label these states with (i) for integers i.
+        As an example, for ExampleRound = [LinearLayer, SBoxLayer] the
+        following must hold (labelling states as in the report):
 
         ExampleRound:
 
@@ -256,47 +239,44 @@ class TrailNode:
                 ---SBoxLayer--->
             [1, 0, 0, 0, 0, 1, 0, 0] (7)
 
-        Now, it should hold that (1) == (4), (2) == (5), (2) == (6),
-        (3) == (7), just by the fact that these layers are directly connected
-        to each other (if not the same). This is exactly what this method
-        checks for, for any arbitrary cipher.
+        Checks: (1)==(4), (2)==(5), (2)==(6), (3)==(7).
 
-        Note that this is a purely syntatic verification of the report, there
-        is no validation on a semantic level! As an example, it is not
-        guaranteed that (6) == (7), even though it is clear that SBoxes can
-        not change the wordwise activity pattern in any way.
+        For each child at depth d in the parent, this amounts to:
+            parent.bits_in[d]   == child.bits_out[0]    (input match)
+            parent.bits_out[d]  == child.bits_out[-1]   (output match)
 
+        Note that this is a purely syntactic verification of the report, there
+        is no validation on a semantic level!
         """
 
         valid = True
 
-        if self.children == [] or None in (self.input, self.output):
+        if not self.children or None in (self.input, self.output):
             return valid
-        first_child = self.children[0]
-        last_child = self.children[-1]
-
-        bool1 = self.input == first_child.output
-        if self.right is not None:
-            bool2 = self.output == last_child.output
-        else:
-            bool2 = True
-
-        if bool1 and bool2:
-            pass  # everything is fine
-        else:  # incoherent report!
-            valid = False
-            msg = "Report is not coherent"
-            if not bool1:
-                msg += f" between {self.name} and {first_child.name} (1):"
-                msg += f" (self = {self._to_hex()}) | "
-                msg += f"(child[0] = {first_child._to_hex()})."
-            elif not bool2:
-                msg += f" between {self.name} and {last_child.name} (2):"
-                msg += f" (self = {self._to_hex()}) | "
-                msg += f"(child[-1] = {last_child._to_hex()})."
-
-            raise AssertionError(msg)
 
         for child in self.children:
+            d = child._parent_depth
+
+            expected_in  = self.bits_in[d]
+            expected_out = self.bits_out[d]
+            actual_in    = child.bits_out[0]
+            actual_out   = child.bits_out[-1]
+
+            if expected_in and actual_in and expected_in != actual_in:
+                valid = False
+                raise AssertionError(
+                    f"Report is not coherent between {self.name} and "
+                    f"{child.name} (input at depth {d}): "
+                    f"(parent = {expected_in}) | (child = {actual_in})."
+                )
+            if expected_out and actual_out and expected_out != actual_out:
+                valid = False
+                raise AssertionError(
+                    f"Report is not coherent between {self.name} and "
+                    f"{child.name} (output at depth {d}): "
+                    f"(parent = {expected_out}) | (child = {actual_out})."
+                )
+
             valid &= child.verify_correctness()
+
         return valid

--- a/src/civerly/trail.py
+++ b/src/civerly/trail.py
@@ -174,6 +174,8 @@ class TrailNode:
         for i in range(len(self.children) - 1):
             self.children[i].right = self.children[i + 1]
         ########################################################################
+        assert len(self.bits_out[0]) == len(self.input)
+        assert len(self.bits_out[-1]) == len(self.output)
 
 
     def _to_hex(self) -> str:
@@ -254,29 +256,34 @@ class TrailNode:
         if not self.children or None in (self.input, self.output):
             return valid
 
+        dmax = 1 + max([child._parent_depth for child in self.children])
+        off_in  = [0]*dmax
+        off_out = [0]*dmax
+
         for child in self.children:
             d = child._parent_depth
 
-            expected_in  = self.bits_in[d]
-            expected_out = self.bits_out[d]
+            expected_in  = self.bits_in[d][off_in[d] : off_in[d] + len(child.input)]
+            expected_out = self.bits_out[d][off_out[d] : off_out[d] + len(child.output)]
             actual_in    = child.bits_out[0]
             actual_out   = child.bits_out[-1]
 
+            off_in[d]  += len(child.input)
+            off_out[d] += len(child.output)
+
             if expected_in and actual_in and expected_in != actual_in:
-                valid = False
                 raise AssertionError(
                     f"Report is not coherent between {self.name} and "
                     f"{child.name} (input at depth {d}): "
                     f"(parent = {expected_in}) | (child = {actual_in})."
                 )
             if expected_out and actual_out and expected_out != actual_out:
-                valid = False
                 raise AssertionError(
                     f"Report is not coherent between {self.name} and "
                     f"{child.name} (output at depth {d}): "
                     f"(parent = {expected_out}) | (child = {actual_out})."
                 )
 
-            valid &= child.verify_correctness()
+            child.verify_correctness()
 
-        return valid
+        return


### PR DESCRIPTION
Reorganizes the entire program flow of `generate_report` and `get_trail`. Instead of recursive helper functions which do all at once, we divide the process of interpreting MILP-/SAT-results into multiple steps:

- load `results` from file or from `Cipher` attribute
- Construct the `TrailNode` data structure. Done by calling `TrailNode.__init__`
- Verify correctness (done as before)
For `get_trail`, we then return the `TrailNode` of the cipher 

Additionally, for `generate_report` we do:
- Generate Latex string from `TrailNode` structure
- write and compile `.tex` file to get the report
