### PR TITLE
Test/improve cleanup and errors

### DIFF
--- a/docs/source/developer_manual/tests.rst
+++ b/docs/source/developer_manual/tests.rst
@@ -21,9 +21,16 @@ The implementations of ciphers in CiVerLy commonly feature tests like the follow
 
 .. code-block:: sage
 
-   sage: aes.analyse(model_options) # optional - glpk
+   sage: import tempfile
+   sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - glpk  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+   ....:   model_options = MODEL_OPTIONS(..., path=Path(tmpdir))
+   ....:   aes.analyse(model_options)
 
-This test is then only run when the ``sage -t`` invocation contains the optional ``glpk`` flag.
+The ``# optional - glpk`` marker on the ``with`` line causes the entire block to be skipped
+when ``glpk`` is not in the optional flags.
+Using ``tempfile.TemporaryDirectory`` as a context manager guarantees that the generated
+model files are cleaned up automatically, even if the test fails.
+The block is then only run when the ``sage -t`` invocation contains the optional ``glpk`` flag.
 This in turn introduces a new pitfall.
 A developer that forgets to put this optional flag will not notice that it is missing if the solver is installed.
 This then makes the test fail for other developers that do not have the solver installed.
@@ -50,7 +57,10 @@ First, we can mark doctests that will take long time as follows:
 
 .. code-block:: sage
 
-   sage: present_cipher.analyse(model_options) # long
+   sage: import tempfile
+   sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # long  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+   ....:   model_options = MODEL_OPTIONS(..., path=Path(tmpdir))
+   ....:   present_cipher.analyse(model_options)
 
 To include these when running the tests, add ``--long`` to the ``sage -t`` command.
 

--- a/src/civerly/addrx.py
+++ b/src/civerly/addrx.py
@@ -12,13 +12,15 @@ EXAMPLES::
     sage: from civerly.component import ModAdd_CVL, AND_CVL, SBox_CVL
     sage: addrx = AddRX(4, 4, 4, "Cipher")
     sage: edges = [(addrx.IN, (0, 0)), (addrx.IN, (1, 1))]
-    sage: try: addrx.add_subcipher(AND_CVL(4), edges)
-    ....: except TypeError: print("Did not work")
-    Did not work
+    sage: addrx.add_subcipher(AND_CVL(4), edges)
+    Traceback (most recent call last):
+    ...
+    TypeError: AddRX does not accept SBox_CVL and AND_CVL
     sage: e = [(addrx.IN, (0, 0))]
-    sage: try: node = addrx.add_subcipher(SBox_CVL(SBox([0,1,4,3,6,5,2,7])), e)
-    ....: except TypeError: print("Did not work")
-    Did not work
+    sage: addrx.add_subcipher(SBox_CVL(SBox([0,1,4,3,6,5,2,7])), e)
+    Traceback (most recent call last):
+    ...
+    TypeError: AddRX does not accept SBox_CVL and AND_CVL
     sage: edges = [(addrx.IN, (i, i)) for i in range(4)]
     sage: node = addrx.add_subcipher(ModAdd_CVL(8), edges)
 """

--- a/src/civerly/aeslike.py
+++ b/src/civerly/aeslike.py
@@ -24,9 +24,10 @@ EXAMPLES::
     sage: aeslikecipher = AESlike(4, 5, 3, "Cipher") # 5 rows x 3 columns
     sage: modadd = ModAdd_CVL(4)
     sage: edges = [(aeslikecipher.IN, (0, 0)), (aeslikecipher.IN, (1, 0))]
-    sage: try: aeslikecipher.add_subcipher(modadd, edges)
-    ....: except TypeError: print("Did not work")
-    Did not work
+    sage: aeslikecipher.add_subcipher(modadd, edges)
+    Traceback (most recent call last):
+    ...
+    TypeError: The passed sub_cipher has type <class 'civerly.component.ModAdd_CVL'> and is not allowed in SBoxCiphers.
     sage: sb = SBox_CVL(PRESENT)
     sage: for i in range(15):
     ....:   edges = [(aeslikecipher.IN, (i, 0))]

--- a/src/civerly/andrx.py
+++ b/src/civerly/andrx.py
@@ -15,9 +15,10 @@ EXAMPLES::
     sage: node_xor = andrx_cipher.add_subcipher(XOR_CVL(32, name="xor"), edges)
     sage: edges = [(node_xor, (0, 0)), (andrx_cipher.IN, (1, 1))]
     sage: node_and = andrx_cipher.add_subcipher(AND_CVL(32, name="and"), edges)
-    sage: try: andrx_cipher.add_subcipher(SBox_CVL(AES), [(node_and, (0, 0))])
-    ....: except TypeError: print("Did not work")
-    Did not work
+    sage: andrx_cipher.add_subcipher(SBox_CVL(AES), [(node_and, (0, 0))])
+    Traceback (most recent call last):
+    ...
+    TypeError: AndRX does not accept SBox_CVL and ModAdd_CVL
 """
 
 from civerly.wordbasedcipher import WordBasedCipher

--- a/src/civerly/cipher_implementations/abc.py
+++ b/src/civerly/cipher_implementations/abc.py
@@ -75,24 +75,23 @@ class ABC_CVL:
 
         Model ABC in CiVerLy::
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.abc import ABC_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: abc_cipher = ABC_CVL(4)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   solve_range=(0, 10),
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir)
-            ....: )
-            sage: abc_cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   abc_cipher = ABC_CVL(4)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     solve_range=(0, 10),
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir)
+            ....:   )
+            ....:   abc_cipher.analyse(model_options)
             12640 variables and 44257 clauses were written to
             '...'
             [  0 , 10] (trying w =   5) : SAT
@@ -100,8 +99,6 @@ class ABC_CVL:
             [  3 ,  5] (trying w =   4) : SAT
             [  3 ,  4] (trying w =   3) : SAT
             3
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         """
         if rks == []:

--- a/src/civerly/cipher_implementations/abc.py
+++ b/src/civerly/cipher_implementations/abc.py
@@ -78,6 +78,8 @@ class ABC_CVL:
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.abc import ABC_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: abc_cipher = ABC_CVL(4)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -88,16 +90,18 @@ class ABC_CVL:
             ....:   solve_range=(0, 10),
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-ABC-Models/")
+            ....:   path=Path(tmpdir)
             ....: )
             sage: abc_cipher.analyse(model_options)
             12640 variables and 44257 clauses were written to
-            'DOCTEST-ABC-Models/ABC.cnf'
+            '...'
             [  0 , 10] (trying w =   5) : SAT
             [  0 ,  5] (trying w =   2) : UNSAT
             [  3 ,  5] (trying w =   4) : SAT
             [  3 ,  4] (trying w =   3) : SAT
             3
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
         """
         if rks == []:

--- a/src/civerly/cipher_implementations/aes.py
+++ b/src/civerly/cipher_implementations/aes.py
@@ -6,63 +6,47 @@ to exemplary describe the usage of CiVerLy.
 
 EXAMPLES:
 
-First, we want to determine the number of active S-boxes in 10-round AES. For
-this we will use a word-wise model based on the the branch number. As AES is
-already implement in CiVerLy, we can simply import it and instantiate it::
+First, we want to determine the number of active S-boxes in 10-round AES. We
+use a word-wise model based on the branch number. The full list of options is
+given in :class:`civerly.model_options.MODEL_OPTIONS`::
 
     sage: from civerly.cipher_implementations.aes import AES_CVL
-    sage: aes = AES_CVL(R=10)
-
-Next, we have to tell CiVerLy the specifics of the modeling technique we want
-to use. A full list is given in :class:`civerly.model_options.MODEL_OPTIONS`
-but the code below should be rather straightforward::
-
     sage: from civerly.model_options import *
     sage: import tempfile
-    sage: from pathlib import Path
-    sage: tmpdir = tempfile.mkdtemp()
-    sage: model_options = MODEL_OPTIONS(
-    ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-    ....:   optimization=OPTIMIZATION.MILP,
-    ....:   granularity=GRANULARITY.WORDWISE,
-    ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
-    ....:   milp_solver=SCIP_CVL(),
-    ....:   path=Path(tmpdir))
-
-Notice that we set ``sbox_modeling`` to ``None``, as we do not have to model
-the S-box in our wordwise model. Furthermore, the specified path is used for
-storing the generated models. Next, we simply tell CiVerLy to analyse AES::
-
-    sage: # optional - scip
-    sage: aes.analyse(model_options) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - scip  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    ....:   aes = AES_CVL(R=10)
+    ....:   model_options = MODEL_OPTIONS(
+    ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+    ....:       optimization=OPTIMIZATION.MILP,
+    ....:       granularity=GRANULARITY.WORDWISE,
+    ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
+    ....:       milp_solver=SCIP_CVL(),
+    ....:       path=Path(tmpdir))
+    ....:   aes.analyse(model_options)
     2884 variables and 3085 constraints were written to
     '...'
     55
 
-Indeed, there are 55 acitve S-boxes for 10-round AES. We clean up the generated
-files::
+Indeed, there are 55 active S-boxes for 10-round AES. Next up, we want to
+study linear cryptanalysis using the more accurate modeling of MixColumn, which
+requires solving a MILP itself::
 
-    sage: import shutil
-    sage: shutil.rmtree(tmpdir)
-
-Next up, we want to study linear cryptanalysis using the more accurate modeling
-of MixColumn which requires solving a MILP itself::
-
-    sage: # optional - scip
     sage: from civerly.cipher_implementations.aes import AES_CVL
-    sage: aes = AES_CVL(R=10)
-    sage: model_options = MODEL_OPTIONS(
-    ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
-    ....:     optimization=OPTIMIZATION.MILP,
-    ....:     granularity=GRANULARITY.WORDWISE,
-    ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
-    ....:     milp_solver=SCIP_CVL(),
-    ....:     path=Path("./DOCTEST-AES-Models/"))
-    sage: aes.analyse(model_options) # doctest: +NORMALIZE_WHITESPACE
+    sage: from civerly.model_options import *
+    sage: import tempfile
+    sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - scip  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    ....:   aes = AES_CVL(R=10)
+    ....:   model_options = MODEL_OPTIONS(
+    ....:       cryptanalysis=CRYPTANALYSIS.LINEAR,
+    ....:       optimization=OPTIMIZATION.MILP,
+    ....:       granularity=GRANULARITY.WORDWISE,
+    ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
+    ....:       milp_solver=SCIP_CVL(),
+    ....:       path=Path(tmpdir))
+    ....:   aes.analyse(model_options)
     2848 variables and 2977 constraints were written to
-    'DOCTEST-AES-Models/AES.mps'
+    '...'
     55
-    sage: shutil.rmtree("DOCTEST-AES-Models", ignore_errors=True)
 
 Notice that above we use the ``analyse`` function of the ``aes`` cipher.
 While this is rather convenient, it requires the specified solver to be
@@ -176,6 +160,7 @@ the corresponding activity pattern, we can generate a PDF report::
 
 To conclude our example, we remove the generated files::
 
+    sage: import shutil
     sage: shutil.rmtree("DOCTEST-AES-Models", ignore_errors=True)
 """
 from civerly.aeslike import AESlike
@@ -242,98 +227,104 @@ class AES_CVL:
 
             Analyse with other solvers::
 
-                sage: # doctest: +NORMALIZE_WHITESPACE
                 sage: from civerly.cipher_implementations.aes import AES_CVL
                 sage: from civerly.model_options import *
-                sage: from pathlib import Path
-                sage: import shutil
-                sage: aes = AES_CVL(R=2)
-                sage: path = Path("./DOCTEST-AES-Models/")
-                sage: model_options = MODEL_OPTIONS(
-                ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-                ....:     optimization=OPTIMIZATION.MILP,
-                ....:     granularity=GRANULARITY.WORDWISE,
-                ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
-                ....:     milp_solver=GLPK_CVL(),
-                ....:     path=path)
-                sage: aes.analyse(model_options) # optional - glpk
+                sage: import tempfile
+                sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - glpk  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+                ....:   aes = AES_CVL(R=2)
+                ....:   model_options = MODEL_OPTIONS(
+                ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+                ....:       optimization=OPTIMIZATION.MILP,
+                ....:       granularity=GRANULARITY.WORDWISE,
+                ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
+                ....:       milp_solver=GLPK_CVL(),
+                ....:       path=Path(tmpdir))
+                ....:   aes.analyse(model_options)
                 548 variables and 557 constraints were written to
-                'DOCTEST-AES-Models/AES.mps'
+                '...'
                 5
-                sage: shutil.rmtree(path, ignore_errors=True)
-                sage: model_options = MODEL_OPTIONS(
-                ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
-                ....:     optimization=OPTIMIZATION.MILP,
-                ....:     granularity=GRANULARITY.WORDWISE,
-                ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
-                ....:     milp_solver=GLPK_CVL(),
-                ....:     path=path)
-                sage: aes.analyse(model_options) # optional - glpk
+                sage: from civerly.cipher_implementations.aes import AES_CVL
+                sage: from civerly.model_options import *
+                sage: import tempfile
+                sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - glpk  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+                ....:   aes = AES_CVL(R=2)
+                ....:   model_options = MODEL_OPTIONS(
+                ....:       cryptanalysis=CRYPTANALYSIS.LINEAR,
+                ....:       optimization=OPTIMIZATION.MILP,
+                ....:       granularity=GRANULARITY.WORDWISE,
+                ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
+                ....:       milp_solver=GLPK_CVL(),
+                ....:       path=Path(tmpdir))
+                ....:   aes.analyse(model_options)
                 544 variables and 545 constraints were written to
-                'DOCTEST-AES-Models/AES.mps'
+                '...'
                 5
-                sage: shutil.rmtree(path, ignore_errors=True)
-                sage: aes = AES_CVL(R=10)
-                sage: model_options = MODEL_OPTIONS(
-                ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
-                ....:     optimization=OPTIMIZATION.MILP,
-                ....:     granularity=GRANULARITY.WORDWISE,
-                ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
-                ....:     milp_solver=GUROBI_CVL(),
-                ....:     path=path)
-                sage: aes.analyse(model_options) # optional - gurobi
+                sage: from civerly.cipher_implementations.aes import AES_CVL
+                sage: from civerly.model_options import *
+                sage: import tempfile
+                sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+                ....:   aes = AES_CVL(R=10)
+                ....:   model_options = MODEL_OPTIONS(
+                ....:       cryptanalysis=CRYPTANALYSIS.LINEAR,
+                ....:       optimization=OPTIMIZATION.MILP,
+                ....:       granularity=GRANULARITY.WORDWISE,
+                ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
+                ....:       milp_solver=GUROBI_CVL(),
+                ....:       path=Path(tmpdir))
+                ....:   aes.analyse(model_options)
                 2884 variables and 3085 constraints were written to
-                'DOCTEST-AES-Models/AES.mps'
+                '...'
                 55
-                sage: shutil.rmtree(path, ignore_errors=True)
-                sage: model_options = MODEL_OPTIONS(
-                ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-                ....:     optimization=OPTIMIZATION.MILP,
-                ....:     granularity=GRANULARITY.WORDWISE,
-                ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
-                ....:     milp_solver=GUROBI_CVL(),
-                ....:     path=path)
-                sage: aes.analyse(model_options) # optional - gurobi
+                sage: from civerly.cipher_implementations.aes import AES_CVL
+                sage: from civerly.model_options import *
+                sage: import tempfile
+                sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+                ....:   aes = AES_CVL(R=10)
+                ....:   model_options = MODEL_OPTIONS(
+                ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+                ....:       optimization=OPTIMIZATION.MILP,
+                ....:       granularity=GRANULARITY.WORDWISE,
+                ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
+                ....:       milp_solver=GUROBI_CVL(),
+                ....:       path=Path(tmpdir))
+                ....:   aes.analyse(model_options)
                 2848 variables and 2977 constraints were written to
-                'DOCTEST-AES-Models/AES.mps'
+                '...'
                 55
-                sage: shutil.rmtree(path, ignore_errors=True)
 
             Trying the parallel construction
             :math:`F(x_1, x_2) := AES(x_1) || AES(x_2)`:
 
-                sage: # doctest: +NORMALIZE_WHITESPACE
                 sage: from civerly.cipher_implementations.aes import AES_CVL
                 sage: from civerly.model_options import *
                 sage: from civerly.aeslike import AESlike
-                sage: path = Path("./DOCTEST-AES-Models/")
-                sage: cipher = AESlike(8, 4, 8, name="parallelAES")
-                sage: node1 = cipher.add_subcipher(
-                ....:     AES_CVL(R=10),
-                ....:     [(cipher.IN, (i, i)) for i in range(16)])
-                sage: node2 = cipher.add_subcipher(
-                ....:     AES_CVL(R=10),
-                ....:     [(cipher.IN, (i + 16, i)) for i in range(16)])
-                sage: edges = [(node1, (i, i)) for i in range(16)]
-                sage: edges += [(node2, (i, i + 16)) for i in range(16)]
-                sage: cipher.add_output(edges)
-                sage: model_options = MODEL_OPTIONS(
-                ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-                ....:     optimization=OPTIMIZATION.MILP,
-                ....:     granularity=GRANULARITY.WORDWISE,
-                ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
-                ....:     milp_solver=GUROBI_CVL(),
-                ....:     path=path)
-                sage: # optional - gurobi
-                sage: cipher.analyse(model_options)
+                sage: import tempfile
+                sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+                ....:   cipher = AESlike(8, 4, 8, name="parallelAES")
+                ....:   node1 = cipher.add_subcipher(
+                ....:       AES_CVL(R=10),
+                ....:       [(cipher.IN, (i, i)) for i in range(16)])
+                ....:   node2 = cipher.add_subcipher(
+                ....:       AES_CVL(R=10),
+                ....:       [(cipher.IN, (i + 16, i)) for i in range(16)])
+                ....:   edges = [(node1, (i, i)) for i in range(16)]
+                ....:   edges += [(node2, (i, i + 16)) for i in range(16)]
+                ....:   cipher.add_output(edges)
+                ....:   model_options = MODEL_OPTIONS(
+                ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+                ....:       optimization=OPTIMIZATION.MILP,
+                ....:       granularity=GRANULARITY.WORDWISE,
+                ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
+                ....:       milp_solver=GUROBI_CVL(),
+                ....:       path=Path(tmpdir))
+                ....:   cipher.analyse(model_options)
+                ....:   cipher.generate_report(model_options)
+                ....:   trail = str(cipher.get_trail(model_options))
+                ....:   assert "Unnamed Component" not in trail
                 5888 variables and 6145 constraints were written to
-                'DOCTEST-AES-Models/parallelAES.mps'
+                '...'
                 55
-                sage: cipher.generate_report(model_options)
-                Output file in: DOCTEST-AES-Models/parallelAES.pdf
-                sage: trail = str(cipher.get_trail(model_options))
-                sage: assert "Unnamed Component" not in trail
-                sage: shutil.rmtree(path, ignore_errors=True)
+                Output file in: ...
 
             The result shows that roughly half of the states are all-zero,
             which indicates that one of the two AES instances is completely

--- a/src/civerly/cipher_implementations/aes.py
+++ b/src/civerly/cipher_implementations/aes.py
@@ -18,30 +18,32 @@ to use. A full list is given in :class:`civerly.model_options.MODEL_OPTIONS`
 but the code below should be rather straightforward::
 
     sage: from civerly.model_options import *
+    sage: import tempfile
     sage: from pathlib import Path
+    sage: tmpdir = tempfile.mkdtemp()
     sage: model_options = MODEL_OPTIONS(
     ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
     ....:   optimization=OPTIMIZATION.MILP,
     ....:   granularity=GRANULARITY.WORDWISE,
     ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
     ....:   milp_solver=SCIP_CVL(),
-    ....:   path=Path("./DOCTEST-AES-Models/"))
+    ....:   path=Path(tmpdir))
 
 Notice that we set ``sbox_modeling`` to ``None``, as we do not have to model
 the S-box in our wordwise model. Furthermore, the specified path is used for
 storing the generated models. Next, we simply tell CiVerLy to analyse AES::
 
     sage: # optional - scip
-    sage: aes.analyse(model_options) # doctest: +NORMALIZE_WHITESPACE
+    sage: aes.analyse(model_options) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     2884 variables and 3085 constraints were written to
-    'DOCTEST-AES-Models/AES.mps'
+    '...'
     55
 
 Indeed, there are 55 acitve S-boxes for 10-round AES. We clean up the generated
 files::
 
     sage: import shutil
-    sage: shutil.rmtree("DOCTEST-AES-Models", ignore_errors=True)
+    sage: shutil.rmtree(tmpdir)
 
 Next up, we want to study linear cryptanalysis using the more accurate modeling
 of MixColumn which requires solving a MILP itself::

--- a/src/civerly/cipher_implementations/ascon.py
+++ b/src/civerly/cipher_implementations/ascon.py
@@ -32,34 +32,31 @@ class ASCON_CVL:
 
         TESTS::
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.ascon import ASCON_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = ASCON_CVL(R=2)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(7, 9),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   cipher = ASCON_CVL(R=2)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(7, 9),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            ....:   cipher.generate_report(model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             20384 variables and 51649 clauses were written to
             '...'
             [  7 ,  9] (trying w =   8) : SAT
             [  7 ,  8] (trying w =   7) : UNSAT
             8
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
 
         """

--- a/src/civerly/cipher_implementations/ascon.py
+++ b/src/civerly/cipher_implementations/ascon.py
@@ -35,6 +35,8 @@ class ASCON_CVL:
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.ascon import ASCON_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = ASCON_CVL(R=2)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -45,21 +47,19 @@ class ASCON_CVL:
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(7, 9),
-            ....:   path=Path("./DOCTEST-Ascon-Models/"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options=model_options)
             20384 variables and 51649 clauses were written to
-            'DOCTEST-Ascon-Models/ascon.cnf'
+            '...'
             [  7 ,  9] (trying w =   8) : SAT
             [  7 ,  8] (trying w =   7) : UNSAT
             8
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Ascon-Models/ascon.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
-
-        Remove the files:
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Ascon-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
 
         """

--- a/src/civerly/cipher_implementations/chacha.py
+++ b/src/civerly/cipher_implementations/chacha.py
@@ -33,17 +33,19 @@ class ChachaQRF_CVL:
             ....:   import ChachaQRF_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = ChachaQRF_CVL()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   solve_range=(0, 8),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   cipher = ChachaQRF_CVL()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     solve_range=(0, 8),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            ....:   cipher.generate_report(model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             1916 variables and 4957 clauses were written to
             '...'
             [  0 ,  8] (trying w =   4) : SAT
@@ -51,28 +53,25 @@ class ChachaQRF_CVL:
             [  0 ,  2] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.chacha \
             ....:   import ChachaQRF_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = ChachaQRF_CVL()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sat_solver=CADICAL_CVL(),
-            ....:   solve_range=(0, 8),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cadical
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cadical  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   cipher = ChachaQRF_CVL()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sat_solver=CADICAL_CVL(),
+            ....:     solve_range=(0, 8),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            ....:   cipher.generate_report(model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             1916 variables and 4957 clauses were written to
             '...'
             [  0 ,  8] (trying w =   4) : SAT
@@ -80,27 +79,21 @@ class ChachaQRF_CVL:
             [  0 ,  2] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.chacha \
             ....:   import ChachaQRF_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = ChachaQRF_CVL()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   cipher = ChachaQRF_CVL()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             1920 variables and 5797 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -111,8 +104,6 @@ class ChachaQRF_CVL:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         """
         if name is None:
@@ -187,24 +178,21 @@ class Chacha_CVL:
             sage: from civerly.cipher_implementations.chacha import Chacha_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Chacha_CVL(1)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   solve_range=(0, 4),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   cipher = Chacha_CVL(1)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     solve_range=(0, 4),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             22240 variables and 53601 clauses were written to
             '...'
             [  0 ,  4] (trying w =   2) : SAT
             [  0 ,  2] (trying w =   1) : UNSAT
             2
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
 
 

--- a/src/civerly/cipher_implementations/chacha.py
+++ b/src/civerly/cipher_implementations/chacha.py
@@ -32,6 +32,8 @@ class ChachaQRF_CVL:
             sage: from civerly.cipher_implementations.chacha \
             ....:   import ChachaQRF_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = ChachaQRF_CVL()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -39,24 +41,28 @@ class ChachaQRF_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   solve_range=(0, 8),
-            ....:   path=Path("./DOCTEST-ChachaQRF-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
             1916 variables and 4957 clauses were written to
-            'DOCTEST-ChachaQRF-Models/Chacha-QRF.cnf'
+            '...'
             [  0 ,  8] (trying w =   4) : SAT
             [  0 ,  4] (trying w =   2) : SAT
             [  0 ,  2] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-ChachaQRF-Models/Chacha-QRF.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.chacha \
             ....:   import ChachaQRF_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = ChachaQRF_CVL()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -64,35 +70,39 @@ class ChachaQRF_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sat_solver=CADICAL_CVL(),
             ....:   solve_range=(0, 8),
-            ....:   path=Path("./DOCTEST-ChachaQRF-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cadical
             sage: cipher.analyse(model_options=model_options)
             1916 variables and 4957 clauses were written to
-            'DOCTEST-ChachaQRF-Models/Chacha-QRF.cnf'
+            '...'
             [  0 ,  8] (trying w =   4) : SAT
             [  0 ,  4] (trying w =   2) : SAT
             [  0 ,  2] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-ChachaQRF-Models/Chacha-QRF.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.chacha \
             ....:   import ChachaQRF_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = ChachaQRF_CVL()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   path=Path("./DOCTEST-ChachaQRF-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
             1920 variables and 5797 clauses were written to
-            'DOCTEST-ChachaQRF-Models/Chacha-QRF.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -101,10 +111,8 @@ class ChachaQRF_CVL:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
-
             sage: import shutil
-            sage: shutil.rmtree(
-            ....:   "DOCTEST-ChachaQRF-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
         """
         if name is None:
@@ -178,6 +186,8 @@ class Chacha_CVL:
 
             sage: from civerly.cipher_implementations.chacha import Chacha_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Chacha_CVL(1)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -185,16 +195,16 @@ class Chacha_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   solve_range=(0, 4),
-            ....:   path=Path("./DOCTEST-Chacha-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
             22240 variables and 53601 clauses were written to
-            'DOCTEST-Chacha-Models/Chacha.cnf'
+            '...'
             [  0 ,  4] (trying w =   2) : SAT
             [  0 ,  2] (trying w =   1) : UNSAT
             2
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Chacha-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
 
 

--- a/src/civerly/cipher_implementations/craft.py
+++ b/src/civerly/cipher_implementations/craft.py
@@ -40,38 +40,41 @@ class CRAFT_CVL:
         Determine the number of active S-boxes using a word-wise model based
         on the the branch number::
 
+            sage: from civerly.cipher_implementations.craft import CRAFT_CVL
+            sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.WORDWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
-            ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: craft.analyse(model_options) # optional - scip
+            sage: craft = CRAFT_CVL(10)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - scip  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.WORDWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
+            ....:     milp_solver=SCIP_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   craft.analyse(model_options)
             5896 variables and 6121 constraints were written to
             '...'
             10
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir) # optional - scip
 
         Now the improved modeling::
 
+            sage: from civerly.cipher_implementations.craft import CRAFT_CVL
+            sage: from civerly.model_options import *
+            sage: import tempfile
             sage: craft = CRAFT_CVL(10)
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.WORDWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
-            ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: craft.analyse(model_options) # optional - scip
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - scip  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.WORDWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
+            ....:     milp_solver=SCIP_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   craft.analyse(model_options)
             5856 variables and 6041 constraints were written to
             '...'
             36
-            sage: shutil.rmtree(tmpdir) # optional - scip
 
         Indeed, 36 active S-boxes is a much better bound.
 
@@ -79,21 +82,23 @@ class CRAFT_CVL:
         linear trail through CRAFT, we can use bitwise modeling. However,
         this is computationally more difficult than the previous tests::
 
+            sage: from civerly.cipher_implementations.craft import CRAFT_CVL
+            sage: from civerly.model_options import *
+            sage: import tempfile
             sage: craft = CRAFT_CVL(3)
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.CONVEX_HULL,
-            ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: craft.analyse(model_options) # optional - scip
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - scip  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.CONVEX_HULL,
+            ....:     sbox_modeling=SBOX_MODELING.CONVEX_HULL,
+            ....:     milp_solver=SCIP_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   craft.analyse(model_options)
             7440 variables and 9057 constraints were written to
             '...'
             8
-            sage: shutil.rmtree(tmpdir) # optional - scip
 
         Here the objective value is :math:`- \log_2(p)`, with :math:`p` being
         the differential probability (or respectively the linear correlation)
@@ -102,42 +107,45 @@ class CRAFT_CVL:
         We repeat the same experiment but this time use dummy variables to
         model the linear layer::
 
+            sage: from civerly.cipher_implementations.craft import CRAFT_CVL
+            sage: from civerly.model_options import *
+            sage: import tempfile
             sage: craft = CRAFT_CVL(3)
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: craft.analyse(model_options) # optional - scip
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - scip  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:     sbox_modeling=SBOX_MODELING.CONVEX_HULL,
+            ....:     milp_solver=SCIP_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   craft.analyse(model_options)
             7728 variables and 8001 constraints were written to
             '...'
             8
-            sage: shutil.rmtree(tmpdir) # optional - scip
-
 
         It is also possible to use SAT to model the cipher. The results should
         match those that MILP-modeling produces::
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.craft import CRAFT_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
             sage: craft = CRAFT_CVL(3)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: craft.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   craft.analyse(model_options)
+            ....:   craft.generate_report(model_options)
+            ....:   trail = str(craft.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             7440 variables and 17201 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -148,31 +156,28 @@ class CRAFT_CVL:
             [  7 ,  9] (trying w =   8) : SAT
             [  7 ,  8] (trying w =   7) : UNSAT
             8
-            sage: craft.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: trail = str(craft.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         Now with CaDiCaL as solver::
 
-            sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.craft import CRAFT_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
             sage: craft = CRAFT_CVL(3)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CADICAL_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: craft.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cadical  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CADICAL_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   craft.analyse(model_options)
+            ....:   craft.generate_report(model_options)
+            ....:   trail = str(craft.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             7440 variables and 17201 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -183,12 +188,7 @@ class CRAFT_CVL:
             [  7 ,  9] (trying w =   8) : SAT
             [  7 ,  8] (trying w =   7) : UNSAT
             8
-            sage: craft.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: trail = str(craft.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
 
 

--- a/src/civerly/cipher_implementations/craft.py
+++ b/src/civerly/cipher_implementations/craft.py
@@ -40,40 +40,38 @@ class CRAFT_CVL:
         Determine the number of active S-boxes using a word-wise model based
         on the the branch number::
 
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.WORDWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
             ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path("./DOCTEST-CRAFT-Models/"))
+            ....:   path=Path(tmpdir))
             sage: craft.analyse(model_options) # optional - scip
             5896 variables and 6121 constraints were written to
-            'DOCTEST-CRAFT-Models/CRAFT.mps'
+            '...'
             10
-
-        Notice that the bound of 10 active S-boxes is rather trivial (one
-        per round). Hence, this is a good example of why the more accurate
-        modeling of the linear layer is useful. But first some cleanup::
-
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-CRAFT-Models", ignore_errors=True) # optional - scip
+            sage: shutil.rmtree(tmpdir) # optional - scip
 
         Now the improved modeling::
 
             sage: craft = CRAFT_CVL(10)
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.WORDWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
             ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path("./DOCTEST-CRAFT-Models/"))
+            ....:   path=Path(tmpdir))
             sage: craft.analyse(model_options) # optional - scip
             5856 variables and 6041 constraints were written to
-            'DOCTEST-CRAFT-Models/CRAFT.mps'
+            '...'
             36
-            sage: shutil.rmtree("DOCTEST-CRAFT-Models", ignore_errors=True) # optional - scip
+            sage: shutil.rmtree(tmpdir) # optional - scip
 
         Indeed, 36 active S-boxes is a much better bound.
 
@@ -82,6 +80,7 @@ class CRAFT_CVL:
         this is computationally more difficult than the previous tests::
 
             sage: craft = CRAFT_CVL(3)
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.MILP,
@@ -89,12 +88,12 @@ class CRAFT_CVL:
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.CONVEX_HULL,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
             ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path("./DOCTEST-CRAFT-Models/"))
+            ....:   path=Path(tmpdir))
             sage: craft.analyse(model_options) # optional - scip
             7440 variables and 9057 constraints were written to
-            'DOCTEST-CRAFT-Models/CRAFT.mps'
+            '...'
             8
-            sage: shutil.rmtree("DOCTEST-CRAFT-Models", ignore_errors=True) # optional - scip
+            sage: shutil.rmtree(tmpdir) # optional - scip
 
         Here the objective value is :math:`- \log_2(p)`, with :math:`p` being
         the differential probability (or respectively the linear correlation)
@@ -104,6 +103,7 @@ class CRAFT_CVL:
         model the linear layer::
 
             sage: craft = CRAFT_CVL(3)
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.MILP,
@@ -111,12 +111,12 @@ class CRAFT_CVL:
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
             ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path("./DOCTEST-CRAFT-Models/"))
+            ....:   path=Path(tmpdir))
             sage: craft.analyse(model_options) # optional - scip
             7728 variables and 8001 constraints were written to
-            'DOCTEST-CRAFT-Models/CRAFT.mps'
+            '...'
             8
-            sage: shutil.rmtree("DOCTEST-CRAFT-Models", ignore_errors=True) # optional - scip
+            sage: shutil.rmtree(tmpdir) # optional - scip
 
 
         It is also possible to use SAT to model the cipher. The results should
@@ -125,6 +125,8 @@ class CRAFT_CVL:
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.craft import CRAFT_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: craft = CRAFT_CVL(3)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -134,10 +136,10 @@ class CRAFT_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-CRAFT-Models/"))
+            ....:   path=Path(tmpdir))
             sage: craft.analyse(model_options)
             7440 variables and 17201 clauses were written to
-            'DOCTEST-CRAFT-Models/CRAFT.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -146,18 +148,20 @@ class CRAFT_CVL:
             [  7 ,  9] (trying w =   8) : SAT
             [  7 ,  8] (trying w =   7) : UNSAT
             8
-            sage: craft.generate_report(model_options)
-            Output file in: DOCTEST-CRAFT-Models/CRAFT.pdf
+            sage: craft.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: trail = str(craft.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-CRAFT-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
         Now with CaDiCaL as solver::
 
             sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.craft import CRAFT_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: craft = CRAFT_CVL(3)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -167,10 +171,10 @@ class CRAFT_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CADICAL_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-CRAFT-Models/"))
+            ....:   path=Path(tmpdir))
             sage: craft.analyse(model_options)
             7440 variables and 17201 clauses were written to
-            'DOCTEST-CRAFT-Models/CRAFT.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -179,12 +183,12 @@ class CRAFT_CVL:
             [  7 ,  9] (trying w =   8) : SAT
             [  7 ,  8] (trying w =   7) : UNSAT
             8
-            sage: craft.generate_report(model_options)
-            Output file in: DOCTEST-CRAFT-Models/CRAFT.pdf
+            sage: craft.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: trail = str(craft.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-CRAFT-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
 
 

--- a/src/civerly/cipher_implementations/des.py
+++ b/src/civerly/cipher_implementations/des.py
@@ -37,6 +37,8 @@ class DES_F_CVL:
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.des import DES_F_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = DES_F_CVL()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -47,19 +49,21 @@ class DES_F_CVL:
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(0, 4),
-            ....:   path=Path("DOCTEST-DESF-Models"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options=model_options)
             582 variables and 4612 clauses were written to
-            'DOCTEST-DESF-Models/f.cnf'
+            '...'
             [  0 ,  4] (trying w =   2) : SAT
             [  0 ,  2] (trying w =   1) : UNSAT
             2
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-DESF-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
             sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.des import DES_F_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = DES_F_CVL()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -70,18 +74,22 @@ class DES_F_CVL:
             ....:   sat_solver=CADICAL_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(0, 4),
-            ....:   path=Path("DOCTEST-DESF-Models"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options=model_options)
             582 variables and 4612 clauses were written to
-            'DOCTEST-DESF-Models/f.cnf'
+            '...'
             [  0 ,  4] (trying w =   2) : SAT
             [  0 ,  2] (trying w =   1) : UNSAT
             2
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
         Using MILP modeling::
 
             sage: from civerly.cipher_implementations.des import DES_F_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = DES_F_CVL()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -91,17 +99,16 @@ class DES_F_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   milp_solver=GUROBI_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("DOCTEST-DESF-Models"))
+            ....:   path=Path(tmpdir))
             sage: # optional - gurobi # optional - espresso
             sage: cipher.analyse(model_options=model_options)
             630 variables and 4164 constraints were written to
-            'DOCTEST-DESF-Models/f.mps'
+            '...'
             2
-            sage: cipher.generate_report(model_options=model_options)
-            Output file in: DOCTEST-DESF-Models/f.pdf
-
+            sage: cipher.generate_report(model_options=model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-DESF-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
         """
         f = SBoxCipher(32, 32, name="f")
@@ -217,6 +224,8 @@ class DES_CVL:
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.des import DES_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = DES_CVL(R=3)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -227,10 +236,10 @@ class DES_CVL:
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(0, 10),
-            ....:   path=Path("DOCTEST-DES-Models"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options=model_options)
             3826 variables and 18250 clauses were written to
-            'DOCTEST-DES-Models/DES.cnf'
+            '...'
             [  0 , 10] (trying w =   5) : SAT
             [  0 ,  5] (trying w =   2) : UNSAT
             [  3 ,  5] (trying w =   4) : SAT
@@ -239,7 +248,7 @@ class DES_CVL:
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-DES-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
         """
         if name is None:

--- a/src/civerly/cipher_implementations/des.py
+++ b/src/civerly/cipher_implementations/des.py
@@ -34,81 +34,72 @@ class DES_F_CVL:
             sage: vec_to_int(des_f(int_to_vec(0xC9EFE379, 32))) == 0xC2DBC430
             True
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.des import DES_F_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = DES_F_CVL()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(0, 4),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   cipher = DES_F_CVL()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(0, 4),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             582 variables and 4612 clauses were written to
             '...'
             [  0 ,  4] (trying w =   2) : SAT
             [  0 ,  2] (trying w =   1) : UNSAT
             2
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
-            sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.des import DES_F_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = DES_F_CVL()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CADICAL_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(0, 4),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cadical  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   cipher = DES_F_CVL()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CADICAL_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(0, 4),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             582 variables and 4612 clauses were written to
             '...'
             [  0 ,  4] (trying w =   2) : SAT
             [  0 ,  2] (trying w =   1) : UNSAT
             2
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         Using MILP modeling::
 
             sage: from civerly.cipher_implementations.des import DES_F_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = DES_F_CVL()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   milp_solver=GUROBI_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - gurobi # optional - espresso
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   cipher = DES_F_CVL()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     milp_solver=GUROBI_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            ....:   cipher.generate_report(model_options=model_options)
             630 variables and 4164 constraints were written to
             '...'
             2
-            sage: cipher.generate_report(model_options=model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         """
         f = SBoxCipher(32, 32, name="f")
@@ -221,23 +212,24 @@ class DES_CVL:
             ....:   == 0x893D51EC4B563B53
             True
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.des import DES_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = DES_CVL(R=3)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(0, 10),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   cipher = DES_CVL(R=3)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(0, 10),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             3826 variables and 18250 clauses were written to
             '...'
             [  0 , 10] (trying w =   5) : SAT
@@ -245,10 +237,6 @@ class DES_CVL:
             [  3 ,  5] (trying w =   4) : SAT
             [  3 ,  4] (trying w =   3) : UNSAT
             4
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         """
         if name is None:

--- a/src/civerly/cipher_implementations/gift.py
+++ b/src/civerly/cipher_implementations/gift.py
@@ -23,6 +23,8 @@ class GIFT_CVL:
             sage: from civerly.cipher_implementations.gift import GIFT_CVL
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: gift_cipher = GIFT_CVL(R=2)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -30,18 +32,20 @@ class GIFT_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
             ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path("./DOCTEST-GIFT-Models/")
+            ....:   path=Path(tmpdir)
             ....: )
             sage: gift_cipher.analyse(model_options) # optional - scip
             2560 variables and 2849 constraints were written to
-            'DOCTEST-GIFT-Models/GIFT.mps'
+            '...'
             3.4150374993
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-GIFT-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.gift import GIFT_CVL
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: gift_cipher = GIFT_CVL(R=2)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -50,18 +54,20 @@ class GIFT_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   milp_solver=SCIP_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-GIFT-Models/")
+            ....:   path=Path(tmpdir)
             ....: )
             sage: gift_cipher.analyse(model_options) # optional - scip # optional - espresso
             2560 variables and 4161 constraints were written to
-            'DOCTEST-GIFT-Models/GIFT.mps'
+            '...'
             3.4150374993
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-GIFT-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.gift import GIFT_CVL
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: gift_cipher = GIFT_CVL(R=2)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -69,14 +75,14 @@ class GIFT_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.DISTORTED_BALL,
             ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path("./DOCTEST-GIFT-Models/")
+            ....:   path=Path(tmpdir)
             ....: )
             sage: gift_cipher.analyse(model_options) # optional - scip
             2560 variables and 3585 constraints were written to
-            'DOCTEST-GIFT-Models/GIFT.mps'
+            '...'
             3.4150374993
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-GIFT-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
         Model the cipher with SAT using different values for ``sat_precision``:
 
@@ -84,6 +90,8 @@ class GIFT_CVL:
             sage: from civerly.cipher_implementations.gift import GIFT_CVL
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: gift_cipher = GIFT_CVL(R=2)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -93,11 +101,11 @@ class GIFT_CVL:
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-GIFT-Models/")
+            ....:   path=Path(tmpdir)
             ....: )
             sage: gift_cipher.analyse(model_options)
             2560 variables and 6401 clauses were written to
-            'DOCTEST-GIFT-Models/GIFT.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -107,12 +115,14 @@ class GIFT_CVL:
             [  2 ,  3] (trying w =   2) : UNSAT
             3
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-GIFT-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.gift import GIFT_CVL
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: gift_cipher = GIFT_CVL(R=2)
             sage: model_options = MODEL_OPTIONS(
             ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -124,11 +134,11 @@ class GIFT_CVL:
             ....:   sat_precision=1,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-GIFT-Models/")
+            ....:   path=Path(tmpdir)
             ....: )
             sage: gift_cipher.analyse(model_options)
             2560 variables and 6401 clauses were written to
-            'DOCTEST-GIFT-Models/GIFT.cnf'
+            '...'
             [ 0.0 ,10.0] (trying w =  5.0) : SAT
             [ 0.0 , 5.0] (trying w =  2.5) : UNSAT
             [ 2.6 , 5.0] (trying w =  3.8) : SAT
@@ -138,7 +148,7 @@ class GIFT_CVL:
             [ 3.3 , 3.4] (trying w =  3.3) : UNSAT
             3.4
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-GIFT-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
         Simulate external Espresso minimization::
 
@@ -146,6 +156,8 @@ class GIFT_CVL:
             sage: from civerly.cipher_implementations.gift import GIFT_CVL
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: gift_cipher = GIFT_CVL(R=2)
             sage: model_options = MODEL_OPTIONS(
             ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -157,17 +169,17 @@ class GIFT_CVL:
             ....:   sat_precision=1,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=None,
-            ....:   path=Path("./DOCTEST-GIFT-Models/")
+            ....:   path=Path(tmpdir)
             ....: )
             sage: gift_cipher.analyse(model_options)
             Optimization problem for Espresso has been written to...
             sage: import os
             sage: _ = os.popen("espresso -epos "
-            ....: "DOCTEST-GIFT-Models/espresso-d1bda7a_in.pla > "
-            ....: "DOCTEST-GIFT-Models/espresso-d1bda7a_out.pla").read()
+            ....: f"{tmpdir}/espresso-d1bda7a_in.pla > "
+            ....: f"{tmpdir}/espresso-d1bda7a_out.pla").read()
             sage: gift_cipher.analyse(model_options)
             Using existing file ..., make sure it is up to date!
-            2560 variables and 6401 clauses were written to 'DOCTEST-GIFT-Models/GIFT.cnf'
+            2560 variables and 6401 clauses were written to '...'
             [ 0.0 ,10.0] (trying w =  5.0) : SAT
             [ 0.0 , 5.0] (trying w =  2.5) : UNSAT
             [ 2.6 , 5.0] (trying w =  3.8) : SAT
@@ -177,7 +189,7 @@ class GIFT_CVL:
             [ 3.3 , 3.4] (trying w =  3.3) : UNSAT
             3.4
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-GIFT-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
         """
         if name is None:

--- a/src/civerly/cipher_implementations/gift.py
+++ b/src/civerly/cipher_implementations/gift.py
@@ -24,86 +24,79 @@ class GIFT_CVL:
             sage: from civerly.model_options import *
             sage: from pathlib import Path
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: gift_cipher = GIFT_CVL(R=2)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path(tmpdir)
-            ....: )
-            sage: gift_cipher.analyse(model_options) # optional - scip
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - scip  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   gift_cipher = GIFT_CVL(R=2)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.MILP,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       sbox_modeling=SBOX_MODELING.CONVEX_HULL,
+            ....:       milp_solver=SCIP_CVL(),
+            ....:       path=Path(tmpdir)
+            ....:   )
+            ....:   gift_cipher.analyse(model_options)
             2560 variables and 2849 constraints were written to
             '...'
             3.4150374993
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.gift import GIFT_CVL
             sage: from civerly.model_options import *
             sage: from pathlib import Path
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: gift_cipher = GIFT_CVL(R=2)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   milp_solver=SCIP_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir)
-            ....: )
-            sage: gift_cipher.analyse(model_options) # optional - scip # optional - espresso
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - scip  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   gift_cipher = GIFT_CVL(R=2)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     milp_solver=SCIP_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir)
+            ....:   )
+            ....:   gift_cipher.analyse(model_options) 
             2560 variables and 4161 constraints were written to
             '...'
             3.4150374993
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
-
+            
             sage: from civerly.cipher_implementations.gift import GIFT_CVL
             sage: from civerly.model_options import *
             sage: from pathlib import Path
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: gift_cipher = GIFT_CVL(R=2)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.DISTORTED_BALL,
-            ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path(tmpdir)
-            ....: )
-            sage: gift_cipher.analyse(model_options) # optional - scip
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - scip  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   gift_cipher = GIFT_CVL(R=2)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.DISTORTED_BALL,
+            ....:     milp_solver=SCIP_CVL(),
+            ....:     path=Path(tmpdir)
+            ....:   )
+            ....:   gift_cipher.analyse(model_options) 
             2560 variables and 3585 constraints were written to
             '...'
             3.4150374993
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         Model the cipher with SAT using different values for ``sat_precision``:
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.gift import GIFT_CVL
             sage: from civerly.model_options import *
             sage: from pathlib import Path
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: gift_cipher = GIFT_CVL(R=2)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir)
-            ....: )
-            sage: gift_cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   gift_cipher = GIFT_CVL(R=2)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir)
+            ....:   )
+            ....:   gift_cipher.analyse(model_options)
             2560 variables and 6401 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -114,29 +107,26 @@ class GIFT_CVL:
             [  0 ,  3] (trying w =   1) : UNSAT
             [  2 ,  3] (trying w =   2) : UNSAT
             3
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.gift import GIFT_CVL
             sage: from civerly.model_options import *
             sage: from pathlib import Path
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: gift_cipher = GIFT_CVL(R=2)
-            sage: model_options = MODEL_OPTIONS(
-            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   solve_range=(0, 10),
-            ....:   sat_precision=1,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir)
-            ....: )
-            sage: gift_cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   gift_cipher = GIFT_CVL(R=2)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     solve_range=(0, 10),
+            ....:     sat_precision=1,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir)
+            ....:   )
+            ....:   gift_cipher.analyse(model_options)
             2560 variables and 6401 clauses were written to
             '...'
             [ 0.0 ,10.0] (trying w =  5.0) : SAT
@@ -147,37 +137,34 @@ class GIFT_CVL:
             [ 3.3 , 3.5] (trying w =  3.4) : SAT
             [ 3.3 , 3.4] (trying w =  3.3) : UNSAT
             3.4
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         Simulate external Espresso minimization::
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.gift import GIFT_CVL
             sage: from civerly.model_options import *
             sage: from pathlib import Path
-            sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: gift_cipher = GIFT_CVL(R=2)
-            sage: model_options = MODEL_OPTIONS(
-            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   solve_range=(0, 10),
-            ....:   sat_precision=1,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=None,
-            ....:   path=Path(tmpdir)
-            ....: )
-            sage: gift_cipher.analyse(model_options)
-            Optimization problem for Espresso has been written to...
             sage: import os
-            sage: _ = os.popen("espresso -epos "
-            ....: f"{tmpdir}/espresso-d1bda7a_in.pla > "
-            ....: f"{tmpdir}/espresso-d1bda7a_out.pla").read()
-            sage: gift_cipher.analyse(model_options)
+            sage: import tempfile
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso
+            ....:   gift_cipher = GIFT_CVL(R=2)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     solve_range=(0, 10),
+            ....:     sat_precision=1,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=None,
+            ....:     path=Path(tmpdir)
+            ....:   )
+            ....:   gift_cipher.analyse(model_options)
+            ....:   _ = os.popen("espresso -epos "
+            ....:   f"{tmpdir}/espresso-d1bda7a_in.pla > "
+            ....:   f"{tmpdir}/espresso-d1bda7a_out.pla").read()
+            ....:   gift_cipher.analyse(model_options)
+            Optimization problem for Espresso has been written to...
             Using existing file ..., make sure it is up to date!
             2560 variables and 6401 clauses were written to '...'
             [ 0.0 ,10.0] (trying w =  5.0) : SAT
@@ -188,8 +175,6 @@ class GIFT_CVL:
             [ 3.3 , 3.5] (trying w =  3.4) : SAT
             [ 3.3 , 3.4] (trying w =  3.3) : UNSAT
             3.4
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         """
         if name is None:

--- a/src/civerly/cipher_implementations/present.py
+++ b/src/civerly/cipher_implementations/present.py
@@ -41,6 +41,8 @@ class PRESENT_CVL:
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: present_cipher = PRESENT_CVL(R=4)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -48,16 +50,16 @@ class PRESENT_CVL:
             ....:   granularity=GRANULARITY.WORDWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
             ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path("./DOCTEST-PRESENT-Models/"))
+            ....:   path=Path(tmpdir))
             sage: present_cipher.analyse(model_options) # optional - scip
             1284 variables and 1341 constraints were written to
-            'DOCTEST-PRESENT-Models/PRESENT.mps'
+            '...'
             4
 
         Clean-up of the generated files::
 
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-PRESENT-Models") # optional - scip
+            sage: shutil.rmtree(tmpdir) # optional - scip
 
         Of course, since the branch number of any word-permutation is 2, this
         result is not very interesting and unprecise, as the optimal solution
@@ -86,6 +88,8 @@ class PRESENT_CVL:
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: present_cipher = PRESENT_CVL(R=4)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -93,13 +97,13 @@ class PRESENT_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
             ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path("./DOCTEST-PRESENT-Models/"))
+            ....:   path=Path(tmpdir))
             sage: present_cipher.analyse(model_options) # optional - scip
             5312 variables and 6081 constraints were written to
-            'DOCTEST-PRESENT-Models/PRESENT.mps'
+            '...'
             12
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-PRESENT-Models") # optional - scip
+            sage: shutil.rmtree(tmpdir) # optional - scip
 
         Here, the analysis output 12 means that the best differential trail
         over 4 rounds of PRESENT has a probability of :math:`2^{-12}`.
@@ -133,6 +137,8 @@ class PRESENT_CVL:
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: present_cipher = PRESENT_CVL(R=4)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -140,18 +146,20 @@ class PRESENT_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
             ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path("./DOCTEST-PRESENT-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - gurobi
             sage: present_cipher.analyse(model_options)
             5312 variables and 6081 constraints were written to
-            'DOCTEST-PRESENT-Models/PRESENT.mps'
+            '...'
             12
-            sage: present_cipher.generate_report(model_options)
-            Output file in: DOCTEST-PRESENT-Models/PRESENT.pdf
+            sage: present_cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
 
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: present_cipher = PRESENT_CVL(R=4)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -160,18 +168,20 @@ class PRESENT_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   milp_solver=GUROBI_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-PRESENT-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - gurobi # optional - espresso
             sage: present_cipher.analyse(model_options)
             5312 variables and 8641 constraints were written to
-            'DOCTEST-PRESENT-Models/PRESENT.mps'
+            '...'
             12
-            sage: present_cipher.generate_report(model_options)
-            Output file in: DOCTEST-PRESENT-Models/PRESENT.pdf
+            sage: present_cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
 
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: present_cipher = PRESENT_CVL(R=4)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -179,19 +189,19 @@ class PRESENT_CVL:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sbox_modeling=SBOX_MODELING.DISTORTED_BALL,
             ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path("./DOCTEST-PRESENT-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - gurobi
             sage: present_cipher.analyse(model_options) # long
             5312 variables and 6977 constraints were written to
-            'DOCTEST-PRESENT-Models/PRESENT.mps'
+            '...'
             12
-            sage: present_cipher.generate_report(model_options)
-            Output file in: DOCTEST-PRESENT-Models/PRESENT.pdf
+            sage: present_cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
 
         Clean up temporary MILP files::
 
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-PRESENT-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
         Model the cipher with SAT:
 
@@ -199,6 +209,8 @@ class PRESENT_CVL:
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: present_cipher = PRESENT_CVL(R=4)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -208,10 +220,10 @@ class PRESENT_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-PRESENT-Models/"))
+            ....:   path=Path(tmpdir))
             sage: present_cipher.analyse(model_options)
             5312 variables and 13441 clauses were written to
-            'DOCTEST-PRESENT-Models/PRESENT.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -222,12 +234,14 @@ class PRESENT_CVL:
             sage: trail = str(present_cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-PRESENT-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
             sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: present_cipher = PRESENT_CVL(R=4)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -237,10 +251,10 @@ class PRESENT_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CADICAL_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-PRESENT-Models/"))
+            ....:   path=Path(tmpdir))
             sage: present_cipher.analyse(model_options)
             5312 variables and 13441 clauses were written to
-            'DOCTEST-PRESENT-Models/PRESENT.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -251,7 +265,7 @@ class PRESENT_CVL:
             sage: trail = str(present_cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-PRESENT-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 
@@ -261,6 +275,8 @@ class PRESENT_CVL:
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: present_cipher = PRESENT_CVL(R=4)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
@@ -270,10 +286,10 @@ class PRESENT_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-PRESENT-Models/"))
+            ....:   path=Path(tmpdir))
             sage: present_cipher.analyse(model_options)
             5312 variables and 12993 clauses were written to
-            'DOCTEST-PRESENT-Models/PRESENT.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -284,12 +300,14 @@ class PRESENT_CVL:
             sage: trail = str(present_cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-PRESENT-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: present_cipher = PRESENT_CVL(R=4)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
@@ -299,10 +317,10 @@ class PRESENT_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-PRESENT-Models/"))
+            ....:   path=Path(tmpdir))
             sage: present_cipher.analyse(model_options)
             5312 variables and 12993 clauses were written to
-            'DOCTEST-PRESENT-Models/PRESENT.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -311,12 +329,14 @@ class PRESENT_CVL:
             [  4 ,  6] (trying w =   5) : UNSAT
             6
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-PRESENT-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: present_cipher = PRESENT_CVL(R=5)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
@@ -326,10 +346,10 @@ class PRESENT_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-PRESENT-Models/"))
+            ....:   path=Path(tmpdir))
             sage: present_cipher.analyse(model_options)
             6512 variables and 16017 clauses were written to
-            'DOCTEST-PRESENT-Models/PRESENT.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -341,7 +361,7 @@ class PRESENT_CVL:
             sage: trail = str(present_cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-PRESENT-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
         Simulate external Espresso minimization::
 
@@ -349,6 +369,8 @@ class PRESENT_CVL:
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: present_cipher = PRESENT_CVL(R=5)
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
@@ -358,17 +380,17 @@ class PRESENT_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=None,
-            ....:   path=Path("./DOCTEST-PRESENT-Models/"))
+            ....:   path=Path(tmpdir))
             sage: present_cipher.analyse(model_options)
             Optimization problem for Espresso has been written to...
             sage: import os
             sage: _ = os.popen("espresso -epos "
-            ....: "DOCTEST-PRESENT-Models/espresso-1c52f72b_in.pla > "
-            ....: "DOCTEST-PRESENT-Models/espresso-1c52f72b_out.pla").read()
+            ....: f"{tmpdir}/espresso-1c52f72b_in.pla > "
+            ....: f"{tmpdir}/espresso-1c52f72b_out.pla").read()
             sage: present_cipher.analyse(model_options)
             Using existing file ..., make sure it is up to date!
             6512 variables and 16017 clauses were written to
-            'DOCTEST-PRESENT-Models/PRESENT.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -378,7 +400,7 @@ class PRESENT_CVL:
             [  7 ,  8] (trying w =   7) : UNSAT
             8
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-PRESENT-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
         """
         if name is None:

--- a/src/civerly/cipher_implementations/present.py
+++ b/src/civerly/cipher_implementations/present.py
@@ -40,26 +40,20 @@ class PRESENT_CVL:
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
-            sage: from pathlib import Path
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
             sage: present_cipher = PRESENT_CVL(R=4)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.WORDWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
-            ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: present_cipher.analyse(model_options) # optional - scip
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - scip  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.WORDWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
+            ....:     milp_solver=SCIP_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   present_cipher.analyse(model_options)
             1284 variables and 1341 constraints were written to
             '...'
             4
-
-        Clean-up of the generated files::
-
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir) # optional - scip
 
         Of course, since the branch number of any word-permutation is 2, this
         result is not very interesting and unprecise, as the optimal solution
@@ -89,21 +83,19 @@ class PRESENT_CVL:
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
             sage: present_cipher = PRESENT_CVL(R=4)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: present_cipher.analyse(model_options) # optional - scip
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - scip  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.CONVEX_HULL,
+            ....:     milp_solver=SCIP_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   present_cipher.analyse(model_options)
             5312 variables and 6081 constraints were written to
             '...'
             12
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir) # optional - scip
 
         Here, the analysis output 12 means that the best differential trail
         over 4 rounds of PRESENT has a probability of :math:`2^{-12}`.
@@ -138,90 +130,83 @@ class PRESENT_CVL:
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
             sage: present_cipher = PRESENT_CVL(R=4)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - gurobi
-            sage: present_cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.CONVEX_HULL,
+            ....:     milp_solver=GUROBI_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   present_cipher.analyse(model_options)
+            ....:   present_cipher.generate_report(model_options)
             5312 variables and 6081 constraints were written to
             '...'
             12
-            sage: present_cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
 
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
             sage: present_cipher = PRESENT_CVL(R=4)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   milp_solver=GUROBI_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - gurobi # optional - espresso
-            sage: present_cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     milp_solver=GUROBI_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   present_cipher.analyse(model_options)
+            ....:   present_cipher.generate_report(model_options)
             5312 variables and 8641 constraints were written to
             '...'
             12
-            sage: present_cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
 
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
             sage: present_cipher = PRESENT_CVL(R=4)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.DISTORTED_BALL,
-            ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - gurobi
-            sage: present_cipher.analyse(model_options) # long
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # long  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.DISTORTED_BALL,
+            ....:     milp_solver=GUROBI_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   present_cipher.analyse(model_options)
+            ....:   present_cipher.generate_report(model_options)
             5312 variables and 6977 constraints were written to
             '...'
             12
-            sage: present_cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-
-        Clean up temporary MILP files::
-
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
         Model the cipher with SAT:
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: present_cipher = PRESENT_CVL(R=4)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: present_cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   present_cipher = PRESENT_CVL(R=4)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   present_cipher.analyse(model_options)
+            ....:   trail = str(present_cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             5312 variables and 13441 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -231,28 +216,25 @@ class PRESENT_CVL:
             [  7 , 12] (trying w =   9) : UNSAT
             [ 10 , 12] (trying w =  11) : UNSAT
             12
-            sage: trail = str(present_cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
-            sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: present_cipher = PRESENT_CVL(R=4)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CADICAL_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: present_cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cadical  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   present_cipher = PRESENT_CVL(R=4)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CADICAL_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   present_cipher.analyse(model_options)
+            ....:   trail = str(present_cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             5312 variables and 13441 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -262,32 +244,27 @@ class PRESENT_CVL:
             [  7 , 12] (trying w =   9) : UNSAT
             [ 10 , 12] (trying w =  11) : UNSAT
             12
-            sage: trail = str(present_cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir, ignore_errors=True)
-
-
 
         Linear cryptanalysis::
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: present_cipher = PRESENT_CVL(R=4)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: present_cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   present_cipher = PRESENT_CVL(R=4)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   present_cipher.analyse(model_options)
+            ....:   trail = str(present_cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             5312 variables and 12993 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -297,28 +274,23 @@ class PRESENT_CVL:
             [  0 ,  6] (trying w =   3) : UNSAT
             [  4 ,  6] (trying w =   5) : UNSAT
             6
-            sage: trail = str(present_cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: present_cipher = PRESENT_CVL(R=4)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: present_cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   present_cipher = PRESENT_CVL(R=4)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   present_cipher.analyse(model_options)
             5312 variables and 12993 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -328,26 +300,25 @@ class PRESENT_CVL:
             [  0 ,  6] (trying w =   3) : UNSAT
             [  4 ,  6] (trying w =   5) : UNSAT
             6
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: present_cipher = PRESENT_CVL(R=5)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: present_cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   present_cipher = PRESENT_CVL(R=5)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   present_cipher.analyse(model_options)
+            ....:   trail = str(present_cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             6512 variables and 16017 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -358,36 +329,31 @@ class PRESENT_CVL:
             [  7 ,  9] (trying w =   8) : SAT
             [  7 ,  8] (trying w =   7) : UNSAT
             8
-            sage: trail = str(present_cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
         Simulate external Espresso minimization::
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.present \
             ....:   import PRESENT_CVL
             sage: from civerly.model_options import *
-            sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: present_cipher = PRESENT_CVL(R=5)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=None,
-            ....:   path=Path(tmpdir))
-            sage: present_cipher.analyse(model_options)
-            Optimization problem for Espresso has been written to...
             sage: import os
-            sage: _ = os.popen("espresso -epos "
-            ....: f"{tmpdir}/espresso-1c52f72b_in.pla > "
-            ....: f"{tmpdir}/espresso-1c52f72b_out.pla").read()
-            sage: present_cipher.analyse(model_options)
+            sage: import tempfile
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso
+            ....:   present_cipher = PRESENT_CVL(R=5)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=None,
+            ....:     path=Path(tmpdir))
+            ....:   present_cipher.analyse(model_options)
+            ....:   _ = os.popen("espresso -epos "
+            ....:   f"{tmpdir}/espresso-1c52f72b_in.pla > "
+            ....:   f"{tmpdir}/espresso-1c52f72b_out.pla").read()
+            ....:   present_cipher.analyse(model_options)
+            Optimization problem for Espresso has been written to...
             Using existing file ..., make sure it is up to date!
             6512 variables and 16017 clauses were written to
             '...'
@@ -399,8 +365,6 @@ class PRESENT_CVL:
             [  7 ,  9] (trying w =   8) : SAT
             [  7 ,  8] (trying w =   7) : UNSAT
             8
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
         """
         if name is None:

--- a/src/civerly/cipher_implementations/simon.py
+++ b/src/civerly/cipher_implementations/simon.py
@@ -74,205 +74,181 @@ class SIMON_CVL:
 
         Models for differential cryptanalysis::
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.simon import SIMON_CVL
             sage: cipher = SIMON_CVL(32, 64, R=8, use_rotand=False)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(16, 20),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(16, 20),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             4160 variables and 8641 clauses were written to
             '...'
             [ 16 , 20] (trying w =  18) : SAT
             [ 16 , 18] (trying w =  17) : UNSAT
             18
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.simon import SIMON_CVL
             sage: cipher = SIMON_CVL(32, 64, R=8, use_rotand=True)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(16, 20),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(16, 20),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             3912 variables and 9041 clauses were written to
             '...'
             [ 16 , 20] (trying w =  18) : SAT
             [ 16 , 18] (trying w =  17) : UNSAT
             18
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
-            sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.simon import SIMON_CVL
             sage: cipher = SIMON_CVL(32, 64, R=8, use_rotand=False)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CADICAL_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(16, 20),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cadical  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CADICAL_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(16, 20),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             4160 variables and 8641 clauses were written to
             '...'
             [ 16 , 20] (trying w =  18) : SAT
             [ 16 , 18] (trying w =  17) : UNSAT
             18
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
-            sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.simon import SIMON_CVL
             sage: cipher = SIMON_CVL(32, 64, R=8, use_rotand=True)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CADICAL_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(16, 20),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cadical  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CADICAL_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(16, 20),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             3912 variables and 9041 clauses were written to
             '...'
             [ 16 , 20] (trying w =  18) : SAT
             [ 16 , 18] (trying w =  17) : UNSAT
             18
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
         Models for linear cryptanalysis. The results are from Table 1 in
         https://eprint.iacr.org/2015/145.pdf, which uses squared
         correlations::
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.simon import SIMON_CVL
             sage: cipher = SIMON_CVL(32, 64, R=11, use_rotand=False)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(10, 20),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(10, 20),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             5648 variables and 13169 clauses were written to
             '...'
             [ 10 , 20] (trying w =  15) : SAT
             [ 10 , 15] (trying w =  12) : UNSAT
             [ 13 , 15] (trying w =  14) : UNSAT
             15
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.simon import SIMON_CVL
             sage: cipher = SIMON_CVL(32, 64, R=11, use_rotand=True)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(10, 20),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(10, 20),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             6000 variables and 12817 clauses were written to
             '...'
             [ 10 , 20] (trying w =  15) : SAT
             [ 10 , 15] (trying w =  12) : UNSAT
             [ 13 , 15] (trying w =  14) : UNSAT
             15
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
-            sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.simon import SIMON_CVL
             sage: cipher = SIMON_CVL(32, 64, R=11, use_rotand=False)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CADICAL_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(10, 20),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cadical  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CADICAL_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(10, 20),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             5648 variables and 13169 clauses were written to
             '...'
             [ 10 , 20] (trying w =  15) : SAT
             [ 10 , 15] (trying w =  12) : UNSAT
             [ 13 , 15] (trying w =  14) : UNSAT
             15
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
-            sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.simon import SIMON_CVL
             sage: cipher = SIMON_CVL(32, 64, R=11, use_rotand=True)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CADICAL_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(10, 20),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cadical  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CADICAL_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(10, 20),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             6000 variables and 12817 clauses were written to
             '...'
             [ 10 , 20] (trying w =  15) : SAT
             [ 10 , 15] (trying w =  12) : UNSAT
             [ 13 , 15] (trying w =  14) : UNSAT
             15
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
         """
         if name is None:

--- a/src/civerly/cipher_implementations/simon.py
+++ b/src/civerly/cipher_implementations/simon.py
@@ -78,6 +78,8 @@ class SIMON_CVL:
             sage: from civerly.cipher_implementations.simon import SIMON_CVL
             sage: cipher = SIMON_CVL(32, 64, R=8, use_rotand=False)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -86,20 +88,22 @@ class SIMON_CVL:
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(16, 20),
-            ....:   path=Path("./DOCTEST-Simon-Models/"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options=model_options)
             4160 variables and 8641 clauses were written to
-            'DOCTEST-Simon-Models/simon.cnf'
+            '...'
             [ 16 , 20] (trying w =  18) : SAT
             [ 16 , 18] (trying w =  17) : UNSAT
             18
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Simon-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.simon import SIMON_CVL
             sage: cipher = SIMON_CVL(32, 64, R=8, use_rotand=True)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -108,20 +112,22 @@ class SIMON_CVL:
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(16, 20),
-            ....:   path=Path("./DOCTEST-Simon-Models/"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options=model_options)
             3912 variables and 9041 clauses were written to
-            'DOCTEST-Simon-Models/simon.cnf'
+            '...'
             [ 16 , 20] (trying w =  18) : SAT
             [ 16 , 18] (trying w =  17) : UNSAT
             18
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Simon-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
             sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.simon import SIMON_CVL
             sage: cipher = SIMON_CVL(32, 64, R=8, use_rotand=False)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -130,20 +136,22 @@ class SIMON_CVL:
             ....:   sat_solver=CADICAL_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(16, 20),
-            ....:   path=Path("./DOCTEST-Simon-Models/"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options=model_options)
             4160 variables and 8641 clauses were written to
-            'DOCTEST-Simon-Models/simon.cnf'
+            '...'
             [ 16 , 20] (trying w =  18) : SAT
             [ 16 , 18] (trying w =  17) : UNSAT
             18
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Simon-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
             sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.simon import SIMON_CVL
             sage: cipher = SIMON_CVL(32, 64, R=8, use_rotand=True)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -152,15 +160,15 @@ class SIMON_CVL:
             ....:   sat_solver=CADICAL_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(16, 20),
-            ....:   path=Path("./DOCTEST-Simon-Models/"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options=model_options)
             3912 variables and 9041 clauses were written to
-            'DOCTEST-Simon-Models/simon.cnf'
+            '...'
             [ 16 , 20] (trying w =  18) : SAT
             [ 16 , 18] (trying w =  17) : UNSAT
             18
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Simon-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
         Models for linear cryptanalysis. The results are from Table 1 in
         https://eprint.iacr.org/2015/145.pdf, which uses squared
@@ -170,6 +178,8 @@ class SIMON_CVL:
             sage: from civerly.cipher_implementations.simon import SIMON_CVL
             sage: cipher = SIMON_CVL(32, 64, R=11, use_rotand=False)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -178,21 +188,23 @@ class SIMON_CVL:
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(10, 20),
-            ....:   path=Path("./DOCTEST-Simon-Models/"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options=model_options)
             5648 variables and 13169 clauses were written to
-            'DOCTEST-Simon-Models/simon.cnf'
+            '...'
             [ 10 , 20] (trying w =  15) : SAT
             [ 10 , 15] (trying w =  12) : UNSAT
             [ 13 , 15] (trying w =  14) : UNSAT
             15
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Simon-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.simon import SIMON_CVL
             sage: cipher = SIMON_CVL(32, 64, R=11, use_rotand=True)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -201,21 +213,23 @@ class SIMON_CVL:
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(10, 20),
-            ....:   path=Path("./DOCTEST-Simon-Models/"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options=model_options)
             6000 variables and 12817 clauses were written to
-            'DOCTEST-Simon-Models/simon.cnf'
+            '...'
             [ 10 , 20] (trying w =  15) : SAT
             [ 10 , 15] (trying w =  12) : UNSAT
             [ 13 , 15] (trying w =  14) : UNSAT
             15
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Simon-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
             sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.simon import SIMON_CVL
             sage: cipher = SIMON_CVL(32, 64, R=11, use_rotand=False)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -224,21 +238,23 @@ class SIMON_CVL:
             ....:   sat_solver=CADICAL_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(10, 20),
-            ....:   path=Path("./DOCTEST-Simon-Models/"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options=model_options)
             5648 variables and 13169 clauses were written to
-            'DOCTEST-Simon-Models/simon.cnf'
+            '...'
             [ 10 , 20] (trying w =  15) : SAT
             [ 10 , 15] (trying w =  12) : UNSAT
             [ 13 , 15] (trying w =  14) : UNSAT
             15
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Simon-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
             sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.simon import SIMON_CVL
             sage: cipher = SIMON_CVL(32, 64, R=11, use_rotand=True)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -247,16 +263,16 @@ class SIMON_CVL:
             ....:   sat_solver=CADICAL_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(10, 20),
-            ....:   path=Path("./DOCTEST-Simon-Models/"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options=model_options)
             6000 variables and 12817 clauses were written to
-            'DOCTEST-Simon-Models/simon.cnf'
+            '...'
             [ 10 , 20] (trying w =  15) : SAT
             [ 10 , 15] (trying w =  12) : UNSAT
             [ 13 , 15] (trying w =  14) : UNSAT
             15
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Simon-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir, ignore_errors=True)
 
         """
         if name is None:

--- a/src/civerly/cipher_implementations/simon_variants.py
+++ b/src/civerly/cipher_implementations/simon_variants.py
@@ -26,6 +26,8 @@ class SIMON_Variants_CVL:
             sage: cipher = SIMON_Variants_CVL(
             ....:   32, R=6, params=[11, 10, 0], use_rotand=True)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -34,21 +36,25 @@ class SIMON_Variants_CVL:
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(4, 10),
-            ....:   path=Path("./DOCTEST-Simon-Variants-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
             2982 variables and 6861 clauses were written to
-            'DOCTEST-Simon-Variants-Models/simon.cnf'
+            '...'
             [  4 , 10] (trying w =   7) : UNSAT
             [  8 , 10] (trying w =   9) : SAT
             [  8 ,  9] (trying w =   8) : SAT
             8
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.simon_variants \
             ....:   import SIMON_Variants_CVL
             sage: cipher = SIMON_Variants_CVL(
             ....:   32, R=6, params=[11, 3, 9], use_rotand=True)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -57,21 +63,25 @@ class SIMON_Variants_CVL:
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(4, 10),
-            ....:   path=Path("./DOCTEST-Simon-Variants-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
             3216 variables and 7329 clauses were written to
-            'DOCTEST-Simon-Variants-Models/simon.cnf'
+            '...'
             [  4 , 10] (trying w =   7) : SAT
             [  4 ,  7] (trying w =   5) : UNSAT
             [  6 ,  7] (trying w =   6) : SAT
             6
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.simon_variants \
             ....:   import SIMON_Variants_CVL
             sage: cipher = SIMON_Variants_CVL(
             ....:   32, R=6, params=[13, 14, 5], use_rotand=True)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -80,21 +90,25 @@ class SIMON_Variants_CVL:
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(4, 10),
-            ....:   path=Path("./DOCTEST-Simon-Variants-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
             2982 variables and 6861 clauses were written to
-            'DOCTEST-Simon-Variants-Models/simon.cnf'
+            '...'
             [  4 , 10] (trying w =   7) : UNSAT
             [  8 , 10] (trying w =   9) : UNSAT
             [ 10 , 10] (trying w =  10) : SAT
             10
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.simon_variants \
             ....:   import SIMON_Variants_CVL
             sage: cipher = SIMON_Variants_CVL(
             ....:   32, R=6, params=[8, 1, 2], use_rotand=True)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -103,15 +117,17 @@ class SIMON_Variants_CVL:
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(8, 16),
-            ....:   path=Path("./DOCTEST-Simon-Variants-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
             2982 variables and 6861 clauses were written to
-            'DOCTEST-Simon-Variants-Models/simon.cnf'
+            '...'
             [  8 , 16] (trying w =  12) : SAT
             [  8 , 12] (trying w =  10) : UNSAT
             [ 11 , 12] (trying w =  11) : UNSAT
             12
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
         As stated in [KLT15], there exist parameters which yield an optimal
         weight of 26 for 10 rounds SIMON-32, which is better compared to the
@@ -122,6 +138,8 @@ class SIMON_Variants_CVL:
             sage: cipher = SIMON_Variants_CVL(
             ....:   32, R=10, params=[8, 1, 2], use_rotand=True)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -130,20 +148,24 @@ class SIMON_Variants_CVL:
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(24, 26),
-            ....:   path=Path("./DOCTEST-Simon-Variants-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
             4842 variables and 11221 clauses were written to
-            'DOCTEST-Simon-Variants-Models/simon.cnf'
+            '...'
             [ 24 , 26] (trying w =  25) : SAT
             [ 24 , 25] (trying w =  24) : UNSAT
             25
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.simon_variants \
             ....:   import SIMON_Variants_CVL
             sage: cipher = SIMON_Variants_CVL(
             ....:   32, R=10, params=[1, 0, 2], use_rotand=True)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -152,20 +174,24 @@ class SIMON_Variants_CVL:
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(24, 26),
-            ....:   path=Path("./DOCTEST-Simon-Variants-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
             4842 variables and 11221 clauses were written to
-            'DOCTEST-Simon-Variants-Models/simon.cnf'
+            '...'
             [ 24 , 26] (trying w =  25) : UNSAT
             [ 26 , 26] (trying w =  26) : SAT
             26
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.simon_variants \
             ....:   import SIMON_Variants_CVL
             sage: cipher = SIMON_Variants_CVL(
             ....:   32, R=10, params=[11, 0, 6], use_rotand=True)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -174,14 +200,16 @@ class SIMON_Variants_CVL:
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(24, 26),
-            ....:   path=Path("./DOCTEST-Simon-Variants-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
             4842 variables and 11221 clauses were written to
-            'DOCTEST-Simon-Variants-Models/simon.cnf'
+            '...'
             [ 24 , 26] (trying w =  25) : UNSAT
             [ 26 , 26] (trying w =  26) : SAT
             26
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
         Scaling every parameter in SIMON by the same amount should leave
         the trails unchanged, similar to doubleAES having the same bound
@@ -195,6 +223,8 @@ class SIMON_Variants_CVL:
             sage: cipher = SIMON_Variants_CVL(
             ....:   N*32, R=4, params=[8*N, 1*N, 2*N], use_rotand=True)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -203,18 +233,14 @@ class SIMON_Variants_CVL:
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(4, 8),
-            ....:   path=Path("./DOCTEST-Simon-Variants-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: with suppress_output():
             ....:   bound = cipher.analyse(model_options=model_options)
             sage: bound
             6
-
-        Remove the files::
-
             sage: import shutil
-            sage: shutil.rmtree(
-            ....:   "DOCTEST-Simon-Variants-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
         """
 

--- a/src/civerly/cipher_implementations/simon_variants.py
+++ b/src/civerly/cipher_implementations/simon_variants.py
@@ -27,26 +27,23 @@ class SIMON_Variants_CVL:
             ....:   32, R=6, params=[11, 10, 0], use_rotand=True)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(4, 10),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(4, 10),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             2982 variables and 6861 clauses were written to
             '...'
             [  4 , 10] (trying w =   7) : UNSAT
             [  8 , 10] (trying w =   9) : SAT
             [  8 ,  9] (trying w =   8) : SAT
             8
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.simon_variants \
             ....:   import SIMON_Variants_CVL
@@ -54,26 +51,23 @@ class SIMON_Variants_CVL:
             ....:   32, R=6, params=[11, 3, 9], use_rotand=True)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(4, 10),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(4, 10),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             3216 variables and 7329 clauses were written to
             '...'
             [  4 , 10] (trying w =   7) : SAT
             [  4 ,  7] (trying w =   5) : UNSAT
             [  6 ,  7] (trying w =   6) : SAT
             6
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.simon_variants \
             ....:   import SIMON_Variants_CVL
@@ -81,26 +75,23 @@ class SIMON_Variants_CVL:
             ....:   32, R=6, params=[13, 14, 5], use_rotand=True)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(4, 10),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(4, 10),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             2982 variables and 6861 clauses were written to
             '...'
             [  4 , 10] (trying w =   7) : UNSAT
             [  8 , 10] (trying w =   9) : UNSAT
             [ 10 , 10] (trying w =  10) : SAT
             10
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.simon_variants \
             ....:   import SIMON_Variants_CVL
@@ -108,26 +99,23 @@ class SIMON_Variants_CVL:
             ....:   32, R=6, params=[8, 1, 2], use_rotand=True)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(8, 16),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(8, 16),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             2982 variables and 6861 clauses were written to
             '...'
             [  8 , 16] (trying w =  12) : SAT
             [  8 , 12] (trying w =  10) : UNSAT
             [ 11 , 12] (trying w =  11) : UNSAT
             12
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         As stated in [KLT15], there exist parameters which yield an optimal
         weight of 26 for 10 rounds SIMON-32, which is better compared to the
@@ -139,25 +127,22 @@ class SIMON_Variants_CVL:
             ....:   32, R=10, params=[8, 1, 2], use_rotand=True)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(24, 26),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(24, 26),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             4842 variables and 11221 clauses were written to
             '...'
             [ 24 , 26] (trying w =  25) : SAT
             [ 24 , 25] (trying w =  24) : UNSAT
             25
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.simon_variants \
             ....:   import SIMON_Variants_CVL
@@ -165,25 +150,22 @@ class SIMON_Variants_CVL:
             ....:   32, R=10, params=[1, 0, 2], use_rotand=True)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(24, 26),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(24, 26),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             4842 variables and 11221 clauses were written to
             '...'
             [ 24 , 26] (trying w =  25) : UNSAT
             [ 26 , 26] (trying w =  26) : SAT
             26
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.simon_variants \
             ....:   import SIMON_Variants_CVL
@@ -191,25 +173,22 @@ class SIMON_Variants_CVL:
             ....:   32, R=10, params=[11, 0, 6], use_rotand=True)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(24, 26),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(24, 26),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             4842 variables and 11221 clauses were written to
             '...'
             [ 24 , 26] (trying w =  25) : UNSAT
             [ 26 , 26] (trying w =  26) : SAT
             26
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         Scaling every parameter in SIMON by the same amount should leave
         the trails unchanged, similar to doubleAES having the same bound
@@ -224,23 +203,20 @@ class SIMON_Variants_CVL:
             ....:   N*32, R=4, params=[8*N, 1*N, 2*N], use_rotand=True)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(4, 8),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: with suppress_output():
-            ....:   bound = cipher.analyse(model_options=model_options)
-            sage: bound
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(4, 8),
+            ....:     path=Path(tmpdir))
+            ....:   with suppress_output():
+            ....:     bound = cipher.analyse(model_options=model_options)
+            ....:   print(bound)
             6
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         """
 

--- a/src/civerly/cipher_implementations/skinny.py
+++ b/src/civerly/cipher_implementations/skinny.py
@@ -271,7 +271,8 @@ class SKINNY_CVL:
 
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
-            sage: import shutil
+            sage: import shutil, tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, name="branchnum-SKINNY-32")
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -279,14 +280,16 @@ class SKINNY_CVL:
             ....:   granularity=GRANULARITY.WORDWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
             ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path("./DOCTEST-SKINNY-Models/"))
+            ....:   path=Path(tmpdir))
             sage: skinny.analyse(model_options) # optional - scip
             22752 variables and 23505 constraints were written to
-            'DOCTEST-SKINNY-Models/branchnum-SKINNY-32.mps'
+            '...'
             32
-            sage: shutil.rmtree("DOCTEST-SKINNY-Models") # optional - scip
+            sage: shutil.rmtree(tmpdir) # optional - scip
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, R=10, name="wordwise-SKINNY-10")
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -294,14 +297,16 @@ class SKINNY_CVL:
             ....:   granularity=GRANULARITY.WORDWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
             ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path("./DOCTEST-SKINNY-Models/"))
+            ....:   path=Path(tmpdir))
             sage: skinny.analyse(model_options) # optional - scip
             7136 variables and 7361 constraints were written to
-            'DOCTEST-SKINNY-Models/wordwise-SKINNY-10.mps'
+            '...'
             46
-            sage: shutil.rmtree("DOCTEST-SKINNY-Models") # optional - scip
+            sage: shutil.rmtree(tmpdir) # optional - scip
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -310,14 +315,16 @@ class SKINNY_CVL:
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
             ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path("./DOCTEST-SKINNY-Models/"))
+            ....:   path=Path(tmpdir))
             sage: skinny.analyse(model_options) # optional - scip
             9312 variables and 9585 constraints were written to
-            'DOCTEST-SKINNY-Models/bitwise-SKINNY-3.mps'
+            '...'
             10
-            sage: shutil.rmtree("DOCTEST-SKINNY-Models") # optional - scip
+            sage: shutil.rmtree(tmpdir) # optional - scip
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, name="branchnum-SKINNY-32")
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -325,14 +332,16 @@ class SKINNY_CVL:
             ....:   granularity=GRANULARITY.WORDWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
             ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path("./DOCTEST-SKINNY-Models/"))
+            ....:   path=Path(tmpdir))
             sage: skinny.analyse(model_options) # optional - gurobi
             22752 variables and 23505 constraints were written to
-            'DOCTEST-SKINNY-Models/branchnum-SKINNY-32.mps'
+            '...'
             32
-            sage: shutil.rmtree("DOCTEST-SKINNY-Models") # optional - gurobi
+            sage: shutil.rmtree(tmpdir) # optional - gurobi
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, R=10, name="wordwise-SKINNY-10")
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -340,14 +349,16 @@ class SKINNY_CVL:
             ....:   granularity=GRANULARITY.WORDWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
             ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path("./DOCTEST-SKINNY-Models/"))
+            ....:   path=Path(tmpdir))
             sage: skinny.analyse(model_options) # optional - gurobi
             7136 variables and 7361 constraints were written to
-            'DOCTEST-SKINNY-Models/wordwise-SKINNY-10.mps'
+            '...'
             46
-            sage: shutil.rmtree("DOCTEST-SKINNY-Models") # optional - gurobi
+            sage: shutil.rmtree(tmpdir) # optional - gurobi
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -356,18 +367,20 @@ class SKINNY_CVL:
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
             ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path("./DOCTEST-SKINNY-Models/"))
+            ....:   path=Path(tmpdir))
             sage: skinny.analyse(model_options) # optional - gurobi
             9312 variables and 9585 constraints were written to
-            'DOCTEST-SKINNY-Models/bitwise-SKINNY-3.mps'
+            '...'
             10
-            sage: shutil.rmtree("DOCTEST-SKINNY-Models") # optional - gurobi
+            sage: shutil.rmtree(tmpdir) # optional - gurobi
 
         Using SAT modeling::
 
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -378,20 +391,22 @@ class SKINNY_CVL:
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(10, 20),
-            ....:   path=Path("./DOCTEST-SKINNY-Models/"))
+            ....:   path=Path(tmpdir))
             sage: skinny.analyse(model_options)
             8976 variables and 19553 clauses were written to
-            'DOCTEST-SKINNY-Models/bitwise-SKINNY-3.cnf'
+            '...'
             [ 10 , 20] (trying w =  15) : SAT
             [ 10 , 15] (trying w =  12) : SAT
             [ 10 , 12] (trying w =  11) : SAT
             [ 10 , 11] (trying w =  10) : SAT
             10
-            sage: shutil.rmtree("DOCTEST-SKINNY-Models")
+            sage: shutil.rmtree(tmpdir)
 
             sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -402,21 +417,23 @@ class SKINNY_CVL:
             ....:   sat_solver=CADICAL_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(10, 20),
-            ....:   path=Path("./DOCTEST-SKINNY-Models/"))
+            ....:   path=Path(tmpdir))
             sage: skinny.analyse(model_options)
             8976 variables and 19553 clauses were written to
-            'DOCTEST-SKINNY-Models/bitwise-SKINNY-3.cnf'
+            '...'
             [ 10 , 20] (trying w =  15) : SAT
             [ 10 , 15] (trying w =  12) : SAT
             [ 10 , 12] (trying w =  11) : SAT
             [ 10 , 11] (trying w =  10) : SAT
             10
-            sage: shutil.rmtree("DOCTEST-SKINNY-Models")
+            sage: shutil.rmtree(tmpdir)
 
         Modeling linear cryptanalysis::
 
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, R=10, name="wordwise-SKINNY-10")
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
@@ -424,14 +441,16 @@ class SKINNY_CVL:
             ....:   granularity=GRANULARITY.WORDWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
             ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path("./DOCTEST-SKINNY-Models/"))
+            ....:   path=Path(tmpdir))
             sage: skinny.analyse(model_options) # optional - gurobi
             7136 variables and 7521 constraints were written to
-            'DOCTEST-SKINNY-Models/wordwise-SKINNY-10.mps'
+            '...'
             43
-            sage: shutil.rmtree("DOCTEST-SKINNY-Models") # optional - gurobi
+            sage: shutil.rmtree(tmpdir) # optional - gurobi
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
@@ -441,14 +460,16 @@ class SKINNY_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   milp_solver=GUROBI_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-SKINNY-Models/"))
+            ....:   path=Path(tmpdir))
             sage: skinny.analyse(model_options) # optional - gurobi # optional - espresso
             9264 variables and 10161 constraints were written to
-            'DOCTEST-SKINNY-Models/bitwise-SKINNY-3.mps'
+            '...'
             5
-            sage: shutil.rmtree("DOCTEST-SKINNY-Models") # optional - gurobi
+            sage: shutil.rmtree(tmpdir) # optional - gurobi
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
@@ -458,16 +479,18 @@ class SKINNY_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   milp_solver=SCIP_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-SKINNY-Models/"))
+            ....:   path=Path(tmpdir))
             sage: skinny.analyse(model_options) # optional - scip # optional - espresso
             9264 variables and 10161 constraints were written to
-            'DOCTEST-SKINNY-Models/bitwise-SKINNY-3.mps'
+            '...'
             5
-            sage: shutil.rmtree("DOCTEST-SKINNY-Models") # optional - scip # optional - espresso
+            sage: shutil.rmtree(tmpdir) # optional - scip # optional - espresso
 
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
@@ -478,19 +501,21 @@ class SKINNY_CVL:
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(4, 10),
-            ....:   path=Path("./DOCTEST-SKINNY-Models/"))
+            ....:   path=Path(tmpdir))
             sage: skinny.analyse(model_options)
             8976 variables and 19313 clauses were written to
-            'DOCTEST-SKINNY-Models/bitwise-SKINNY-3.cnf'
+            '...'
             [  4 , 10] (trying w =   7) : SAT
             [  4 ,  7] (trying w =   5) : SAT
             [  4 ,  5] (trying w =   4) : UNSAT
             5
-            sage: shutil.rmtree("DOCTEST-SKINNY-Models") # optional - cryptominisat # optional - espresso
+            sage: shutil.rmtree(tmpdir) # optional - cryptominisat # optional - espresso
 
             sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
@@ -501,20 +526,15 @@ class SKINNY_CVL:
             ....:   sat_solver=CADICAL_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(4, 10),
-            ....:   path=Path("./DOCTEST-SKINNY-Models/"))
+            ....:   path=Path(tmpdir))
             sage: skinny.analyse(model_options)
             8976 variables and 19313 clauses were written to
-            'DOCTEST-SKINNY-Models/bitwise-SKINNY-3.cnf'
+            '...'
             [  4 , 10] (trying w =   7) : SAT
             [  4 ,  7] (trying w =   5) : SAT
             [  4 ,  5] (trying w =   4) : UNSAT
             5
-            sage: shutil.rmtree("DOCTEST-SKINNY-Models") # optional - cadical # optional - espresso
-
-        Remove the files:
-
-            sage: import shutil
-            sage: shutil.rmtree("DOCTEST-SKINNY-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir) # optional - cadical # optional - espresso
 
         """
         assert n in [64, 128], (

--- a/src/civerly/cipher_implementations/skinny.py
+++ b/src/civerly/cipher_implementations/skinny.py
@@ -271,128 +271,126 @@ class SKINNY_CVL:
 
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
-            sage: import shutil, tempfile
-            sage: tmpdir = tempfile.mkdtemp()
+            sage: import tempfile
             sage: skinny = SKINNY_CVL(64, 64, name="branchnum-SKINNY-32")
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.WORDWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
-            ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: skinny.analyse(model_options) # optional - scip
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - scip  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.WORDWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
+            ....:     milp_solver=SCIP_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   skinny.analyse(model_options)
             22752 variables and 23505 constraints were written to
             '...'
             32
-            sage: shutil.rmtree(tmpdir) # optional - scip
+
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, R=10, name="wordwise-SKINNY-10")
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.WORDWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
-            ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: skinny.analyse(model_options) # optional - scip
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - scip  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.WORDWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
+            ....:     milp_solver=SCIP_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   skinny.analyse(model_options)
             7136 variables and 7361 constraints were written to
             '...'
             46
-            sage: shutil.rmtree(tmpdir) # optional - scip
+
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   milp_solver=SCIP_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: skinny.analyse(model_options) # optional - scip
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - scip  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:     sbox_modeling=SBOX_MODELING.CONVEX_HULL,
+            ....:     milp_solver=SCIP_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   skinny.analyse(model_options)
             9312 variables and 9585 constraints were written to
             '...'
             10
-            sage: shutil.rmtree(tmpdir) # optional - scip
+
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, name="branchnum-SKINNY-32")
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.WORDWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
-            ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: skinny.analyse(model_options) # optional - gurobi
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.WORDWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.BRANCH_NUMBER,
+            ....:     milp_solver=GUROBI_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   skinny.analyse(model_options)
             22752 variables and 23505 constraints were written to
             '...'
             32
-            sage: shutil.rmtree(tmpdir) # optional - gurobi
+
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, R=10, name="wordwise-SKINNY-10")
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.WORDWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
-            ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: skinny.analyse(model_options) # optional - gurobi
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.WORDWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
+            ....:     milp_solver=GUROBI_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   skinny.analyse(model_options)
             7136 variables and 7361 constraints were written to
             '...'
             46
-            sage: shutil.rmtree(tmpdir) # optional - gurobi
+
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: skinny.analyse(model_options) # optional - gurobi
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:     sbox_modeling=SBOX_MODELING.CONVEX_HULL,
+            ....:     milp_solver=GUROBI_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   skinny.analyse(model_options)
             9312 variables and 9585 constraints were written to
             '...'
             10
-            sage: shutil.rmtree(tmpdir) # optional - gurobi
 
         Using SAT modeling::
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(10, 20),
-            ....:   path=Path(tmpdir))
-            sage: skinny.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(10, 20),
+            ....:     path=Path(tmpdir))
+            ....:   skinny.analyse(model_options)
             8976 variables and 19553 clauses were written to
             '...'
             [ 10 , 20] (trying w =  15) : SAT
@@ -400,25 +398,23 @@ class SKINNY_CVL:
             [ 10 , 12] (trying w =  11) : SAT
             [ 10 , 11] (trying w =  10) : SAT
             10
-            sage: shutil.rmtree(tmpdir)
 
-            sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CADICAL_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(10, 20),
-            ....:   path=Path(tmpdir))
-            sage: skinny.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cadical  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CADICAL_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(10, 20),
+            ....:     path=Path(tmpdir))
+            ....:   skinny.analyse(model_options)
             8976 variables and 19553 clauses were written to
             '...'
             [ 10 , 20] (trying w =  15) : SAT
@@ -426,115 +422,109 @@ class SKINNY_CVL:
             [ 10 , 12] (trying w =  11) : SAT
             [ 10 , 11] (trying w =  10) : SAT
             10
-            sage: shutil.rmtree(tmpdir)
 
         Modeling linear cryptanalysis::
 
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, R=10, name="wordwise-SKINNY-10")
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.WORDWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
-            ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: skinny.analyse(model_options) # optional - gurobi
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.WORDWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
+            ....:     milp_solver=GUROBI_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   skinny.analyse(model_options)
             7136 variables and 7521 constraints were written to
             '...'
             43
-            sage: shutil.rmtree(tmpdir) # optional - gurobi
-            sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
-            sage: from civerly.model_options import *
-            sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   milp_solver=GUROBI_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: skinny.analyse(model_options) # optional - gurobi # optional - espresso
-            9264 variables and 10161 constraints were written to
-            '...'
-            5
-            sage: shutil.rmtree(tmpdir) # optional - gurobi
-            sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
-            sage: from civerly.model_options import *
-            sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   milp_solver=SCIP_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: skinny.analyse(model_options) # optional - scip # optional - espresso
-            9264 variables and 10161 constraints were written to
-            '...'
-            5
-            sage: shutil.rmtree(tmpdir) # optional - scip # optional - espresso
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
             sage: skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(4, 10),
-            ....:   path=Path(tmpdir))
-            sage: skinny.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     milp_solver=GUROBI_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   skinny.analyse(model_options)
+            9264 variables and 10161 constraints were written to
+            '...'
+            5
+
+            sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
+            sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - scip  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     milp_solver=SCIP_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   skinny.analyse(model_options)
+            9264 variables and 10161 constraints were written to
+            '...'
+            5
+
+            sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
+            sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(4, 10),
+            ....:     path=Path(tmpdir))
+            ....:   skinny.analyse(model_options)
             8976 variables and 19313 clauses were written to
             '...'
             [  4 , 10] (trying w =   7) : SAT
             [  4 ,  7] (trying w =   5) : SAT
             [  4 ,  5] (trying w =   4) : UNSAT
             5
-            sage: shutil.rmtree(tmpdir) # optional - cryptominisat # optional - espresso
 
-            sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CADICAL_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(4, 10),
-            ....:   path=Path(tmpdir))
-            sage: skinny.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cadical  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   skinny = SKINNY_CVL(64, 64, R=3, name="bitwise-SKINNY-3")
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CADICAL_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     solve_range=(4, 10),
+            ....:     path=Path(tmpdir))
+            ....:   skinny.analyse(model_options)
             8976 variables and 19313 clauses were written to
             '...'
             [  4 , 10] (trying w =   7) : SAT
             [  4 ,  7] (trying w =   5) : SAT
             [  4 ,  5] (trying w =   4) : UNSAT
             5
-            sage: shutil.rmtree(tmpdir) # optional - cadical # optional - espresso
 
         """
         assert n in [64, 128], (

--- a/src/civerly/cipher_implementations/speck.py
+++ b/src/civerly/cipher_implementations/speck.py
@@ -64,20 +64,20 @@ class SPECK_CVL:
             True
 
             sage: from civerly.cipher_implementations.speck import SPECK_CVL
-            sage: cipher = SPECK_CVL(32, 64, R=4)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   cipher = SPECK_CVL(32, 64, R=4)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            ....:   cipher.generate_report(model_options)
             1788 variables and 4189 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -88,26 +88,23 @@ class SPECK_CVL:
             [  4 ,  6] (trying w =   5) : SAT
             [  4 ,  5] (trying w =   4) : UNSAT
             5
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.speck import SPECK_CVL
-            sage: cipher = SPECK_CVL(32, 64, R=4)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CADICAL_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cadical
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cadical  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   cipher = SPECK_CVL(32, 64, R=4)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CADICAL_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            ....:   cipher.generate_report(model_options)
             1788 variables and 4189 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -118,29 +115,26 @@ class SPECK_CVL:
             [  4 ,  6] (trying w =   5) : SAT
             [  4 ,  5] (trying w =   4) : UNSAT
             5
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         Linear cryptanalysis (the results were tested until :math:`R = 12`
         and match Table 2 in [LWR16])::
 
             sage: from civerly.cipher_implementations.speck import SPECK_CVL
-            sage: cipher = SPECK_CVL(32, 64, R=7)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   cipher = SPECK_CVL(32, 64, R=7)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            ....:   cipher.generate_report(model_options)
             2992 variables and 7776 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -150,26 +144,23 @@ class SPECK_CVL:
             [  7 , 12] (trying w =   9) : SAT
             [  7 ,  9] (trying w =   8) : UNSAT
             9
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.speck import SPECK_CVL
-            sage: cipher = SPECK_CVL(32, 64, R=7)
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CADICAL_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cadical
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cadical  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   cipher = SPECK_CVL(32, 64, R=7)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CADICAL_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            ....:   cipher.generate_report(model_options)
             2992 variables and 7776 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -179,10 +170,7 @@ class SPECK_CVL:
             [  7 , 12] (trying w =   9) : SAT
             [  7 ,  9] (trying w =   8) : UNSAT
             9
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
 
         """

--- a/src/civerly/cipher_implementations/speck.py
+++ b/src/civerly/cipher_implementations/speck.py
@@ -66,6 +66,8 @@ class SPECK_CVL:
             sage: from civerly.cipher_implementations.speck import SPECK_CVL
             sage: cipher = SPECK_CVL(32, 64, R=4)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -73,11 +75,11 @@ class SPECK_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-Speck-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
             1788 variables and 4189 clauses were written to
-            'DOCTEST-Speck-Models/speck.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -86,12 +88,16 @@ class SPECK_CVL:
             [  4 ,  6] (trying w =   5) : SAT
             [  4 ,  5] (trying w =   4) : UNSAT
             5
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Speck-Models/speck.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.speck import SPECK_CVL
             sage: cipher = SPECK_CVL(32, 64, R=4)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -99,11 +105,11 @@ class SPECK_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CADICAL_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-Speck-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cadical
             sage: cipher.analyse(model_options=model_options)
             1788 variables and 4189 clauses were written to
-            'DOCTEST-Speck-Models/speck.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -112,8 +118,10 @@ class SPECK_CVL:
             [  4 ,  6] (trying w =   5) : SAT
             [  4 ,  5] (trying w =   4) : UNSAT
             5
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Speck-Models/speck.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
         Linear cryptanalysis (the results were tested until :math:`R = 12`
         and match Table 2 in [LWR16])::
@@ -121,6 +129,8 @@ class SPECK_CVL:
             sage: from civerly.cipher_implementations.speck import SPECK_CVL
             sage: cipher = SPECK_CVL(32, 64, R=7)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -128,11 +138,11 @@ class SPECK_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-Speck-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
             2992 variables and 7776 clauses were written to
-            'DOCTEST-Speck-Models/speck.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -140,12 +150,16 @@ class SPECK_CVL:
             [  7 , 12] (trying w =   9) : SAT
             [  7 ,  9] (trying w =   8) : UNSAT
             9
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Speck-Models/speck.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.speck import SPECK_CVL
             sage: cipher = SPECK_CVL(32, 64, R=7)
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
             ....:   optimization=OPTIMIZATION.SAT,
@@ -153,11 +167,11 @@ class SPECK_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CADICAL_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-Speck-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cadical
             sage: cipher.analyse(model_options=model_options)
             2992 variables and 7776 clauses were written to
-            'DOCTEST-Speck-Models/speck.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -165,11 +179,10 @@ class SPECK_CVL:
             [  7 , 12] (trying w =   9) : SAT
             [  7 ,  9] (trying w =   8) : UNSAT
             9
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Speck-Models/speck.pdf
-
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Speck-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
 
         """

--- a/src/civerly/cipher_implementations/toy_ciphers/toy1.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy1.py
@@ -12,12 +12,13 @@ class Toy1:
 
         TESTS::
 
-        The test code for SAT:
-            sage: # optional - cryptominisat
             sage: from civerly.cipher_implementations.toy_ciphers.toy1 \
             ....:   import Toy1
             sage: from civerly.model_options import *
             sage: import tempfile
+
+        The test code for SAT:
+            sage: # optional - cryptominisat
             sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
             ....:   cipher = Toy1()
             ....:   model_options = MODEL_OPTIONS(
@@ -85,8 +86,7 @@ class Toy1:
 
         The test code for MILP:
 
-            sage: from civerly.cipher_implementations.toy_ciphers.toy1 \
-            ....:   import Toy1
+            sage: from civerly.cipher_implementations.toy_ciphers.toy1 import Toy1
             sage: from civerly.model_options import *
             sage: import tempfile
             sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # doctest: +ELLIPSIS
@@ -105,9 +105,12 @@ class Toy1:
             ....:   GUROBI_CVL().process_solution_file(
             ....:       solution_file_name=Path(tmpdir) / "Toy1.sol",
             ....:   )[1]
-            474 variables and 346 constraints were written to
-            '...'
+            474 variables and 346 constraints were written to '...'
+            ...
             0
+            sage: from civerly.cipher_implementations.toy_ciphers.toy1 import Toy1
+            sage: from civerly.model_options import *
+            sage: import tempfile
             sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - scip  # doctest: +ELLIPSIS
             ....:   cipher = Toy1()
             ....:   model_options = MODEL_OPTIONS(
@@ -124,9 +127,12 @@ class Toy1:
             ....:   SCIP_CVL().process_solution_file(
             ....:       solution_file_name=Path(tmpdir) / "Toy1.sol",
             ....:   )[1]
-            474 variables and 346 constraints were written to
-            '...'
+            474 variables and 346 constraints were written to '...'
+            ...
             0
+            sage: from civerly.cipher_implementations.toy_ciphers.toy1 import Toy1
+            sage: from civerly.model_options import *
+            sage: import tempfile
             sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - glpk  # doctest: +ELLIPSIS
             ....:   cipher = Toy1()
             ....:   model_options = MODEL_OPTIONS(
@@ -143,9 +149,12 @@ class Toy1:
             ....:   GLPK_CVL().process_solution_file(
             ....:       solution_file_name=Path(tmpdir) / "Toy1.sol",
             ....:   )[1]
-            474 variables and 346 constraints were written to
-            '...'
+            474 variables and 346 constraints were written to '...'
+            ...
             0
+            sage: from civerly.cipher_implementations.toy_ciphers.toy1 import Toy1
+            sage: from civerly.model_options import *
+            sage: import tempfile
             sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # doctest: +ELLIPSIS
             ....:   cipher = Toy1()
             ....:   model_options = MODEL_OPTIONS(
@@ -156,8 +165,7 @@ class Toy1:
             ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:       path=Path(tmpdir))
             ....:   cipher.analyse(model_options=model_options)
-            486 variables and 350 constraints were written to
-            '...'
+            486 variables and 350 constraints were written to '...'
             0
 
         """

--- a/src/civerly/cipher_implementations/toy_ciphers/toy1.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy1.py
@@ -13,21 +13,24 @@ class Toy1:
         TESTS::
 
         The test code for SAT:
+            sage: # optional - cryptominisat
             sage: from civerly.cipher_implementations.toy_ciphers.toy1 \
             ....:   import Toy1
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy1()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy1()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:       sat_solver=CRYPTOMINISAT_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            ....:   cipher.generate_report(model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             382 variables and 1527 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -38,28 +41,17 @@ class Toy1:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
-
-            sage: from civerly.cipher_implementations.toy_ciphers.toy1 \
-            ....:   import Toy1
-            sage: from civerly.model_options import *
-            sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy1()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy1()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:       sat_solver=CRYPTOMINISAT_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             382 variables and 1003 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -70,24 +62,16 @@ class Toy1:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
-
-            sage: from civerly.cipher_implementations.toy_ciphers.toy1 \
-            ....:   import Toy1
-            sage: from civerly.model_options import *
-            sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy1()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy1()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:       sat_solver=CRYPTOMINISAT_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             426 variables and 955 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -98,8 +82,6 @@ class Toy1:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         The test code for MILP:
 
@@ -107,65 +89,76 @@ class Toy1:
             ....:   import Toy1
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy1()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   path=Path(tmpdir))
-            sage: milp_model = cipher.model(model_options=model_options)  # doctest: +ELLIPSIS
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # doctest: +ELLIPSIS
+            ....:   cipher = Toy1()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.MILP,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:       path=Path(tmpdir))
+            ....:   cipher.model(model_options=model_options)
+            ....:   GUROBI_CVL().solve(
+            ....:       input_file_name=Path(tmpdir) / "Toy1.mps",
+            ....:       output_file_name=Path(tmpdir) / "Toy1.sol",
+            ....:   )
+            ....:   GUROBI_CVL().process_solution_file(
+            ....:       solution_file_name=Path(tmpdir) / "Toy1.sol",
+            ....:   )[1]
             474 variables and 346 constraints were written to
             '...'
-            sage: from pathlib import Path
-            sage: GUROBI_CVL().solve( # optional - gurobi
-            ....:   input_file_name=Path(tmpdir) / "Toy1.mps",
-            ....:   output_file_name=Path(tmpdir) / "Toy1.sol",
-            ....: )
-            sage: GUROBI_CVL().process_solution_file( # optional - gurobi
-            ....:   solution_file_name=Path(tmpdir) / "Toy1.sol",
-            ....: )[1]
             0
-            sage: SCIP_CVL().solve( # optional - scip
-            ....:   input_file_name=Path(tmpdir) / "Toy1.mps",
-            ....:   output_file_name=Path(tmpdir) / "Toy1.sol",
-            ....: )
-            sage: SCIP_CVL().process_solution_file( # optional - scip
-            ....:   solution_file_name=Path(tmpdir) / "Toy1.sol",
-            ....: )[1]
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - scip  # doctest: +ELLIPSIS
+            ....:   cipher = Toy1()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.MILP,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:       path=Path(tmpdir))
+            ....:   cipher.model(model_options=model_options)
+            ....:   SCIP_CVL().solve(
+            ....:       input_file_name=Path(tmpdir) / "Toy1.mps",
+            ....:       output_file_name=Path(tmpdir) / "Toy1.sol",
+            ....:   )
+            ....:   SCIP_CVL().process_solution_file(
+            ....:       solution_file_name=Path(tmpdir) / "Toy1.sol",
+            ....:   )[1]
+            474 variables and 346 constraints were written to
+            '...'
             0
-            sage: GLPK_CVL().solve( # optional - glpk
-            ....:   input_file_name=Path(tmpdir) / "Toy1.mps",
-            ....:   output_file_name=Path(tmpdir) / "Toy1.sol",
-            ....: )
-            sage: GLPK_CVL().process_solution_file( # optional - glpk
-            ....:   solution_file_name=Path(tmpdir) / "Toy1.sol",
-            ....: )[1]
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - glpk  # doctest: +ELLIPSIS
+            ....:   cipher = Toy1()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.MILP,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:       path=Path(tmpdir))
+            ....:   cipher.model(model_options=model_options)
+            ....:   GLPK_CVL().solve(
+            ....:       input_file_name=Path(tmpdir) / "Toy1.mps",
+            ....:       output_file_name=Path(tmpdir) / "Toy1.sol",
+            ....:   )
+            ....:   GLPK_CVL().process_solution_file(
+            ....:       solution_file_name=Path(tmpdir) / "Toy1.sol",
+            ....:   )[1]
+            474 variables and 346 constraints were written to
+            '...'
             0
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
-
-            sage: from civerly.cipher_implementations.toy_ciphers.toy1 \
-            ....:   import Toy1
-            sage: from civerly.model_options import *
-            sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy1()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   milp_solver=GUROBI_CVL(),
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   path=Path(tmpdir))
-            sage: # optional - gurobi
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # doctest: +ELLIPSIS
+            ....:   cipher = Toy1()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:       optimization=OPTIMIZATION.MILP,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       milp_solver=GUROBI_CVL(),
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
             486 variables and 350 constraints were written to
             '...'
             0
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         """
         cipher = SBoxCipher(37, 37, name="Toy1")

--- a/src/civerly/cipher_implementations/toy_ciphers/toy1.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy1.py
@@ -16,6 +16,8 @@ class Toy1:
             sage: from civerly.cipher_implementations.toy_ciphers.toy1 \
             ....:   import Toy1
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy1()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -23,11 +25,11 @@ class Toy1:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   path=Path("./DOCTEST-Toy1-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
             382 variables and 1527 clauses were written to
-            'DOCTEST-Toy1-Models/Toy1.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -36,14 +38,18 @@ class Toy1:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Toy1-Models/Toy1.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.toy_ciphers.toy1 \
             ....:   import Toy1
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy1()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
@@ -51,11 +57,11 @@ class Toy1:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   path=Path("./DOCTEST-Toy1-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
             382 variables and 1003 clauses were written to
-            'DOCTEST-Toy1-Models/Toy1.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -64,10 +70,14 @@ class Toy1:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.toy_ciphers.toy1 \
             ....:   import Toy1
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy1()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
@@ -75,11 +85,11 @@ class Toy1:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   path=Path("./DOCTEST-Toy1-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
             426 variables and 955 clauses were written to
-            'DOCTEST-Toy1-Models/Toy1.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -88,51 +98,59 @@ class Toy1:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
         The test code for MILP:
 
             sage: from civerly.cipher_implementations.toy_ciphers.toy1 \
             ....:   import Toy1
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy1()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.MILP,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   path=Path("./DOCTEST-Toy1-Models/"))
-            sage: milp_model = cipher.model(model_options=model_options)
+            ....:   path=Path(tmpdir))
+            sage: milp_model = cipher.model(model_options=model_options)  # doctest: +ELLIPSIS
             474 variables and 346 constraints were written to
-            'DOCTEST-Toy1-Models/Toy1.mps'
+            '...'
             sage: from pathlib import Path
             sage: GUROBI_CVL().solve( # optional - gurobi
-            ....:   input_file_name=Path("DOCTEST-Toy1-Models/Toy1.mps"),
-            ....:   output_file_name=Path("DOCTEST-Toy1-Models/Toy1.sol"),
+            ....:   input_file_name=Path(tmpdir) / "Toy1.mps",
+            ....:   output_file_name=Path(tmpdir) / "Toy1.sol",
             ....: )
             sage: GUROBI_CVL().process_solution_file( # optional - gurobi
-            ....:   solution_file_name=Path("DOCTEST-Toy1-Models/Toy1.sol"),
+            ....:   solution_file_name=Path(tmpdir) / "Toy1.sol",
             ....: )[1]
             0
             sage: SCIP_CVL().solve( # optional - scip
-            ....:   input_file_name=Path("DOCTEST-Toy1-Models/Toy1.mps"),
-            ....:   output_file_name=Path("DOCTEST-Toy1-Models/Toy1.sol"),
+            ....:   input_file_name=Path(tmpdir) / "Toy1.mps",
+            ....:   output_file_name=Path(tmpdir) / "Toy1.sol",
             ....: )
             sage: SCIP_CVL().process_solution_file( # optional - scip
-            ....:   solution_file_name=Path("DOCTEST-Toy1-Models/Toy1.sol"),
+            ....:   solution_file_name=Path(tmpdir) / "Toy1.sol",
             ....: )[1]
             0
             sage: GLPK_CVL().solve( # optional - glpk
-            ....:   input_file_name=Path("DOCTEST-Toy1-Models/Toy1.mps"),
-            ....:   output_file_name=Path("DOCTEST-Toy1-Models/Toy1.sol"),
+            ....:   input_file_name=Path(tmpdir) / "Toy1.mps",
+            ....:   output_file_name=Path(tmpdir) / "Toy1.sol",
             ....: )
             sage: GLPK_CVL().process_solution_file( # optional - glpk
-            ....:   solution_file_name=Path("DOCTEST-Toy1-Models/Toy1.sol"),
+            ....:   solution_file_name=Path(tmpdir) / "Toy1.sol",
             ....: )[1]
             0
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.toy_ciphers.toy1 \
             ....:   import Toy1
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy1()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
@@ -140,16 +158,14 @@ class Toy1:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   milp_solver=GUROBI_CVL(),
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   path=Path("./DOCTEST-Toy1-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - gurobi
             sage: cipher.analyse(model_options=model_options)
             486 variables and 350 constraints were written to
-            'DOCTEST-Toy1-Models/Toy1.mps'
+            '...'
             0
-
-        Removing the files:
             sage: import shutil
-            sage: shutil.rmtree(Path("DOCTEST-Toy1-Models"), ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
         """
         cipher = SBoxCipher(37, 37, name="Toy1")

--- a/src/civerly/cipher_implementations/toy_ciphers/toy10.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy10.py
@@ -23,19 +23,18 @@ class Toy10:
             sage: from civerly.model_options import *
             sage: from pathlib import Path
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy10(False)
-            sage: model_options = MODEL_OPTIONS(
-            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:     optimization=OPTIMIZATION.SAT,
-            ....:     granularity=GRANULARITY.BITWISE,
-            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:     sat_solver=CRYPTOMINISAT_CVL(),
-            ....:     logic_minimizer=ESPRESSO_CVL(),
-            ....:     path=Path(tmpdir)
-            ....: )
-            sage: cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy10(False)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       sat_solver=CRYPTOMINISAT_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options)
             92 variables and 288 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -46,8 +45,6 @@ class Toy10:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : UNSAT
             1
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
             sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.toy_ciphers.toy10 \
@@ -55,19 +52,18 @@ class Toy10:
             sage: from civerly.model_options import *
             sage: from pathlib import Path
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy10(False)
-            sage: model_options = MODEL_OPTIONS(
-            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:     optimization=OPTIMIZATION.SAT,
-            ....:     granularity=GRANULARITY.BITWISE,
-            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:     sat_solver=CADICAL_CVL(),
-            ....:     logic_minimizer=ESPRESSO_CVL(),
-            ....:     path=Path(tmpdir)
-            ....: )
-            sage: cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy10(False)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       sat_solver=CADICAL_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options)
             92 variables and 288 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -78,8 +74,6 @@ class Toy10:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : UNSAT
             1
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.toy_ciphers.toy10 \
@@ -87,19 +81,18 @@ class Toy10:
             sage: from civerly.model_options import *
             sage: from pathlib import Path
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy10(True)
-            sage: model_options = MODEL_OPTIONS(
-            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:     optimization=OPTIMIZATION.SAT,
-            ....:     granularity=GRANULARITY.BITWISE,
-            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:     sat_solver=CRYPTOMINISAT_CVL(),
-            ....:     logic_minimizer=ESPRESSO_CVL(),
-            ....:     path=Path(tmpdir)
-            ....: )
-            sage: cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy10(True)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       sat_solver=CRYPTOMINISAT_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options)
             122 variables and 690 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -110,32 +103,28 @@ class Toy10:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : UNSAT
             1
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
+            sage: # optional - gurobi # optional - espresso
             sage: from civerly.cipher_implementations.toy_ciphers.toy10 \
             ....:   import Toy10
             sage: from civerly.model_options import *
             sage: from pathlib import Path
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy10(True)
-            sage: model_options = MODEL_OPTIONS(
-            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:     optimization=OPTIMIZATION.MILP,
-            ....:     granularity=GRANULARITY.BITWISE,
-            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:     milp_solver=GUROBI_CVL(),
-            ....:     logic_minimizer=ESPRESSO_CVL(),
-            ....:     path=Path(tmpdir)
-            ....: )
-            sage: cipher.analyse(model_options) # optional - gurobi # optional - espresso
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy10(True)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:       optimization=OPTIMIZATION.MILP,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:       milp_solver=GUROBI_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options)
             128 variables and 702 constraints were written to
             '...'
             1
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir) # optional - gurobi
 
         """
 

--- a/src/civerly/cipher_implementations/toy_ciphers/toy10.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy10.py
@@ -22,6 +22,8 @@ class Toy10:
             ....:   import Toy10
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy10(False)
             sage: model_options = MODEL_OPTIONS(
             ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
@@ -31,11 +33,11 @@ class Toy10:
             ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:     sat_solver=CRYPTOMINISAT_CVL(),
             ....:     logic_minimizer=ESPRESSO_CVL(),
-            ....:     path=Path("./DOCTEST-Toy10-Models/")
+            ....:     path=Path(tmpdir)
             ....: )
             sage: cipher.analyse(model_options)
             92 variables and 288 clauses were written to
-            'DOCTEST-Toy10-Models/toy10.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -45,13 +47,15 @@ class Toy10:
             [  0 ,  1] (trying w =   0) : UNSAT
             1
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Toy10-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
             sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.toy_ciphers.toy10 \
             ....:   import Toy10
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy10(False)
             sage: model_options = MODEL_OPTIONS(
             ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
@@ -61,11 +65,11 @@ class Toy10:
             ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:     sat_solver=CADICAL_CVL(),
             ....:     logic_minimizer=ESPRESSO_CVL(),
-            ....:     path=Path("./DOCTEST-Toy10-Models/")
+            ....:     path=Path(tmpdir)
             ....: )
             sage: cipher.analyse(model_options)
             92 variables and 288 clauses were written to
-            'DOCTEST-Toy10-Models/toy10.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -75,13 +79,15 @@ class Toy10:
             [  0 ,  1] (trying w =   0) : UNSAT
             1
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Toy10-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.toy_ciphers.toy10 \
             ....:   import Toy10
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy10(True)
             sage: model_options = MODEL_OPTIONS(
             ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
@@ -91,11 +97,11 @@ class Toy10:
             ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:     sat_solver=CRYPTOMINISAT_CVL(),
             ....:     logic_minimizer=ESPRESSO_CVL(),
-            ....:     path=Path("./DOCTEST-Toy10-Models/")
+            ....:     path=Path(tmpdir)
             ....: )
             sage: cipher.analyse(model_options)
             122 variables and 690 clauses were written to
-            'DOCTEST-Toy10-Models/toy10.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -104,11 +110,15 @@ class Toy10:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : UNSAT
             1
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.toy_ciphers.toy10 \
             ....:   import Toy10
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy10(True)
             sage: model_options = MODEL_OPTIONS(
             ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
@@ -118,15 +128,14 @@ class Toy10:
             ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:     milp_solver=GUROBI_CVL(),
             ....:     logic_minimizer=ESPRESSO_CVL(),
-            ....:     path=Path("./DOCTEST-Toy10-Models/")
+            ....:     path=Path(tmpdir)
             ....: )
             sage: cipher.analyse(model_options) # optional - gurobi # optional - espresso
             128 variables and 702 constraints were written to
-            'DOCTEST-Toy10-Models/toy10.mps'
+            '...'
             1
-
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Toy10-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir) # optional - gurobi
 
         """
 

--- a/src/civerly/cipher_implementations/toy_ciphers/toy11.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy11.py
@@ -13,29 +13,27 @@ class Toy11:
 
         TESTS::
 
+            sage: # optional - gurobi # optional - espresso
             sage: from civerly.cipher_implementations.toy_ciphers.toy11 \
             ....:   import Toy11
             sage: from civerly.model_options import *
             sage: from pathlib import Path
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy11()
-            sage: model_options = MODEL_OPTIONS(
-            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:     optimization=OPTIMIZATION.MILP,
-            ....:     granularity=GRANULARITY.BITWISE,
-            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:     milp_solver=GUROBI_CVL(),
-            ....:     logic_minimizer=ESPRESSO_CVL(),
-            ....:     path=Path(tmpdir)
-            ....: )
-            sage: cipher.analyse(model_options) # optional - gurobi # optional - espresso
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy11()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:       optimization=OPTIMIZATION.MILP,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:       milp_solver=GUROBI_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options)
             101 variables and 388 constraints were written to
             '...'
             1
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir) # optional - gurobi
 
             sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.toy_ciphers.toy11 \
@@ -43,19 +41,18 @@ class Toy11:
             sage: from civerly.model_options import *
             sage: from pathlib import Path
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy11()
-            sage: model_options = MODEL_OPTIONS(
-            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:     optimization=OPTIMIZATION.SAT,
-            ....:     granularity=GRANULARITY.BITWISE,
-            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:     sat_solver=CADICAL_CVL(),
-            ....:     logic_minimizer=ESPRESSO_CVL(),
-            ....:     path=Path(tmpdir)
-            ....: )
-            sage: cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy11()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:       sat_solver=CADICAL_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options)
             89 variables and 436 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -66,8 +63,6 @@ class Toy11:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : UNSAT
             1
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         """
 

--- a/src/civerly/cipher_implementations/toy_ciphers/toy11.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy11.py
@@ -17,6 +17,8 @@ class Toy11:
             ....:   import Toy11
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy11()
             sage: model_options = MODEL_OPTIONS(
             ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
@@ -26,18 +28,22 @@ class Toy11:
             ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:     milp_solver=GUROBI_CVL(),
             ....:     logic_minimizer=ESPRESSO_CVL(),
-            ....:     path=Path("./DOCTEST-Toy11-Models/")
+            ....:     path=Path(tmpdir)
             ....: )
             sage: cipher.analyse(model_options) # optional - gurobi # optional - espresso
             101 variables and 388 constraints were written to
-            'DOCTEST-Toy11-Models/toy11.mps'
+            '...'
             1
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir) # optional - gurobi
 
             sage: # optional - cadical # optional - espresso
             sage: from civerly.cipher_implementations.toy_ciphers.toy11 \
             ....:   import Toy11
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy11()
             sage: model_options = MODEL_OPTIONS(
             ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
@@ -47,11 +53,11 @@ class Toy11:
             ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:     sat_solver=CADICAL_CVL(),
             ....:     logic_minimizer=ESPRESSO_CVL(),
-            ....:     path=Path("./DOCTEST-Toy11-Models/")
+            ....:     path=Path(tmpdir)
             ....: )
             sage: cipher.analyse(model_options)
             89 variables and 436 clauses were written to
-            'DOCTEST-Toy11-Models/toy11.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -60,9 +66,8 @@ class Toy11:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : UNSAT
             1
-
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Toy11-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
         """
 

--- a/src/civerly/cipher_implementations/toy_ciphers/toy2.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy2.py
@@ -16,6 +16,8 @@ class Toy2:
             sage: from civerly.cipher_implementations.toy_ciphers.toy2 \
             ....:   import Toy2
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy2()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -23,11 +25,11 @@ class Toy2:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   path=Path("./DOCTEST-Toy2-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
             1120 variables and 6177 clauses were written to
-            'DOCTEST-Toy2-Models/Toy2.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -36,14 +38,18 @@ class Toy2:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Toy2-Models/Toy2.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
             sage: from civerly.cipher_implementations.toy_ciphers.toy2 \
             ....:   import Toy2
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy2()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -51,11 +57,11 @@ class Toy2:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   path=Path("./DOCTEST-Toy2-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
             1408 variables and 3617 clauses were written to
-            'DOCTEST-Toy2-Models/Toy2.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -64,13 +70,17 @@ class Toy2:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Toy2-Models/Toy2.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
         The test code for MILP:
             sage: from civerly.cipher_implementations.toy_ciphers.toy2 \
             ....:   import Toy2
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy2()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -78,20 +88,18 @@ class Toy2:
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path("./DOCTEST-Toy2-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - gurobi
             sage: cipher.analyse(model_options=model_options)
             1472 variables and 1105 constraints were written to
-            'DOCTEST-Toy2-Models/Toy2.mps'
+            '...'
             0
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Toy2-Models/Toy2.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
-
-        Removing the files:
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Toy2-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
         """
         cipher = SBoxCipher(16, 16, name="Toy2")
 

--- a/src/civerly/cipher_implementations/toy_ciphers/toy2.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy2.py
@@ -13,21 +13,24 @@ class Toy2:
         TESTS::
 
         The test code for SAT:
+            sage: # optional - cryptominisat
             sage: from civerly.cipher_implementations.toy_ciphers.toy2 \
             ....:   import Toy2
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy2()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy2()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:       sat_solver=CRYPTOMINISAT_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
+            ....:   cipher.generate_report(model_options)
             1120 variables and 6177 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -38,28 +41,18 @@ class Toy2:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
-
-            sage: from civerly.cipher_implementations.toy_ciphers.toy2 \
-            ....:   import Toy2
-            sage: from civerly.model_options import *
-            sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy2()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy2()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:       sat_solver=CRYPTOMINISAT_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            ....:   cipher.generate_report(model_options)
             1408 variables and 3617 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -70,36 +63,31 @@ class Toy2:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         The test code for MILP:
+            sage: # optional - gurobi
             sage: from civerly.cipher_implementations.toy_ciphers.toy2 \
             ....:   import Toy2
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy2()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - gurobi
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy2()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.MILP,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:       milp_solver=GUROBI_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            ....:   cipher.generate_report(model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             1472 variables and 1105 constraints were written to
             '...'
             0
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
         """
         cipher = SBoxCipher(16, 16, name="Toy2")
 

--- a/src/civerly/cipher_implementations/toy_ciphers/toy3.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy3.py
@@ -19,6 +19,8 @@ class Toy3:
             sage: from civerly.cipher_implementations.toy_ciphers.toy3 \
             ....:   import Toy3
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy3()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -28,10 +30,10 @@ class Toy3:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-Toy3-Models/"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options)
             798 variables and 3591 clauses were written to
-            'DOCTEST-Toy3-Models/Toy3.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -42,8 +44,8 @@ class Toy3:
             8
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Toy3-Models/Toy3.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
 
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.toy_ciphers.toy3 \
@@ -58,12 +60,12 @@ class Toy3:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-Toy3-Models/"))
-            sage: cipher.analyse(model_options)
-            Using existing file DOCTEST-Toy3-Models/espresso-5a255793_out.pla,
+            ....:   path=Path(tmpdir))
+            sage: cipher.analyse(model_options)  # doctest: +ELLIPSIS
+            Using existing file ...,
             make sure it is up to date!
             812 variables and 3563 clauses were written to
-            'DOCTEST-Toy3-Models/Toy3.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -74,17 +76,18 @@ class Toy3:
             8
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Toy3-Models/Toy3.pdf
-
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Toy3-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
         The test code for MILP:
 
             sage: from civerly.cipher_implementations.toy_ciphers.toy3 \
             ....:   import Toy3
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy3()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -93,18 +96,18 @@ class Toy3:
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
             ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path("./DOCTEST-Toy3-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - gurobi
             sage: cipher.analyse(model_options)
             854 variables and 1313 constraints were written to
-            'DOCTEST-Toy3-Models/Toy3.mps'
+            '...'
             8
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Toy3-Models/Toy3.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Toy3-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
         Test multi-step modeling with external Espresso reduction::
 
@@ -112,6 +115,8 @@ class Toy3:
             sage: from civerly.cipher_implementations.toy_ciphers.toy3 \
             ....:   import Toy3
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy3()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -121,19 +126,19 @@ class Toy3:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=None,
-            ....:   path=Path("./DOCTEST-Toy3-Models/"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options)
             Optimization problem for Espresso has been written to...
             sage: # optional - espresso
             sage: import os
             sage: _ = os.popen("espresso -epos "
-            ....: "DOCTEST-Toy3-Models/espresso-5a255793_in.pla > "
-            ....: "DOCTEST-Toy3-Models/espresso-5a255793_out.pla").read()
-            sage: cipher.analyse(model_options)
-            Using existing file DOCTEST-Toy3-Models/espresso-5a255793_out.pla,
+            ....: f"{tmpdir}/espresso-5a255793_in.pla > "
+            ....: f"{tmpdir}/espresso-5a255793_out.pla").read()
+            sage: cipher.analyse(model_options)  # doctest: +ELLIPSIS
+            Using existing file ...,
             make sure it is up to date!
             812 variables and 3563 clauses were written to
-            'DOCTEST-Toy3-Models/Toy3.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -143,7 +148,7 @@ class Toy3:
             [  7 ,  8] (trying w =   7) : UNSAT
             8
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Toy3-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
 
         """

--- a/src/civerly/cipher_implementations/toy_ciphers/toy3.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy3.py
@@ -20,18 +20,35 @@ class Toy3:
             ....:   import Toy3
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy3()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy3()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       sat_solver=CRYPTOMINISAT_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
+            ....:   cipher.generate_report(model_options)
+            ....:   cipher = Toy3()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       sat_solver=CRYPTOMINISAT_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
+            ....:   cipher.generate_report(model_options)
             798 variables and 3591 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -42,101 +59,72 @@ class Toy3:
             [  7 ,  9] (trying w =   8) : SAT
             [  7 ,  8] (trying w =   7) : UNSAT
             8
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
+            Using existing file ..., make sure it is up to date!
+            812 variables and 3563 clauses were written to
+            '...'
+            [  0 ,100] (trying w =  50) : SAT
+            [  0 , 50] (trying w =  25) : SAT
+            [  0 , 25] (trying w =  12) : SAT
+            [  0 , 12] (trying w =   6) : UNSAT
+            [  7 , 12] (trying w =   9) : SAT
+            [  7 ,  9] (trying w =   8) : SAT
+            [  7 ,  8] (trying w =   7) : UNSAT
+            8
+            Output file in: ...
+
+        The test code for MILP:
+
+            sage: # optional - gurobi
+            sage: from civerly.cipher_implementations.toy_ciphers.toy3 \
+            ....:   import Toy3
+            sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy3()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.MILP,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:       sbox_modeling=SBOX_MODELING.CONVEX_HULL,
+            ....:       milp_solver=GUROBI_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
+            ....:   cipher.generate_report(model_options)
+            854 variables and 1313 constraints were written to
+            '...'
+            8
+            Output file in: ...
+
+        Test multi-step modeling with external Espresso reduction::
 
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.toy_ciphers.toy3 \
             ....:   import Toy3
             sage: from civerly.model_options import *
-            sage: cipher = Toy3()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options)  # doctest: +ELLIPSIS
-            Using existing file ...,
-            make sure it is up to date!
-            812 variables and 3563 clauses were written to
-            '...'
-            [  0 ,100] (trying w =  50) : SAT
-            [  0 , 50] (trying w =  25) : SAT
-            [  0 , 25] (trying w =  12) : SAT
-            [  0 , 12] (trying w =   6) : UNSAT
-            [  7 , 12] (trying w =   9) : SAT
-            [  7 ,  9] (trying w =   8) : SAT
-            [  7 ,  8] (trying w =   7) : UNSAT
-            8
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
-            Output file in: ...
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
-
-        The test code for MILP:
-
-            sage: from civerly.cipher_implementations.toy_ciphers.toy3 \
-            ....:   import Toy3
-            sage: from civerly.model_options import *
-            sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy3()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - gurobi
-            sage: cipher.analyse(model_options)
-            854 variables and 1313 constraints were written to
-            '...'
-            8
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
-            Output file in: ...
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
-
-        Test multi-step modeling with external Espresso reduction::
-
-            sage: # optional - cryptominisat
-            sage: from civerly.cipher_implementations.toy_ciphers.toy3 \
-            ....:   import Toy3
-            sage: from civerly.model_options import *
-            sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy3()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=None,
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options)
+            sage: import tempfile, os
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy3()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       sat_solver=CRYPTOMINISAT_CVL(),
+            ....:       logic_minimizer=None,
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options)
+            ....:   _ = os.popen(
+            ....:       f"espresso -epos {tmpdir}/espresso-5a255793_in.pla > "
+            ....:       f"{tmpdir}/espresso-5a255793_out.pla"
+            ....:   ).read()
+            ....:   cipher.analyse(model_options)
             Optimization problem for Espresso has been written to...
-            sage: # optional - espresso
-            sage: import os
-            sage: _ = os.popen("espresso -epos "
-            ....: f"{tmpdir}/espresso-5a255793_in.pla > "
-            ....: f"{tmpdir}/espresso-5a255793_out.pla").read()
-            sage: cipher.analyse(model_options)  # doctest: +ELLIPSIS
-            Using existing file ...,
-            make sure it is up to date!
+            Using existing file ..., make sure it is up to date!
             812 variables and 3563 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -147,8 +135,6 @@ class Toy3:
             [  7 ,  9] (trying w =   8) : SAT
             [  7 ,  8] (trying w =   7) : UNSAT
             8
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
 
         """

--- a/src/civerly/cipher_implementations/toy_ciphers/toy4.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy4.py
@@ -17,6 +17,8 @@ class Toy4:
             sage: from civerly.cipher_implementations.toy_ciphers.toy4 \
             ....:   import Toy4
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy4()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -26,10 +28,10 @@ class Toy4:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-Toy4-Models/"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options=model_options)
             288 variables and 1537 clauses were written to
-            'DOCTEST-Toy4-Models/Toy4.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -38,15 +40,19 @@ class Toy4:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Toy4-Models/Toy4.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.toy_ciphers.toy4 \
             ....:   import Toy4
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy4()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -56,10 +62,10 @@ class Toy4:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-Toy4-Models/"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options=model_options)
             360 variables and 897 clauses were written to
-            'DOCTEST-Toy4-Models/Toy4.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -68,16 +74,20 @@ class Toy4:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Toy4-Models/Toy4.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
         The test code for MILP:
 
             sage: from civerly.cipher_implementations.toy_ciphers.toy4 \
             ....:   import Toy4
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy4()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -86,21 +96,16 @@ class Toy4:
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
             ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path("./DOCTEST-Toy4-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - gurobi
             sage: cipher.analyse(model_options)
             376 variables and 305 constraints were written to
-            'DOCTEST-Toy4-Models/Toy4.mps'
+            '...'
             0
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
-
-        The last line checks whether the ciphers last layer is represented
-        correctly, even though it has a smaller width than the ciphers
-        wordsize.
-        Removing the files:
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Toy4-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
         """
         cipher = SBoxCipher(32, 16, name="Toy4")

--- a/src/civerly/cipher_implementations/toy_ciphers/toy4.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy4.py
@@ -18,18 +18,21 @@ class Toy4:
             ....:   import Toy4
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy4()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy4()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       sat_solver=CRYPTOMINISAT_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            ....:   cipher.generate_report(model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             288 variables and 1537 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -40,30 +43,22 @@ class Toy4:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
-
-            sage: # optional - cryptominisat # optional - espresso
-            sage: from civerly.cipher_implementations.toy_ciphers.toy4 \
-            ....:   import Toy4
-            sage: from civerly.model_options import *
-            sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy4()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy4()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       sat_solver=CRYPTOMINISAT_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            ....:   cipher.generate_report(model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             360 variables and 897 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -74,38 +69,31 @@ class Toy4:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : SAT
             0
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         The test code for MILP:
 
+            sage: # optional - gurobi
             sage: from civerly.cipher_implementations.toy_ciphers.toy4 \
             ....:   import Toy4
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy4()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - gurobi
-            sage: cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy4()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.MILP,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:       sbox_modeling=SBOX_MODELING.CONVEX_HULL,
+            ....:       milp_solver=GUROBI_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             376 variables and 305 constraints were written to
             '...'
             0
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         """
         cipher = SBoxCipher(32, 16, name="Toy4")

--- a/src/civerly/cipher_implementations/toy_ciphers/toy5.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy5.py
@@ -14,6 +14,8 @@ class Toy5:
             sage: from civerly.cipher_implementations.toy_ciphers.toy5 \
             ....:   import Toy5
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy5()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -23,10 +25,10 @@ class Toy5:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CADICAL_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-Toy5-Models/"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options)
             2940 variables and 13997 clauses were written to
-            'DOCTEST-Toy5-Models/Toy5.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -35,8 +37,8 @@ class Toy5:
             [  7 ,  9] (trying w =   8) : SAT
             [  7 ,  8] (trying w =   7) : UNSAT
             8
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Toy5-Models/Toy5.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
 
@@ -53,12 +55,12 @@ class Toy5:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   sat_solver=CADICAL_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-Toy5-Models/"))
-            sage: cipher.analyse(model_options)
-            Using existing file DOCTEST-Toy5-Models/espresso-5a255793_out.pla,
+            ....:   path=Path(tmpdir))
+            sage: cipher.analyse(model_options)  # doctest: +ELLIPSIS
+            Using existing file ...,
             make sure it is up to date!
             3256 variables and 11381 clauses were written to
-            'DOCTEST-Toy5-Models/Toy5.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -67,15 +69,19 @@ class Toy5:
             [  7 ,  9] (trying w =   8) : SAT
             [  7 ,  8] (trying w =   7) : UNSAT
             8
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Toy5-Models/Toy5.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
 
             sage: # optional - gurobi
             sage: from civerly.cipher_implementations.toy_ciphers.toy5 \
             ....:   import Toy5
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy5()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -84,17 +90,17 @@ class Toy5:
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
             ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path("./DOCTEST-Toy5-Models/"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options)
             3404 variables and 4177 constraints were written to
-            'DOCTEST-Toy5-Models/Toy5.mps'
+            '...'
             8
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Toy5-Models/Toy5.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Toy5-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
         """
         cipher = SBoxCipher(48, 16, name="Toy5")

--- a/src/civerly/cipher_implementations/toy_ciphers/toy5.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy5.py
@@ -15,18 +15,35 @@ class Toy5:
             ....:   import Toy5
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy5()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CADICAL_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy5()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       sat_solver=CADICAL_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options)
+            ....:   cipher.generate_report(model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
+            ....:   cipher = Toy5()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       sat_solver=CADICAL_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options)
+            ....:   cipher.generate_report(model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             2940 variables and 13997 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -37,28 +54,8 @@ class Toy5:
             [  7 ,  9] (trying w =   8) : SAT
             [  7 ,  8] (trying w =   7) : UNSAT
             8
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-
-            sage: # optional - cadical # optional - espresso
-            sage: from civerly.cipher_implementations.toy_ciphers.toy5 \
-            ....:   import Toy5
-            sage: from civerly.model_options import *
-            sage: cipher = Toy5()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CADICAL_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options)  # doctest: +ELLIPSIS
-            Using existing file ...,
-            make sure it is up to date!
+            Using existing file ..., make sure it is up to date!
             3256 variables and 11381 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -69,38 +66,31 @@ class Toy5:
             [  7 ,  9] (trying w =   8) : SAT
             [  7 ,  8] (trying w =   7) : UNSAT
             8
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
             sage: # optional - gurobi
             sage: from civerly.cipher_implementations.toy_ciphers.toy5 \
             ....:   import Toy5
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy5()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-            ....:   milp_solver=GUROBI_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy5()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.MILP,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:       sbox_modeling=SBOX_MODELING.CONVEX_HULL,
+            ....:       milp_solver=GUROBI_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options)
+            ....:   cipher.generate_report(model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             3404 variables and 4177 constraints were written to
             '...'
             8
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         """
         cipher = SBoxCipher(48, 16, name="Toy5")

--- a/src/civerly/cipher_implementations/toy_ciphers/toy6.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy6.py
@@ -12,17 +12,19 @@ class Toy6:
             sage: from civerly.cipher_implementations.toy_ciphers.toy6 \
             ....:   import Toy6
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy6()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   path=Path("./DOCTEST-Toy6-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options)
             397 variables and 1142 clauses were written to
-            'DOCTEST-Toy6-Models/Toy6.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -31,12 +33,12 @@ class Toy6:
             [  0 ,  3] (trying w =   1) : UNSAT
             [  2 ,  3] (trying w =   2) : SAT
             2
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Toy6-Models/Toy6.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Toy6-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
 
         """

--- a/src/civerly/cipher_implementations/toy_ciphers/toy6.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy6.py
@@ -9,20 +9,23 @@ class Toy6:
 
         TESTS::
 
+            sage: # optional - cryptominisat
             sage: from civerly.cipher_implementations.toy_ciphers.toy6 \
             ....:   import Toy6
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy6()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy6()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       sat_solver=CRYPTOMINISAT_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options)
+            ....:   cipher.generate_report(model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             397 variables and 1142 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -33,12 +36,7 @@ class Toy6:
             [  0 ,  3] (trying w =   1) : UNSAT
             [  2 ,  3] (trying w =   2) : SAT
             2
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
 
         """

--- a/src/civerly/cipher_implementations/toy_ciphers/toy7.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy7.py
@@ -41,16 +41,6 @@ class Toy7:
             [  3 ,  4] (trying w =   3) : SAT
             3
             Output file in: ...
-            Using existing file ..., make sure it is up to date!
-            Using existing file ..., make sure it is up to date!
-            Using existing file ..., make sure it is up to date!
-            Using existing file ..., make sure it is up to date!
-            Using existing file ..., make sure it is up to date!
-            1356 variables and 3621 clauses were written to '...'
-            [  0 ,  8] (trying w =   4) : SAT
-            [  0 ,  4] (trying w =   2) : UNSAT
-            [  3 ,  4] (trying w =   3) : SAT
-            3
 
         """
 

--- a/src/civerly/cipher_implementations/toy_ciphers/toy7.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy7.py
@@ -17,30 +17,40 @@ class Toy7:
             ....:   import Toy7
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy7()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   solve_range=(0, 8),
-            ....:   path=Path(tmpdir))
-            sage: cipher.analyse(model_options=model_options)
-            1356 variables and 3621 clauses were written to
-            '...'
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy7()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       sat_solver=CRYPTOMINISAT_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       solve_range=(0, 8),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            ....:   cipher.generate_report(model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
+            Using existing file ..., make sure it is up to date!
+            Using existing file ..., make sure it is up to date!
+            Using existing file ..., make sure it is up to date!
+            1356 variables and 3621 clauses were written to '...'
             [  0 ,  8] (trying w =   4) : SAT
             [  0 ,  4] (trying w =   2) : UNSAT
             [  3 ,  4] (trying w =   3) : SAT
             3
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
+            Using existing file ..., make sure it is up to date!
+            Using existing file ..., make sure it is up to date!
+            Using existing file ..., make sure it is up to date!
+            Using existing file ..., make sure it is up to date!
+            Using existing file ..., make sure it is up to date!
+            1356 variables and 3621 clauses were written to '...'
+            [  0 ,  8] (trying w =   4) : SAT
+            [  0 ,  4] (trying w =   2) : UNSAT
+            [  3 ,  4] (trying w =   3) : SAT
+            3
 
         """
 

--- a/src/civerly/cipher_implementations/toy_ciphers/toy7.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy7.py
@@ -16,6 +16,8 @@ class Toy7:
             sage: from civerly.cipher_implementations.toy_ciphers.toy7 \
             ....:   import Toy7
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy7()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -25,26 +27,20 @@ class Toy7:
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
             ....:   solve_range=(0, 8),
-            ....:   path=Path("./DOCTEST-Toy7-Models/"))
+            ....:   path=Path(tmpdir))
             sage: cipher.analyse(model_options=model_options)
-            Using existing file DOCTEST-Toy7-Models/espresso-4ce399fb_out.pla,
-            make sure it is up to date!
-            Using existing file DOCTEST-Toy7-Models/espresso-4ce399fb_out.pla,
-            make sure it is up to date!
-            Using existing file DOCTEST-Toy7-Models/espresso-d3ba4659_out.pla,
-            make sure it is up to date!
             1356 variables and 3621 clauses were written to
-            'DOCTEST-Toy7-Models/Toy7.cnf'
+            '...'
             [  0 ,  8] (trying w =   4) : SAT
             [  0 ,  4] (trying w =   2) : UNSAT
             [  3 ,  4] (trying w =   3) : SAT
             3
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Toy7-Models/Toy7.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Toy7-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
         """
 

--- a/src/civerly/cipher_implementations/toy_ciphers/toy8.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy8.py
@@ -12,27 +12,25 @@ class Toy8:
 
         The test code for SAT:
 
+            sage: # optional - cryptominisat
             sage: from civerly.cipher_implementations.toy_ciphers.toy8 \
             ....:   import Toy8
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy8()
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options=model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy8()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       sat_solver=CRYPTOMINISAT_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            ....:   cipher.generate_report(model_options)
+            ....:   trail = str(cipher.get_trail(model_options))
+            ....:   assert "Unnamed Component" not in trail
             ...
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-            sage: trail = str(cipher.get_trail(model_options))
-            sage: assert "Unnamed Component" not in trail
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         """
 

--- a/src/civerly/cipher_implementations/toy_ciphers/toy8.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy8.py
@@ -15,22 +15,24 @@ class Toy8:
             sage: from civerly.cipher_implementations.toy_ciphers.toy8 \
             ....:   import Toy8
             sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy8()
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.SAT,
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   path=Path("./DOCTEST-Toy8-Models/"))
+            ....:   path=Path(tmpdir))
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options=model_options)
             ...
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-Toy8-Models/Toy8.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
             sage: trail = str(cipher.get_trail(model_options))
             sage: assert "Unnamed Component" not in trail
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Toy8-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
         """
 

--- a/src/civerly/cipher_implementations/toy_ciphers/toy9.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy9.py
@@ -14,6 +14,8 @@ class Toy9:
             ....:   import Toy9
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy9()
             sage: model_options = MODEL_OPTIONS(
             ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -22,18 +24,22 @@ class Toy9:
             ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:     milp_solver=GUROBI_CVL(),
             ....:     logic_minimizer=ESPRESSO_CVL(),
-            ....:     path=Path("./DOCTEST-Toy9-Models/")
+            ....:     path=Path(tmpdir)
             ....: )
             sage: cipher.analyse(model_options) # optional - gurobi # optional - espresso
             36 variables and 85 constraints were written to
-            'DOCTEST-Toy9-Models/toy9.mps'
+            '...'
             1.4150374993
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir) # optional - gurobi
 
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.toy_ciphers.toy9 \
             ....:   import Toy9
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: cipher = Toy9()
             sage: model_options = MODEL_OPTIONS(
             ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -42,11 +48,11 @@ class Toy9:
             ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:     sat_solver=CRYPTOMINISAT_CVL(),
             ....:     logic_minimizer=ESPRESSO_CVL(),
-            ....:     path=Path("./DOCTEST-Toy9-Models/")
+            ....:     path=Path(tmpdir)
             ....: )
             sage: cipher.analyse(model_options)
             36 variables and 109 clauses were written to
-            'DOCTEST-Toy9-Models/toy9.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -56,7 +62,7 @@ class Toy9:
             [  0 ,  1] (trying w =   0) : UNSAT
             1
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-Toy9-Models", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
         """
 

--- a/src/civerly/cipher_implementations/toy_ciphers/toy9.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy9.py
@@ -10,28 +10,26 @@ class Toy9:
 
         TESTS::
 
+            sage: # optional - gurobi # optional - espresso
             sage: from civerly.cipher_implementations.toy_ciphers.toy9 \
             ....:   import Toy9
             sage: from civerly.model_options import *
             sage: from pathlib import Path
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy9()
-            sage: model_options = MODEL_OPTIONS(
-            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:     optimization=OPTIMIZATION.MILP,
-            ....:     granularity=GRANULARITY.BITWISE,
-            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:     milp_solver=GUROBI_CVL(),
-            ....:     logic_minimizer=ESPRESSO_CVL(),
-            ....:     path=Path(tmpdir)
-            ....: )
-            sage: cipher.analyse(model_options) # optional - gurobi # optional - espresso
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy9()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.MILP,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       milp_solver=GUROBI_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options)
             36 variables and 85 constraints were written to
             '...'
             1.4150374993
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir) # optional - gurobi
 
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.cipher_implementations.toy_ciphers.toy9 \
@@ -39,18 +37,17 @@ class Toy9:
             sage: from civerly.model_options import *
             sage: from pathlib import Path
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: cipher = Toy9()
-            sage: model_options = MODEL_OPTIONS(
-            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:     optimization=OPTIMIZATION.SAT,
-            ....:     granularity=GRANULARITY.BITWISE,
-            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:     sat_solver=CRYPTOMINISAT_CVL(),
-            ....:     logic_minimizer=ESPRESSO_CVL(),
-            ....:     path=Path(tmpdir)
-            ....: )
-            sage: cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
+            ....:   cipher = Toy9()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       sat_solver=CRYPTOMINISAT_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options)
             36 variables and 109 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -61,8 +58,6 @@ class Toy9:
             [  0 ,  3] (trying w =   1) : SAT
             [  0 ,  1] (trying w =   0) : UNSAT
             1
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
         """
 

--- a/src/civerly/cipher_implementations/weak_present.py
+++ b/src/civerly/cipher_implementations/weak_present.py
@@ -24,72 +24,66 @@ class WEAK_PRESENT_CVL:
             sage: from civerly.cipher_implementations.weak_present \
             ....:     import WEAK_PRESENT_CVL
             sage: from civerly.model_options import *
-            sage: from pathlib import Path
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: weak_cipher = WEAK_PRESENT_CVL(R=2)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   milp_solver=GUROBI_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir)
-            ....: )
-            sage: weak_cipher.analyse(model_options) # optional - gurobi # optional - espresso
-            2560 variables and 4417 constraints were written to ...
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   weak_cipher = WEAK_PRESENT_CVL(R=2)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     milp_solver=GUROBI_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir)
+            ....:   )
+            ....:   weak_cipher.analyse(model_options)
+            2560 variables and 4417 constraints were written to
+            '...'
             3.4150374993
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir) # optional - gurobi
 
         Use SCIP solver::
 
             sage: from civerly.cipher_implementations.weak_present \
             ....:     import WEAK_PRESENT_CVL
             sage: from civerly.model_options import *
-            sage: from pathlib import Path
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: weak_cipher = WEAK_PRESENT_CVL(R=2)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   milp_solver=SCIP_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir)
-            ....: )
-            sage: weak_cipher.analyse(model_options) # optional - scip # optional - espresso
-            2560 variables and 4417 constraints were written to ...
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - scip  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   weak_cipher = WEAK_PRESENT_CVL(R=2)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     milp_solver=SCIP_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir)
+            ....:   )
+            ....:   weak_cipher.analyse(model_options)
+            2560 variables and 4417 constraints were written to
+            '...'
             3.4150374993
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir) # optional - scip # optional - espresso
 
         Now for linear cryptanalysis the cipher with MILP:
 
             sage: from civerly.cipher_implementations.weak_present \
             ....:     import WEAK_PRESENT_CVL
             sage: from civerly.model_options import *
-            sage: from pathlib import Path
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: weak_cipher = WEAK_PRESENT_CVL(R=2)
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
-            ....:   optimization=OPTIMIZATION.MILP,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   milp_solver=GUROBI_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(tmpdir)
-            ....: )
-            sage: weak_cipher.analyse(model_options) # optional - gurobi # optional - espresso
-            2560 variables and 4321 constraints were written to ...
-            1.2451124979000001
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir) # optional - gurobi
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   weak_cipher = WEAK_PRESENT_CVL(R=2)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     milp_solver=GUROBI_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir)
+            ....:   )
+            ....:   weak_cipher.analyse(model_options)
+            2560 variables and 4321 constraints were written to
+            '...'
+            1.2451124979
         """
         if name is None:
             name = "WEAK_PRESENT"

--- a/src/civerly/cipher_implementations/weak_present.py
+++ b/src/civerly/cipher_implementations/weak_present.py
@@ -25,8 +25,9 @@ class WEAK_PRESENT_CVL:
             ....:     import WEAK_PRESENT_CVL
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: weak_cipher = WEAK_PRESENT_CVL(R=2)
-            sage: dir_name = "DOCTEST-WEAK_PRESENT-Models"
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.MILP,
@@ -34,13 +35,13 @@ class WEAK_PRESENT_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   milp_solver=GUROBI_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(dir_name)
+            ....:   path=Path(tmpdir)
             ....: )
             sage: weak_cipher.analyse(model_options) # optional - gurobi # optional - espresso
             2560 variables and 4417 constraints were written to ...
             3.4150374993
             sage: import shutil
-            sage: shutil.rmtree(dir_name) # optional - gurobi
+            sage: shutil.rmtree(tmpdir) # optional - gurobi
 
         Use SCIP solver::
 
@@ -48,8 +49,9 @@ class WEAK_PRESENT_CVL:
             ....:     import WEAK_PRESENT_CVL
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: weak_cipher = WEAK_PRESENT_CVL(R=2)
-            sage: dir_name = "DOCTEST-WEAK_PRESENT-Models"
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:   optimization=OPTIMIZATION.MILP,
@@ -57,13 +59,13 @@ class WEAK_PRESENT_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   milp_solver=SCIP_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(dir_name)
+            ....:   path=Path(tmpdir)
             ....: )
             sage: weak_cipher.analyse(model_options) # optional - scip # optional - espresso
             2560 variables and 4417 constraints were written to ...
             3.4150374993
             sage: import shutil
-            sage: shutil.rmtree(dir_name) # optional - scip # optional - espresso
+            sage: shutil.rmtree(tmpdir) # optional - scip # optional - espresso
 
         Now for linear cryptanalysis the cipher with MILP:
 
@@ -71,8 +73,9 @@ class WEAK_PRESENT_CVL:
             ....:     import WEAK_PRESENT_CVL
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: weak_cipher = WEAK_PRESENT_CVL(R=2)
-            sage: dir_name = "DOCTEST-WEAK_PRESENT-Models"
             sage: model_options = MODEL_OPTIONS(
             ....:   cryptanalysis=CRYPTANALYSIS.LINEAR,
             ....:   optimization=OPTIMIZATION.MILP,
@@ -80,13 +83,13 @@ class WEAK_PRESENT_CVL:
             ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:   milp_solver=GUROBI_CVL(),
             ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path(dir_name)
+            ....:   path=Path(tmpdir)
             ....: )
             sage: weak_cipher.analyse(model_options) # optional - gurobi # optional - espresso
             2560 variables and 4321 constraints were written to ...
             1.2451124979000001
             sage: import shutil
-            sage: shutil.rmtree(dir_name) # optional - gurobi
+            sage: shutil.rmtree(tmpdir) # optional - gurobi
         """
         if name is None:
             name = "WEAK_PRESENT"

--- a/src/civerly/component.py
+++ b/src/civerly/component.py
@@ -253,7 +253,7 @@ class I_CVL(Component):
             sage: int_to_vec(0x1929ab6, 16)
             Traceback (most recent call last):
             ...
-            ValueError: Input size of 26382006 too large (can at most be 65536)
+            ValueError: Input size of 26385078 too large (can at most be 65536)
 
         TESTS::
 

--- a/src/civerly/component.py
+++ b/src/civerly/component.py
@@ -53,9 +53,10 @@ class Component(ABC):
     EXAMPLES::
 
         sage: from civerly.component import Component
-        sage: try: comp = Component(16, 16)
-        ....: except TypeError: print("Did not work")
-        Did not work
+        sage: comp = Component(16, 16)  # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+        ...
+        TypeError: Can't instantiate abstract class Component...
 
     .. admonition:: For future development
 
@@ -249,9 +250,10 @@ class I_CVL(Component):
             sage: identity = I_CVL(16)
             sage: hex(vec_to_int(identity(int_to_vec(0x1f2,16))))
             '0x1f2'
-            sage: try: hex(vec_to_int(identity(int_to_vec(0x1929ab6,16))))
-            ....: except ValueError: print("Did not work")
-            Did not work
+            sage: int_to_vec(0x1929ab6, 16)
+            Traceback (most recent call last):
+            ...
+            ValueError: Input size of 26382006 too large (can at most be 65536)
 
         TESTS::
 
@@ -472,9 +474,10 @@ class ConstXOR_CVL(Component):
         sage: constxor = ConstXOR_CVL(32, 0x11112222)
         sage: hex(vec_to_int(constxor(int_to_vec(0xababcdcd,32))))
         '0xbabaefef'
-        sage: try: constxor.const = 0x1019b214
-        ....: except AttributeError: print("Did not work")
-        Did not work
+        sage: constxor.const = 0x1019b214  # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+        ...
+        AttributeError: ...
 
     TESTS::
 

--- a/src/civerly/component.py
+++ b/src/civerly/component.py
@@ -992,37 +992,34 @@ class AND_CVL(Component):
 
         TESTS::
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.component import AND_CVL
             sage: from civerly.model_options import *
             sage: from civerly.cipher import Cipher
             sage: from civerly.util import suppress_output
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: results = []
-            sage: N = 10
-            sage: for n in range(1, N+1):
-            ....:   cipher = Cipher(2*n, n, name="and-doctest")
-            ....:   node = cipher.add_subcipher(
-            ....:       AND_CVL(n, name="and"),
-            ....:       [(cipher.IN, (i, i)) for i in range(2*n)]
-            ....:   )
-            ....:   cipher.add_output([(node, (i, i)) for i in range(n)])
-            ....:   model_options = MODEL_OPTIONS(
-            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:       optimization=OPTIMIZATION.SAT,
-            ....:       granularity=GRANULARITY.BITWISE,
-            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:       sat_solver=CRYPTOMINISAT_CVL(),
-            ....:       logic_minimizer=ESPRESSO_CVL(),
-            ....:       path=Path(tmpdir))
-            ....:   with suppress_output():
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso
+            ....:   results = []
+            ....:   N = 10
+            ....:   for n in range(1, N+1):
+            ....:     cipher = Cipher(2*n, n, name="and-doctest")
+            ....:     node = cipher.add_subcipher(
+            ....:         AND_CVL(n, name="and"),
+            ....:         [(cipher.IN, (i, i)) for i in range(2*n)]
+            ....:     )
+            ....:     cipher.add_output([(node, (i, i)) for i in range(n)])
+            ....:     model_options = MODEL_OPTIONS(
+            ....:         cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:         optimization=OPTIMIZATION.SAT,
+            ....:         granularity=GRANULARITY.BITWISE,
+            ....:         sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:         sat_solver=CRYPTOMINISAT_CVL(),
+            ....:         logic_minimizer=ESPRESSO_CVL(),
+            ....:         path=Path(tmpdir))
+            ....:     with suppress_output():
             ....:       result = cipher.analyse(model_options)
-            ....:   results.append(result)
-            sage: results == [1]*N
+            ....:     results.append(result)
+            ....:   print(results == [1]*N)
             True
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
 
 
         """
@@ -1478,34 +1475,55 @@ class LinearLayer_CVL(Component):
             sage: from civerly.cipher import Cipher
             sage: from civerly.component import LinearLayer_CVL
             sage: from civerly.model_options import *
-            sage: from pathlib import Path
             sage: import tempfile
-            sage: tmpdir = tempfile.mkdtemp()
-            sage: arr = [
-            ....:   [1, 0, 0, 0],
-            ....:   [0, 1, 0, 0],
-            ....:   [0, 0, 1, 0],
-            ....:   [0, 0, 0, 1],
-            ....:   [0, 0, 0, 1],
-            ....:   [0, 0, 1, 0],
-            ....:   [0, 1, 0, 0],
-            ....:   [1, 0, 0, 0]
-            ....: ]
-            sage: linearlayer = LinearLayer_CVL(matrix(GF(2), 8, 4, arr))
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   path=Path(tmpdir))
-            sage: cipher = Cipher(4, 8, name="LL-doctest")
-            sage: node = cipher.add_subcipher(
-            ....:   linearlayer, [(cipher.IN, (i, i)) for i in range(4)]
-            ....: )
-            sage: cipher.add_output([(node, (i, i)) for i in range(8)])
-            sage: # optional - cryptominisat
-            sage: cipher.analyse(model_options)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   arr = [
+            ....:     [1, 0, 0, 0],
+            ....:     [0, 1, 0, 0],
+            ....:     [0, 0, 1, 0],
+            ....:     [0, 0, 0, 1],
+            ....:     [0, 0, 0, 1],
+            ....:     [0, 0, 1, 0],
+            ....:     [0, 1, 0, 0],
+            ....:     [1, 0, 0, 0]
+            ....:   ]
+            ....:   linearlayer = LinearLayer_CVL(matrix(GF(2), 8, 4, arr))
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   cipher = Cipher(4, 8, name="LL-doctest")
+            ....:   node = cipher.add_subcipher(
+            ....:     linearlayer, [(cipher.IN, (i, i)) for i in range(4)]
+            ....:   )
+            ....:   cipher.add_output([(node, (i, i)) for i in range(8)])
+            ....:   cipher.analyse(model_options)
+            ....:   cipher.generate_report(model_options)
+            ....:   arr = [
+            ....:     [0, 0, 1, 1],
+            ....:     [1, 0, 1, 1],
+            ....:     [0, 1, 0, 0],
+            ....:     [1, 1, 1, 0],
+            ....:     [1, 1, 0, 0],
+            ....:     [0, 0, 0, 0],
+            ....:     [0, 1, 0, 0],
+            ....:     [1, 0, 1, 1]
+            ....:   ]
+            ....:   mat = matrix(GF(2), 8, 4, arr)
+            ....:   linearlayer = LinearLayer_CVL(mat, name=f"L(4 -> 8)")
+            ....:   cipher = Cipher(4, 8, name="LL-doctest")
+            ....:   node = cipher.add_subcipher(
+            ....:     linearlayer, [(cipher.IN, (i, i)) for i in range(4)])
+            ....:   cipher.add_output([(node, (i, i)) for i in range(8)])
+            ....:   cipher.model(model_options)
+            ....:   model_options.sat_solver.solve(
+            ....:     Path(tmpdir) / 'LL-doctest.cnf',
+            ....:     Path(tmpdir) / 'LL-doctest.sat',
+            ....:     model_options)
+            ....:   cipher.get_trail(model_options)
             48 variables and 89 clauses were written to
             '...'
             [  0 ,100] (trying w =  50) : SAT
@@ -1516,33 +1534,9 @@ class LinearLayer_CVL(Component):
             [  0 , 3] (trying w =   1) : SAT
             [  0 , 1] (trying w =   0) : SAT
             0
-            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
             Output file in: ...
-
-            sage: arr = [
-            ....:   [0, 0, 1, 1],
-            ....:   [1, 0, 1, 1],
-            ....:   [0, 1, 0, 0],
-            ....:   [1, 1, 1, 0],
-            ....:   [1, 1, 0, 0],
-            ....:   [0, 0, 0, 0],
-            ....:   [0, 1, 0, 0],
-            ....:   [1, 0, 1, 1]
-            ....: ]
-            sage: mat = matrix(GF(2), 8, 4, arr)
-            sage: linearlayer = LinearLayer_CVL(mat, name=f"L(4 -> 8)")
-            sage: cipher = Cipher(4, 8, name="LL-doctest")
-            sage: node = cipher.add_subcipher(
-            ....:   linearlayer, [(cipher.IN, (i, i)) for i in range(4)])
-            sage: cipher.add_output([(node, (i, i)) for i in range(8)])
-            sage: sat_model = cipher.model(model_options)  # doctest: +ELLIPSIS
             48 variables and 110 clauses were written to
             '...'
-            sage: # optional - cryptominisat
-            sage: model_options.sat_solver.solve(
-            ....:   Path(tmpdir) / 'LL-doctest.cnf',
-            ....:   Path(tmpdir) / 'LL-doctest.sat',
-            ....:   model_options)
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -1551,10 +1545,7 @@ class LinearLayer_CVL(Component):
             [  0 , 3] (trying w =   1) : SAT
             [  0 , 1] (trying w =   0) : SAT
             0
-            sage: cipher.get_trail(model_options)
             ...
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
         """
 
         if model_options.cryptanalysis == CRYPTANALYSIS.DIFFERENTIAL:
@@ -1986,7 +1977,6 @@ class SBox_CVL(Component):
                 sage: from civerly.solvers import *
                 sage: from civerly.util import suppress_output, vec_to_int
                 sage: import tempfile
-                sage: tmpdir = tempfile.mkdtemp()
                 sage: sb = SBox(
                 ....:   (4, 0, 1, 8, 2, 5, 10, 7, 6, 9, 3, 11, 12, 13, 14, 15)
                 ....: )
@@ -1996,36 +1986,34 @@ class SBox_CVL(Component):
                 ....:   sbox, [(cipher.IN, (i, i)) for i in range(4)]
                 ....: )
                 sage: cipher.add_output([(node, (i, i)) for i in range(4)])
-                sage: model_options = MODEL_OPTIONS(
-                ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-                ....:   optimization=OPTIMIZATION.MILP,
-                ....:   granularity=GRANULARITY.BITWISE,
-                ....:   sbox_modeling=SBOX_MODELING.DISTORTED_BALL,
-                ....:   milp_solver=GUROBI_CVL(),
-                ....:   path=Path(tmpdir))
-                sage: # optional - gurobi
-                sage: with suppress_output():
-                ....:   milp = cipher.analyse(model_options)
-                sage: results, objective_value = model_options.milp_solver.process_solution_file(
-                ....:   model_options.path / (cipher.name + ".sol")
-                ....: )
-                sage: objective_value
+                sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi
+                ....:   model_options = MODEL_OPTIONS(
+                ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+                ....:     optimization=OPTIMIZATION.MILP,
+                ....:     granularity=GRANULARITY.BITWISE,
+                ....:     sbox_modeling=SBOX_MODELING.DISTORTED_BALL,
+                ....:     milp_solver=GUROBI_CVL(),
+                ....:     path=Path(tmpdir))
+                ....:   with suppress_output():
+                ....:     milp = cipher.analyse(model_options)
+                ....:   results, objective_value = model_options.milp_solver.process_solution_file(
+                ....:     model_options.path / (cipher.name + ".sol")
+                ....:   )
+                ....:   print(objective_value)
+                ....:   in_diff  = vec_to_int(vector(
+                ....:     GF(2), 4,
+                ....:     [results['IN'][i] for i in range(4)]
+                ....:   ))
+                ....:   out_diff = vec_to_int(vector(
+                ....:     GF(2), 4,
+                ....:     [results['OUT'][i] for i in range(4)]
+                ....:   ))
+                ....:   ddt = sb.difference_distribution_table()
+                ....:   print(ddt[in_diff][out_diff])
+                ....:   print(ddt[in_diff][out_diff]/16.0 == 2**(-objective_value))
                 1
-                sage: in_diff  = vec_to_int(vector(
-                ....:   GF(2), 4,
-                ....:   [results['IN'][i] for i in range(4)]
-                ....: ))
-                sage: out_diff = vec_to_int(vector(
-                ....:   GF(2), 4,
-                ....:   [results['OUT'][i] for i in range(4)]
-                ....: ))
-                sage: ddt = sb.difference_distribution_table()
-                sage: ddt[in_diff][out_diff]
                 8
-                sage: ddt[in_diff][out_diff]/16.0 == 2**(-objective_value)
                 True
-                sage: import shutil
-                sage: shutil.rmtree(tmpdir)
 
             Test small-sbox modeling for toy cipher using a single SBox with a
             unique transition of (non-trivial) maximal probability::
@@ -2036,7 +2024,6 @@ class SBox_CVL(Component):
                 sage: from civerly.model_options import *
                 sage: from civerly.util import suppress_output, vec_to_int
                 sage: import tempfile
-                sage: tmpdir = tempfile.mkdtemp()
                 sage: sb = SBox(
                 ....:   (4, 0, 1, 8, 2, 5, 10, 7, 6, 9, 3, 11, 12, 13, 14, 15)
                 ....: )
@@ -2046,38 +2033,36 @@ class SBox_CVL(Component):
                 ....:   sbox, [(cipher.IN, (i, i)) for i in range(4)]
                 ....: )
                 sage: cipher.add_output([(node, (i, i)) for i in range(4)])
-                sage: model_options = MODEL_OPTIONS(
-                ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-                ....:   optimization=OPTIMIZATION.MILP,
-                ....:   granularity=GRANULARITY.BITWISE,
-                ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
-                ....:   milp_solver=GUROBI_CVL(),
-                ....:   path=Path(tmpdir))
-                sage:  # optional - gurobi
-                sage: with suppress_output():
-                ....:   milp = cipher.model(model_options)
-                sage: model_options.milp_solver.solve(
-                ....:   input_file_name=model_options.path / (cipher.name + ".mps"),
-                ....:   output_file_name=model_options.path / (cipher.name + ".sol"),
-                ....: )
-                sage: results, objective_value = model_options.milp_solver.process_solution_file(
-                ....:   model_options.path / (cipher.name + ".sol"),
-                ....: )
-                sage: objective_value
+                sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - gurobi
+                ....:   model_options = MODEL_OPTIONS(
+                ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+                ....:     optimization=OPTIMIZATION.MILP,
+                ....:     granularity=GRANULARITY.BITWISE,
+                ....:     sbox_modeling=SBOX_MODELING.CONVEX_HULL,
+                ....:     milp_solver=GUROBI_CVL(),
+                ....:     path=Path(tmpdir))
+                ....:   with suppress_output():
+                ....:     milp = cipher.model(model_options)
+                ....:   model_options.milp_solver.solve(
+                ....:     input_file_name=model_options.path / (cipher.name + ".mps"),
+                ....:     output_file_name=model_options.path / (cipher.name + ".sol"),
+                ....:   )
+                ....:   results, objective_value = model_options.milp_solver.process_solution_file(
+                ....:     model_options.path / (cipher.name + ".sol"),
+                ....:   )
+                ....:   print(objective_value)
+                ....:   in_diff  = vec_to_int(vector(
+                ....:     GF(2), 4, [results['IN'][i] for i in range(4)]
+                ....:   ))
+                ....:   out_diff = vec_to_int(vector(
+                ....:     GF(2), 4, [results['OUT'][i] for i in range(4)]
+                ....:   ))
+                ....:   ddt = sb.difference_distribution_table()
+                ....:   print(ddt[in_diff][out_diff])
+                ....:   print(ddt[in_diff][out_diff]/16.0 == 2**(-objective_value))
                 1
-                sage: in_diff  = vec_to_int(vector(
-                ....:   GF(2), 4, [results['IN'][i] for i in range(4)]
-                ....: ))
-                sage: out_diff = vec_to_int(vector(
-                ....:   GF(2), 4, [results['OUT'][i] for i in range(4)]
-                ....: ))
-                sage: ddt = sb.difference_distribution_table()
-                sage: ddt[in_diff][out_diff]
                 8
-                sage: ddt[in_diff][out_diff]/16.0 == 2**(-objective_value)
                 True
-                sage: import shutil
-                sage: shutil.rmtree(tmpdir)
         """
         solver = model_options.milp_solver
 
@@ -2396,39 +2381,38 @@ class SBox_CVL(Component):
             sage: from civerly.component import SBox_CVL
             sage: from civerly.model_options import *
             sage: from civerly.util import suppress_output, vec_to_int
+            sage: import tempfile
             sage: sb = SBox((4, 0, 1, 8, 2, 5, 10, 7, 6, 9, 3, 11, 12, 13, 14, 15))
             sage: sbox = SBox_CVL(sb, "s-box")
             sage: cipher = SBoxCipher(4, 4, name="ToySingleSBoxCipher")
             sage: node = cipher.add_subcipher(sbox, [(cipher.IN, (i, i)) for i in range(4)])
             sage: cipher.add_output([(node, (i, i)) for i in range(4)])
-            sage: model_options = MODEL_OPTIONS(
-            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:   optimization=OPTIMIZATION.SAT,
-            ....:   granularity=GRANULARITY.BITWISE,
-            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   logic_minimizer=ESPRESSO_CVL(),
-            ....:   path=Path("./DOCTEST-ToySingleSBoxCipher-Models/"))
-            sage: # optional - cryptominisat # optional - espresso
-            sage: with suppress_output(): cipher.analyse(model_options)
-            sage: results, objective_value = model_options.sat_solver.process_solution_file(
-            ....:   model_options.path / (cipher.name + ".sat")
-            ....: )
-            sage: objective_value
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cryptominisat  # optional - espresso
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CRYPTOMINISAT_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir))
+            ....:   with suppress_output(): cipher.analyse(model_options)
+            ....:   results, objective_value = model_options.sat_solver.process_solution_file(
+            ....:     model_options.path / (cipher.name + ".sat")
+            ....:   )
+            ....:   print(objective_value)
+            ....:   in_diff  = vec_to_int(
+            ....:     vector(GF(2), 4, [results[i+1] for i in range(4)])
+            ....:   )
+            ....:   out_diff = vec_to_int(
+            ....:     vector(GF(2), 4, [results[i+5] for i in range(4)])
+            ....:   )
+            ....:   print(sb.difference_distribution_table()[in_diff][out_diff])
+            ....:   print(sb.difference_distribution_table()[in_diff][out_diff]/16.0
+            ....:         == 2**(-int(objective_value)))
             1
-            sage: in_diff  = vec_to_int(
-            ....:   vector(GF(2), 4, [results[i+1] for i in range(4)])
-            ....: )
-            sage: out_diff = vec_to_int(
-            ....:   vector(GF(2), 4, [results[i+5] for i in range(4)])
-            ....: )
-            sage: sb.difference_distribution_table()[in_diff][out_diff]
             8
-            sage: sb.difference_distribution_table()[in_diff][out_diff]/16.0 \
-            ....:   == 2**(-int(objective_value))
             True
-            sage: import shutil
-            sage: shutil.rmtree("./DOCTEST-ToySingleSBoxCipher-Models/")
 
 
         """

--- a/src/civerly/component.py
+++ b/src/civerly/component.py
@@ -997,6 +997,8 @@ class AND_CVL(Component):
             sage: from civerly.model_options import *
             sage: from civerly.cipher import Cipher
             sage: from civerly.util import suppress_output
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: results = []
             sage: N = 10
             sage: for n in range(1, N+1):
@@ -1013,15 +1015,14 @@ class AND_CVL(Component):
             ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
             ....:       sat_solver=CRYPTOMINISAT_CVL(),
             ....:       logic_minimizer=ESPRESSO_CVL(),
-            ....:       path=Path("./DOCTEST-ANDComponent-Models/"))
+            ....:       path=Path(tmpdir))
             ....:   with suppress_output():
             ....:       result = cipher.analyse(model_options)
             ....:   results.append(result)
             sage: results == [1]*N
             True
             sage: import shutil
-            sage: shutil.rmtree(
-            ....:   "./DOCTEST-ANDComponent-Models/", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
 
 
         """
@@ -1478,6 +1479,8 @@ class LinearLayer_CVL(Component):
             sage: from civerly.component import LinearLayer_CVL
             sage: from civerly.model_options import *
             sage: from pathlib import Path
+            sage: import tempfile
+            sage: tmpdir = tempfile.mkdtemp()
             sage: arr = [
             ....:   [1, 0, 0, 0],
             ....:   [0, 1, 0, 0],
@@ -1495,7 +1498,7 @@ class LinearLayer_CVL(Component):
             ....:   granularity=GRANULARITY.BITWISE,
             ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
             ....:   sat_solver=CRYPTOMINISAT_CVL(),
-            ....:   path=Path("./DOCTEST-LL-SAT/"))
+            ....:   path=Path(tmpdir))
             sage: cipher = Cipher(4, 8, name="LL-doctest")
             sage: node = cipher.add_subcipher(
             ....:   linearlayer, [(cipher.IN, (i, i)) for i in range(4)]
@@ -1504,7 +1507,7 @@ class LinearLayer_CVL(Component):
             sage: # optional - cryptominisat
             sage: cipher.analyse(model_options)
             48 variables and 89 clauses were written to
-            'DOCTEST-LL-SAT/LL-doctest.cnf'
+            '...'
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
             [  0 , 25] (trying w =  12) : SAT
@@ -1513,8 +1516,8 @@ class LinearLayer_CVL(Component):
             [  0 , 3] (trying w =   1) : SAT
             [  0 , 1] (trying w =   0) : SAT
             0
-            sage: cipher.generate_report(model_options)
-            Output file in: DOCTEST-LL-SAT/LL-doctest.pdf
+            sage: cipher.generate_report(model_options)  # doctest: +ELLIPSIS
+            Output file in: ...
 
             sage: arr = [
             ....:   [0, 0, 1, 1],
@@ -1532,13 +1535,13 @@ class LinearLayer_CVL(Component):
             sage: node = cipher.add_subcipher(
             ....:   linearlayer, [(cipher.IN, (i, i)) for i in range(4)])
             sage: cipher.add_output([(node, (i, i)) for i in range(8)])
-            sage: sat_model = cipher.model(model_options)
+            sage: sat_model = cipher.model(model_options)  # doctest: +ELLIPSIS
             48 variables and 110 clauses were written to
-            'DOCTEST-LL-SAT/LL-doctest.cnf'
+            '...'
             sage: # optional - cryptominisat
             sage: model_options.sat_solver.solve(
-            ....:   Path('DOCTEST-LL-SAT/LL-doctest.cnf'),
-            ....:   Path('DOCTEST-LL-SAT/LL-doctest.sat'),
+            ....:   Path(tmpdir) / 'LL-doctest.cnf',
+            ....:   Path(tmpdir) / 'LL-doctest.sat',
             ....:   model_options)
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT
@@ -1550,11 +1553,8 @@ class LinearLayer_CVL(Component):
             0
             sage: cipher.get_trail(model_options)
             ...
-
-        Removing the files:
-
             sage: import shutil
-            sage: shutil.rmtree("DOCTEST-LL-SAT", ignore_errors=True)
+            sage: shutil.rmtree(tmpdir)
         """
 
         if model_options.cryptanalysis == CRYPTANALYSIS.DIFFERENTIAL:
@@ -1985,6 +1985,8 @@ class SBox_CVL(Component):
                 sage: from civerly.model_options import *
                 sage: from civerly.solvers import *
                 sage: from civerly.util import suppress_output, vec_to_int
+                sage: import tempfile
+                sage: tmpdir = tempfile.mkdtemp()
                 sage: sb = SBox(
                 ....:   (4, 0, 1, 8, 2, 5, 10, 7, 6, 9, 3, 11, 12, 13, 14, 15)
                 ....: )
@@ -2000,7 +2002,7 @@ class SBox_CVL(Component):
                 ....:   granularity=GRANULARITY.BITWISE,
                 ....:   sbox_modeling=SBOX_MODELING.DISTORTED_BALL,
                 ....:   milp_solver=GUROBI_CVL(),
-                ....:   path=Path("./DOCTEST-ToySingleSBoxCipher-Models/"))
+                ....:   path=Path(tmpdir))
                 sage: # optional - gurobi
                 sage: with suppress_output():
                 ....:   milp = cipher.analyse(model_options)
@@ -2023,7 +2025,7 @@ class SBox_CVL(Component):
                 sage: ddt[in_diff][out_diff]/16.0 == 2**(-objective_value)
                 True
                 sage: import shutil
-                sage: shutil.rmtree("./DOCTEST-ToySingleSBoxCipher-Models/")
+                sage: shutil.rmtree(tmpdir)
 
             Test small-sbox modeling for toy cipher using a single SBox with a
             unique transition of (non-trivial) maximal probability::
@@ -2033,6 +2035,8 @@ class SBox_CVL(Component):
                 sage: from civerly.component import SBox_CVL
                 sage: from civerly.model_options import *
                 sage: from civerly.util import suppress_output, vec_to_int
+                sage: import tempfile
+                sage: tmpdir = tempfile.mkdtemp()
                 sage: sb = SBox(
                 ....:   (4, 0, 1, 8, 2, 5, 10, 7, 6, 9, 3, 11, 12, 13, 14, 15)
                 ....: )
@@ -2048,7 +2052,7 @@ class SBox_CVL(Component):
                 ....:   granularity=GRANULARITY.BITWISE,
                 ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
                 ....:   milp_solver=GUROBI_CVL(),
-                ....:   path=Path("./DOCTEST-ToySingleSBoxCipher-Models/"))
+                ....:   path=Path(tmpdir))
                 sage:  # optional - gurobi
                 sage: with suppress_output():
                 ....:   milp = cipher.model(model_options)
@@ -2073,7 +2077,7 @@ class SBox_CVL(Component):
                 sage: ddt[in_diff][out_diff]/16.0 == 2**(-objective_value)
                 True
                 sage: import shutil
-                sage: shutil.rmtree("./DOCTEST-ToySingleSBoxCipher-Models/")
+                sage: shutil.rmtree(tmpdir)
         """
         solver = model_options.milp_solver
 

--- a/src/civerly/sboxcipher.py
+++ b/src/civerly/sboxcipher.py
@@ -81,6 +81,9 @@ class SBoxCipher(Cipher):
                 sage: from civerly.model_options import *
                 sage: from sage.crypto.sboxes import PRESENT as present_S_sage
                 sage: from civerly.util import suppress_output
+                sage: import tempfile
+                sage: from pathlib import Path
+                sage: tmpdir = tempfile.mkdtemp()
                 sage: name = "ToyFeistel"
                 sage: n = 4
                 sage: R = 1
@@ -114,7 +117,7 @@ class SBoxCipher(Cipher):
                 ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
                 ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
                 ....:   milp_solver=GUROBI_CVL(),
-                ....:   path=Path("./DOCTEST-ToyFeistelCipher-Models/"))
+                ....:   path=Path(tmpdir))
                 sage: # optional - gurobi
                 sage: with suppress_output():
                 ....:   milp = cipher.analyse(model_options)
@@ -137,7 +140,7 @@ class SBoxCipher(Cipher):
                 ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
                 ....:   sbox_modeling=SBOX_MODELING.CONVEX_HULL,
                 ....:   milp_solver=GUROBI_CVL(),
-                ....:   path=Path("./DOCTEST-ToyFeistelCipher-Models/"))
+                ....:   path=Path(tmpdir))
                 sage: # optional - gurobi
                 sage: with suppress_output():
                 ....:   milp = cipher.analyse(model_options)
@@ -146,9 +149,7 @@ class SBoxCipher(Cipher):
                 ....: )[1]
                 1
                 sage: import shutil
-                sage: shutil.rmtree(
-                ....:   "DOCTEST-ToyFeistelCipher-Models",
-                ....:   ignore_errors=True)
+                sage: shutil.rmtree(tmpdir)
 
         """
         if model_options.granularity == GRANULARITY.WORDWISE \

--- a/src/civerly/solvers.py
+++ b/src/civerly/solvers.py
@@ -1021,24 +1021,21 @@ class NoSolverWarning(Warning):
         sage: from civerly.cipher_implementations.aes import AES_CVL
         sage: import tempfile
         sage: aes = AES_CVL(6)
-        sage: tmpdir = tempfile.mkdtemp()
-        sage: model_options = MODEL_OPTIONS(
-        ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-        ....:   optimization=OPTIMIZATION.MILP,
-        ....:   granularity=GRANULARITY.WORDWISE,
-        ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
-        ....:   milp_solver=None,
-        ....:   sat_solver=None,
-        ....:   path=Path(tmpdir))
-        sage: with suppress_output():
-        ....:   aes.analyse(model_options)
+        sage: with tempfile.TemporaryDirectory() as tmpdir:
+        ....:   model_options = MODEL_OPTIONS(
+        ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+        ....:     optimization=OPTIMIZATION.MILP,
+        ....:     granularity=GRANULARITY.WORDWISE,
+        ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
+        ....:     milp_solver=None,
+        ....:     sat_solver=None,
+        ....:     path=Path(tmpdir))
+        ....:   with suppress_output():
+        ....:     aes.analyse(model_options)
         Traceback (most recent call last):
         ...
         NoSolverWarning: No solver has been selected.
         CiVerLy will return without solving.
-
-        sage: import shutil
-        sage: shutil.rmtree(tmpdir)
 
 
     """

--- a/src/civerly/solvers.py
+++ b/src/civerly/solvers.py
@@ -1019,7 +1019,9 @@ class NoSolverWarning(Warning):
         sage: from civerly.model_options import *
         sage: from civerly.util import suppress_output
         sage: from civerly.cipher_implementations.aes import AES_CVL
+        sage: import tempfile
         sage: aes = AES_CVL(6)
+        sage: tmpdir = tempfile.mkdtemp()
         sage: model_options = MODEL_OPTIONS(
         ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
         ....:   optimization=OPTIMIZATION.MILP,
@@ -1027,7 +1029,7 @@ class NoSolverWarning(Warning):
         ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.GENERALIZED_WORDWISE,
         ....:   milp_solver=None,
         ....:   sat_solver=None,
-        ....:   path=Path("./DOCTEST-ModelOptions/"))
+        ....:   path=Path(tmpdir))
         sage: with suppress_output():
         ....:   aes.analyse(model_options)
         Traceback (most recent call last):
@@ -1036,7 +1038,7 @@ class NoSolverWarning(Warning):
         CiVerLy will return without solving.
 
         sage: import shutil
-        sage: shutil.rmtree("DOCTEST-ModelOptions")
+        sage: shutil.rmtree(tmpdir)
 
 
     """

--- a/src/civerly/util.py
+++ b/src/civerly/util.py
@@ -361,9 +361,10 @@ def _generate_constraints_sum_leq_int_LS24(sat, sum_arr, num):
         sage: from sage.sat.solvers.dimacs import DIMACS
         sage: from civerly.solvers import *
         sage: from civerly.model_options import *
+        sage: import tempfile
         sage: from pathlib import Path
-        sage: path = Path('./util_doctests/')
-        sage: path.mkdir(parents=True, exist_ok=True)
+        sage: tmpdir = tempfile.mkdtemp()
+        sage: path = Path(tmpdir)
         sage: for NUM_CLAUSES in range(1, 20):
         ....:   sat = DIMACS()
         ....:   for i in range(1, NUM_CLAUSES + 1): sat.add_clause((i,))
@@ -385,7 +386,7 @@ def _generate_constraints_sum_leq_int_LS24(sat, sum_arr, num):
         ....:                   "The constraints don't assert correct bound!")
         ....:           else: break
         sage: import shutil
-        sage: shutil.rmtree(path, ignore_errors=True)
+        sage: shutil.rmtree(tmpdir)
 
     If everything works correctly, then a constraint system which requires
     :math:`w` many variables to be SAT only becomes possible to solve if we
@@ -445,16 +446,18 @@ def _write_espresso_input(posset, esp_file_name, workdir_path):
     TESTS::
 
         sage: from civerly.util import _write_espresso_input
+        sage: import tempfile
         sage: from pathlib import Path
         sage: import os
-        sage: path = Path("./DOCTEST-Espresso/")
+        sage: tmpdir = tempfile.mkdtemp()
+        sage: path = Path(tmpdir)
         sage: file_name = "espresso-input-doctest"
         sage: posset = [(0, 0, 0)]
         sage: _write_espresso_input(posset, file_name, path)
         sage: os.path.exists(path / f"{file_name}_in.pla")
         True
         sage: import shutil
-        sage: shutil.rmtree("DOCTEST-Espresso", ignore_errors=True)
+        sage: shutil.rmtree(tmpdir)
 
     """
 
@@ -487,9 +490,11 @@ def _read_espresso_output(esp_file_out):
 
         sage: from civerly.util import _write_espresso_input
         sage: from civerly.util import _read_espresso_output
+        sage: import tempfile
         sage: from pathlib import Path
         sage: import os
-        sage: path = Path("./DOCTEST-Espresso/")
+        sage: tmpdir = tempfile.mkdtemp()
+        sage: path = Path(tmpdir)
         sage: file_name = "espresso-output-doctest"
         sage: posset = [(0, 0, 0), (1, 1, 1)]
         sage: _write_espresso_input(posset, file_name, path)
@@ -502,7 +507,7 @@ def _read_espresso_output(esp_file_out):
         sage: clauses == posset_from_clauses
         True
         sage: import shutil
-        sage: shutil.rmtree("DOCTEST-Espresso", ignore_errors=True)
+        sage: shutil.rmtree(tmpdir)
 
     Note that the clauses are not the correct ones describing posset,
     as the flipping via Espresso's `-epos` is missing.

--- a/src/civerly/util.py
+++ b/src/civerly/util.py
@@ -21,6 +21,23 @@ EXAMPLES::
     ...
     ValueError: Input size of 4660 too large (can at most be 4096)
 
+TESTS:
+
+    Verify that temporary directories used in doctests are actually removed
+    after cleanup, and that errors during cleanup are raised rather than
+    silently suppressed::
+
+        sage: import tempfile, shutil, os
+        sage: tmpdir = tempfile.mkdtemp()
+        sage: assert os.path.exists(tmpdir)    # directory exists before cleanup
+        sage: shutil.rmtree(tmpdir)
+        sage: os.path.exists(tmpdir)           # directory is gone after cleanup
+        False
+        sage: shutil.rmtree(tmpdir)            # raises without ignore_errors
+        Traceback (most recent call last):
+        ...
+        FileNotFoundError: ...
+
 """
 
 import warnings

--- a/src/civerly/util.py
+++ b/src/civerly/util.py
@@ -16,9 +16,10 @@ EXAMPLES::
     <class 'sage.modules.vector_mod2_dense.Vector_mod2_dense'>
     sage: vec_to_int(int_to_vec(0x1234,16)) == 0x1234
     True
-    sage: try: int_to_vec(0x1234, 12)
-    ....: except ValueError: print("Did not work")
-    Did not work
+    sage: int_to_vec(0x1234, 12)
+    Traceback (most recent call last):
+    ...
+    ValueError: Input size of 4660 too large (can at most be 4096)
 
 """
 
@@ -89,9 +90,10 @@ def int_to_vec(input_num, size):
         sage: int_to_vec(0x12340, 24)
         (0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0,
         1, 0, 0, 0, 0, 0, 0)
-        sage: try: int_to_vec(0x12340, 16)
-        ....: except ValueError: print("Did not work")
-        Did not work
+        sage: int_to_vec(0x12340, 16)
+        Traceback (most recent call last):
+        ...
+        ValueError: Input size of 74560 too large (can at most be 65536)
 
     TESTS::
 


### PR DESCRIPTION
Pull request for Issue [github.com/kryptoloesungen/CiVerLy#4](https://github.com/kryptoloesungen/CiVerLy/issues/4)
   
  What was changed                                                                                   
   
5a3e1d0 - Replaced try/except patterns with explicit Traceback format in doctests — now verifies exception type and message                                         
c608330 - Fixed a wrong expected error value introduced in the above commit (0x1929ab6 = 26385078, not 26382006) 
7c96271 - Migrated all ~80 doctest cleanup calls across 26 files to tempfile.mkdtemp() with explicit shutil.rmtree(tmpdir) and # doctest: +ELLIPSIS for path matching               
4e09986 - Added an explicit test in util.py proving cleanup actually removes the directory and that errors surface                                                                     
   
  ---           
  Alternative approaches considered for temp directory cleanup                                       
     
  tempfile.TemporaryDirectory() context manager                                                      
  auto-cleans even on failure, no shutil.rmtree needed at all. 
  Rejected because in Sage doctests, everything would have to be inside the with block, so inline sage: commands couldn’t be used anymore. Using it would require restructuring the tests.