### PR TITLE
Make ciphers exportable (json)

### DIFF
--- a/docs/source/user_manual/export_trail.rst
+++ b/docs/source/user_manual/export_trail.rst
@@ -1,0 +1,43 @@
+Exporting the Results
+=======================
+
+CiVerLy supports exporting Cipher objects into a json file.
+As Cipher objects also contain the trails coming from previous runs of :meth:`analysis`,
+it is possible to directly access those results from outside of CiVerLy,
+allowing to seamlessly incorporate them into your workflow.
+
+See the following example to understand how to export and load Cipher objects.
+
+.. code-block::
+    # First, analyse some cipher
+    from civerly.cipher_implementations.present import PRESENT_CVL
+    from civerly.model_options import *
+    cipher = PRESENT_CVL(4)
+    model_options = MODEL_OPTIONS(
+        optimization=OPTIMIZATION.MILP,
+        cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+        granularity=GRANULARITY.BITWISE,
+        sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+        milp_solver=GUROBI_CVL(),
+        linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+        logic_minimizer=ESPRESSO_CVL(),
+        path=Path("export-example")
+    )
+    cipher.analyse(model_options)
+    input_difference = cipher.result['in']
+    output_difference = cipher.result['out']
+   
+    # Export the cipher together with its results
+    import tempfile
+    with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+        tmpfile_name = f.name
+    cipher.export(tmpfile_name)
+   
+    # Load the cipher from scratch
+    loaded = cipher.load(tmpfile_name)
+    
+    # The results are still the same
+    loaded.result['in'] == input_difference
+    loaded.result['out'] == output_difference
+
+

--- a/docs/source/user_manual/index.rst
+++ b/docs/source/user_manual/index.rst
@@ -50,6 +50,12 @@ This can be as simple as printing e.g. the number of active S-boxes but you can
 also generate a PDF containing the details of the found trail.
 For more details, see `Generating the Report <generate_report.html>`_.
 
+**Exporting the Results**
+
+You can also export the results of your last analysis into a json file.
+This allows you to externally access and postprocess all your results later on.
+For more details, see `Exporting the Results <export_trail.html>`_.
+
 
 
 .. toctree::
@@ -60,3 +66,4 @@ For more details, see `Generating the Report <generate_report.html>`_.
    model_cipher
    solve_model
    generate_report
+   export_trail

--- a/src/civerly/addrx.py
+++ b/src/civerly/addrx.py
@@ -62,3 +62,8 @@ class AddRX(WordBasedCipher):
                 return super().add_subcipher(sub_cipher, edges)
             raise TypeError("AddRX does not accept SBox_CVL and AND_CVL")
         raise TypeError(f"Trying to add illegal component {type(sub_cipher)}.")
+
+    def _to_dict(self):
+        d = super()._to_dict()
+        d["type"] = "AddRX"
+        return d

--- a/src/civerly/aeslike.py
+++ b/src/civerly/aeslike.py
@@ -146,3 +146,14 @@ class AESlike(WordSBoxCipher):
         """
         assert self.__cols > 0
         return int(self.__cols)
+
+    def _to_dict(self):
+        d = super()._to_dict()
+        d["type"] = "AESlike"
+        d["rows"] = self.rows
+        d["cols"] = self.cols
+        return d
+
+    @classmethod
+    def _init_from_dict(cls, d):
+        return cls(d["wordsize"], d["rows"], d["cols"], name=d["name"])

--- a/src/civerly/andrx.py
+++ b/src/civerly/andrx.py
@@ -58,3 +58,8 @@ class AndRX(WordBasedCipher):
                 return super().add_subcipher(sub_cipher, edges)
             raise TypeError("AndRX does not accept SBox_CVL and ModAdd_CVL")
         raise TypeError(f"Trying to add illegal component {type(sub_cipher)}.")
+
+    def _to_dict(self):
+        d = super()._to_dict()
+        d["type"] = "AndRX"
+        return d

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -302,6 +302,9 @@ class Cipher:
         def _copy_over_dictionaries_recursively(self, prev, model_options):
             return
 
+        def _to_dict(self):
+            return {"type": "__Special_Node"}
+
         def _to_tikz(self, _comps=[]):
             return ""
 
@@ -1695,142 +1698,22 @@ class Cipher:
         root_node.verify_correctness()
         return root_node
 
-    # ------------------------------------------------------------------
-    # JSON export / import
-    # ------------------------------------------------------------------
-
     def _to_dict(self):
         r"""
         Return a JSON-serializable dictionary representation of ``self``.
 
         Used internally by :meth:`export` and :meth:`load`.
         """
-        from civerly.component import (
-            I_CVL, C_CVL, RK_CVL, ConstXOR_CVL, RoundkeyXOR_CVL,
-            XOR_CVL, ModAdd_CVL, AND_CVL, LinearLayer_CVL,
-            PermuteLayer_CVL, RotateLayer_CVL, SBox_CVL, ROT_AND_CVL,
-        )
-
-        def _int_or_none(x):
-            return int(x) if x is not None else None
-
-        def node_to_dict(node):
-            if isinstance(node, Cipher.__Special_Node):
-                return {"type": "__Special_Node"}
-            # Check subclasses before their superclasses
-            if isinstance(node, RotateLayer_CVL):
-                return {
-                    "type": "RotateLayer_CVL",
-                    "name": node.name,
-                    "input_length": int(node.input_length),
-                    "r": int(node.r),
-                    "word_coarseness": int(node.word_coarseness),
-                }
-            if isinstance(node, PermuteLayer_CVL):
-                return {
-                    "type": "PermuteLayer_CVL",
-                    "name": node.name,
-                    "perm": [int(x) for x in node.perm],
-                    "word_coarseness": int(node.word_coarseness),
-                }
-            if isinstance(node, LinearLayer_CVL):
-                return {
-                    "type": "LinearLayer_CVL",
-                    "name": node.name,
-                    "binary_matrix": [
-                        [int(x) for x in row]
-                        for row in node.binary_matrix.rows()
-                    ],
-                    "branch_number_differential": _int_or_none(
-                        node.branch_number_differential
-                    ),
-                    "branch_number_linear": _int_or_none(
-                        node.branch_number_linear
-                    ),
-                }
-            if isinstance(node, RoundkeyXOR_CVL):
-                return {
-                    "type": "RoundkeyXOR_CVL",
-                    "name": node.name,
-                    "output_length": int(node.output_length),
-                    "const": int(node.const),
-                }
-            if isinstance(node, ConstXOR_CVL):
-                return {
-                    "type": "ConstXOR_CVL",
-                    "name": node.name,
-                    "output_length": int(node.output_length),
-                    "const": int(node.const),
-                }
-            if isinstance(node, RK_CVL):
-                return {
-                    "type": "RK_CVL",
-                    "name": node.name,
-                    "output_length": int(node.output_length),
-                    "const": int(node.const),
-                }
-            if isinstance(node, C_CVL):
-                return {
-                    "type": "C_CVL",
-                    "name": node.name,
-                    "output_length": int(node.output_length),
-                    "const": int(node.const),
-                }
-            if isinstance(node, I_CVL):
-                return {
-                    "type": "I_CVL",
-                    "name": node.name,
-                    "input_length": int(node.input_length),
-                }
-            if isinstance(node, XOR_CVL):
-                return {
-                    "type": "XOR_CVL",
-                    "name": node.name,
-                    "word_length": int(node.word_length),
-                }
-            if isinstance(node, ModAdd_CVL):
-                return {
-                    "type": "ModAdd_CVL",
-                    "name": node.name,
-                    "word_length": int(node.word_length),
-                }
-            if isinstance(node, AND_CVL):
-                return {
-                    "type": "AND_CVL",
-                    "name": node.name,
-                    "word_length": int(node.word_length),
-                }
-            if isinstance(node, SBox_CVL):
-                return {
-                    "type": "SBox_CVL",
-                    "name": node.name,
-                    "S": [int(x) for x in node.S],
-                }
-            if isinstance(node, ROT_AND_CVL):
-                return {
-                    "type": "ROT_AND_CVL",
-                    "name": node.name,
-                    "word_length": int(node.word_length),
-                    "r": int(node.r),
-                }
-            if isinstance(node, Cipher):
-                return {"type": type(node).__name__, "cipher": node._to_dict()}
-            raise ValueError(
-                f"Cannot serialize node of unknown type "
-                f"{type(node).__name__!r}"
-            )
-
-        # The OUT node is appended last when is_valid becomes True
         out_idx = len(self.nodes) - 1 if self.is_valid else None
 
         node_dicts = [
-            {**node_to_dict(n), "result": n.result}
+            {**n._to_dict(), "result": n.result}
             for i, n in enumerate(self.nodes)
             if out_idx is None or i != out_idx
         ]
 
         edge_dicts = [
-            [[a, b], [x, y]]
+            ((a, b), (x, y))
             for (a, b), (x, y) in self.edges
             if out_idx is None or b != out_idx
         ]
@@ -1840,20 +1723,11 @@ class Cipher:
             for entry in self.outputs
         ]
 
-        extra = {}
-        if hasattr(self, 'wordsize'):
-            extra["wordsize"] = int(self.wordsize)
-        if hasattr(self, 'rows'):
-            extra["rows"] = int(self.rows)
-        if hasattr(self, 'cols'):
-            extra["cols"] = int(self.cols)
-
         return {
-            "cipher_class": type(self).__name__,
+            "type": "Cipher",
             "name": self.name,
             "input_length": self.input_length,
             "output_length": self.output_length,
-            **extra,
             "nodes": node_dicts,
             "edges": edge_dicts,
             "outputs": output_dicts,
@@ -1895,48 +1769,8 @@ class Cipher:
 
             sage: cipher.export(tmp)
             Object 'test' has been exported to ...
-            sage: import json
-            sage: with open(tmp, "r") as f:
-            ....:   dictionary = json.load(f)
-            sage: dictionary == {
-            ....:     'cipher_class': 'Cipher', 'name': 'test',
-            ....:     'input_length': 9, 'output_length': 9,
-            ....:     'nodes': [
-            ....:         {'type': '__Special_Node', 'result': None},
-            ....:         {
-            ....:             'type': 'SBox_CVL', 'name': 'Unnamed Component',
-            ....:             'S': [0, 6, 1, 4, 2, 3, 5, 7], 'result': None
-            ....:         },
-            ....:         {
-            ....:             'type': 'SBox_CVL', 'name': 'Unnamed Component',
-            ....:             'S': [0, 6, 1, 4, 2, 3, 5, 7], 'result': None
-            ....:         },
-            ....:         {
-            ....:             'type': 'SBox_CVL', 'name': 'Unnamed Component',
-            ....:             'S': [0, 6, 1, 4, 2, 3, 5, 7], 'result': None
-            ....:         }
-            ....:     ],
-            ....:     'edges': [
-            ....:         [[0, 1], [0, 0]],
-            ....:         [[0, 1], [1, 1]],
-            ....:         [[0, 1], [2, 2]],
-            ....:         [[0, 2], [3, 0]],
-            ....:         [[0, 2], [4, 1]],
-            ....:         [[0, 2], [5, 2]],
-            ....:         [[0, 3], [6, 0]],
-            ....:         [[0, 3], [7, 1]],
-            ....:         [[0, 3], [8, 2]]
-            ....:     ],
-            ....:     'outputs': [
-            ....:         [1, 0], [1, 1], [1, 2],
-            ....:         [2, 0], [2, 1], [2, 2],
-            ....:         [3, 0], [3, 1], [3, 2]
-            ....:     ],
-            ....:     'result': None
-            ....: }
-            True
             sage: loaded = Cipher.load(tmp)
-            sage: cipher == loaded
+            sage: cipher == loaded and loaded.result is None
             True
 
         After analysis, ``result`` holds the trail bit-pattern and is
@@ -1963,7 +1797,6 @@ class Cipher:
             True
 
         Again with a different cipher type::
-            
             sage: import tempfile
             sage: from civerly.cipher import Cipher
             sage: from civerly.cipher_implementations.aes import AES_CVL
@@ -1972,19 +1805,96 @@ class Cipher:
             ....:   tmp = f.name
             ....:   aes.export(tmp)
             ....:   loaded = Cipher.load(tmp)
-            ....:   aes == loaded and aes.__dict__ == loaded.__dict__
+            ....:   aes == loaded
             Object 'AES' has been exported to ...
             True
-            sage: from civerly.aeslike import AESlike
-            sage: isinstance(loaded, AESlike)
-            True
-
 
         """
         with open(path, "w") as f:
-            json.dump(self._to_dict(), f,
-                      default=lambda obj: int(obj))
+            json.dump(self._to_dict(), f, default=lambda obj: int(obj))
         print(f"Object '{self.name}' has been exported to {path}.")
+
+    @classmethod
+    def _init_from_dict(cls, d):
+        r"""
+        Construct a new empty cipher shell from a dictionary produced by
+        :meth:`_to_dict`. Override in subclasses that have a different
+        constructor signature.
+        """
+        return cls(d["input_length"], d["output_length"], name=d["name"])
+
+    @staticmethod
+    def _populate_from_dict(cipher, d):
+        r"""
+        Restore nodes, edges, outputs and result onto an empty cipher shell
+        using data from a dictionary produced by :meth:`_to_dict`.
+        """
+        from civerly.component import (
+            I_CVL, C_CVL, RK_CVL, ConstXOR_CVL, RoundkeyXOR_CVL,
+            XOR_CVL, ModAdd_CVL, AND_CVL, LinearLayer_CVL,
+            PermuteLayer_CVL, RotateLayer_CVL, SBox_CVL, ROT_AND_CVL,
+        )
+        from civerly.sboxcipher import SBoxCipher
+        from civerly.wordbasedcipher import WordBasedCipher
+        from civerly.wordsboxcipher import WordSBoxCipher
+        from civerly.aeslike import AESlike
+        from civerly.addrx import AddRX
+        from civerly.andrx import AndRX
+
+        _TYPE_MAP = {
+            "Cipher": Cipher,
+            "SBoxCipher": SBoxCipher,
+            "WordBasedCipher": WordBasedCipher,
+            "WordSBoxCipher": WordSBoxCipher,
+            "AESlike": AESlike,
+            "AddRX": AddRX,
+            "AndRX": AndRX,
+            "I_CVL": I_CVL,
+            "C_CVL": C_CVL,
+            "RK_CVL": RK_CVL,
+            "ConstXOR_CVL": ConstXOR_CVL,
+            "RoundkeyXOR_CVL": RoundkeyXOR_CVL,
+            "XOR_CVL": XOR_CVL,
+            "ModAdd_CVL": ModAdd_CVL,
+            "AND_CVL": AND_CVL,
+            "LinearLayer_CVL": LinearLayer_CVL,
+            "PermuteLayer_CVL": PermuteLayer_CVL,
+            "RotateLayer_CVL": RotateLayer_CVL,
+            "SBox_CVL": SBox_CVL,
+            "ROT_AND_CVL": ROT_AND_CVL,
+        }
+
+        def node_from_dict(nd):
+            class_var = _TYPE_MAP[nd["type"]]
+            if class_var is None:
+                raise ValueError(f"Unknown node type {nd["type"]!r} in JSON")
+            return class_var._from_dict(nd)
+
+        # Restore the IN node's result (index 0)
+        cipher.nodes[0].result = d["nodes"][0]["result"]
+        w = 1 if type(cipher) == Cipher else cipher.wordsize
+
+        for node_idx, nd in enumerate(d["nodes"][1:], start=1):
+            component = node_from_dict(nd)
+            incoming = list(set([
+                (a, (x//w, y//w))
+                for (a, b), (x, y) in d["edges"]
+                if b == node_idx
+            ]))
+            cipher.add_subcipher(component, incoming)
+            if not isinstance(component, Cipher):
+                cipher.nodes[node_idx].result = nd["result"]
+
+        output_edges = list(set([
+            (a, (x//w, y//w))
+            for y, entry in enumerate(d["outputs"])
+            if entry is not None
+            for a, x in [entry]
+        ]))
+        if output_edges:
+            cipher.add_output(output_edges)
+
+        cipher.result = d["result"]
 
     @classmethod
     def _from_dict(cls, d):
@@ -1992,129 +1902,8 @@ class Cipher:
         Reconstruct a :class:`Cipher` from a dictionary produced by
         :meth:`_to_dict`.
         """
-        from civerly.component import (
-            I_CVL, C_CVL, RK_CVL, ConstXOR_CVL, RoundkeyXOR_CVL,
-            XOR_CVL, ModAdd_CVL, AND_CVL, LinearLayer_CVL,
-            PermuteLayer_CVL, RotateLayer_CVL, SBox_CVL, ROT_AND_CVL,
-        )
-
-        def node_from_dict(nd):
-            t = nd["type"]
-            name = nd.get("name")
-            if t == "I_CVL":
-                return I_CVL(nd["input_length"], name=name)
-            if t == "C_CVL":
-                return C_CVL(nd["output_length"], nd["const"], name=name)
-            if t == "RK_CVL":
-                return RK_CVL(nd["output_length"], nd["const"], name=name)
-            if t == "ConstXOR_CVL":
-                return ConstXOR_CVL(
-                    nd["output_length"], nd["const"], name=name
-                )
-            if t == "RoundkeyXOR_CVL":
-                return RoundkeyXOR_CVL(
-                    nd["output_length"], nd["const"], name=name
-                )
-            if t == "XOR_CVL":
-                return XOR_CVL(nd["word_length"], name=name)
-            if t == "ModAdd_CVL":
-                return ModAdd_CVL(nd["word_length"], name=name)
-            if t == "AND_CVL":
-                return AND_CVL(nd["word_length"], name=name)
-            if t == "LinearLayer_CVL":
-                mat = matrix(GF(2), nd["binary_matrix"])
-                return LinearLayer_CVL(
-                    mat,
-                    branch_number_differential=nd[
-                        "branch_number_differential"
-                    ],
-                    branch_number_linear=nd["branch_number_linear"],
-                    name=name,
-                )
-            if t == "PermuteLayer_CVL":
-                return PermuteLayer_CVL(
-                    nd["perm"],
-                    word_coarseness=nd["word_coarseness"],
-                    name=name,
-                )
-            if t == "RotateLayer_CVL":
-                return RotateLayer_CVL(
-                    nd["input_length"],
-                    nd["r"],
-                    word_coarseness=nd["word_coarseness"],
-                    name=name,
-                )
-            if t == "SBox_CVL":
-                return SBox_CVL(SBox(nd["S"]), name=name)
-            if t == "ROT_AND_CVL":
-                return ROT_AND_CVL(nd["word_length"], nd["r"], name=name)
-            if t in (
-                "Cipher", "WordBasedCipher", "SBoxCipher",
-                "WordSBoxCipher", "AddRX", "AndRX", "AESlike"
-            ):
-                return cls._from_dict(nd["cipher"])
-            raise ValueError(f"Unknown node type {t!r} in JSON")
-
-        cipher_class_name = d.get("cipher_class", "Cipher")
-        if cipher_class_name == "SBoxCipher":
-            from civerly.sboxcipher import SBoxCipher
-            wordsize = 1
-            cipher = SBoxCipher(d["input_length"], d["output_length"], name=d["name"])
-        elif cipher_class_name == "WordBasedCipher":
-            from civerly.wordbasedcipher import WordBasedCipher
-            wordsize = d["wordsize"]
-            cipher = WordBasedCipher(wordsize, d["input_length"] // wordsize, d["output_length"] // wordsize, name=d["name"])
-        elif cipher_class_name == "WordSBoxCipher":
-            from civerly.wordsboxcipher import WordSBoxCipher
-            wordsize = d["wordsize"]
-            cipher = WordSBoxCipher(wordsize, d["input_length"] // wordsize, d["output_length"] // wordsize, name=d["name"])
-        elif cipher_class_name == "AddRX":
-            from civerly.addrx import AddRX
-            wordsize = d["wordsize"]
-            cipher = AddRX(wordsize, d["input_length"] // wordsize, d["output_length"] // wordsize, name=d["name"])
-        elif cipher_class_name == "AndRX":
-            from civerly.andrx import AndRX
-            wordsize = d["wordsize"]
-            cipher = AndRX(wordsize, d["input_length"] // wordsize, d["output_length"] // wordsize, name=d["name"])
-        elif cipher_class_name == "AESlike":
-            from civerly.aeslike import AESlike
-            wordsize = d["wordsize"]
-            cipher = AESlike(d["wordsize"], d["rows"], d["cols"], name=d["name"])
-        else:
-            wordsize = 1
-            cipher = cls(d["input_length"], d["output_length"], name=d["name"])
-
-        # Restore the IN node's result (index 0)
-        cipher.nodes[0].result = d["nodes"][0].get("result")
-
-        # d["nodes"][0] is the IN node — always present, skip during
-        # reconstruction (its index 0 is implicit in the edge list)
-        for node_idx, nd in enumerate(d["nodes"][1:], start=1):
-            component = node_from_dict(nd)
-            incoming = sorted(list(set([
-                (a, (x//wordsize, y//wordsize))
-                # (a, (x, y))
-                for [a, b], [x, y] in d["edges"]
-                if b == node_idx
-            ])))
-            cipher.add_subcipher(component, incoming)
-            # For Cipher nodes, _from_dict already restored .result on the
-            # component before add_subcipher deepcopied it, so it is correct.
-            # For leaf Component nodes, restore .result explicitly.
-            if nd["type"] != "Cipher":
-                cipher.nodes[node_idx].result = nd.get("result")
-
-        output_edges = sorted(list(set([
-            (a, (x//wordsize, y//wordsize))
-            # (a, (x, y))
-            for y, entry in enumerate(d["outputs"])
-            if entry is not None
-            for a, x in [entry]
-        ])))
-        if output_edges:
-            cipher.add_output(output_edges)
-
-        cipher.result = d["result"]
+        cipher = cls._init_from_dict(d)
+        Cipher._populate_from_dict(cipher, d)
         return cipher
 
     @classmethod

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -402,6 +402,12 @@ class Cipher:
         # wordsize. Any subclass of WordBasedCipher will overwrite this value
         # with `self.wordsize`
 
+        self.result = None
+        # self.result stores the input/output of the last call to self.analyse
+        # as a dict {"in": [...], "out": [...]}. It is None until analyse is
+        # called for the first time, and is completely overwritten on each
+        # subsequent call.
+
     # Get-functions of various attributes:
     # --------------------------------------------------
 
@@ -1479,9 +1485,9 @@ class Cipher:
                     input_file_name=model_options.path / (self.name + ".mps"),
                     output_file_name=model_options.path / (self.name + ".sol")
                 )
-                return model_options.milp_solver.process_solution_file(
-                    model_options.path / (self.name + ".sol")
-                )[1]
+                results, weight = self.read_results(model_options)
+                TrailNode(self, model_options, results)
+                return weight
         elif model_options.optimization == OPTIMIZATION.SAT:
             self.model(model_options)
             if self._return_immediately_:
@@ -1498,9 +1504,9 @@ class Cipher:
                 if model_options.sat_solver is None:
                     raise NoSolverWarning()
                 else:
-                    return model_options.sat_solver.process_solution_file(
-                        model_options.path / (self.name + ".sat"),
-                    )[1]
+                    results, weight = self.read_results(model_options)
+                    TrailNode(self, model_options, results)
+                    return weight
         else:
             raise InvalidModelOptionException(
                 model_options.optimization, OPTIMIZATION

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -52,7 +52,6 @@ from civerly.model_options import OPTIMIZATION, GRANULARITY
 from civerly.model_options import CRYPTANALYSIS
 from civerly.model_options import InvalidModelOptionException
 from civerly.solvers import NoSolverWarning
-from civerly.util import _before_brackets, _between_brackets
 from civerly.util import suppress_output, translate_sat_clause
 from civerly.trail import TrailNode
 
@@ -1643,11 +1642,11 @@ class Cipher:
         if model_options.optimization == OPTIMIZATION.MILP:
             solution_file_name = model_options.path / (self.name + ".sol")
             return model_options.milp_solver.process_solution_file(
-                solution_file_name) #, "MILP"
+                solution_file_name)
         elif model_options.optimization == OPTIMIZATION.SAT:
             solution_file_name = model_options.path / (self.name + ".sat")
             return model_options.sat_solver.process_solution_file(
-                solution_file_name) #, "SAT"
+                solution_file_name)
         else:
             raise InvalidModelOptionException(
                 model_options.optimization, OPTIMIZATION

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -98,6 +98,7 @@ class Cipher:
             self._return_immediately_ = False
             self.sum_arr_milp = []
             self.sum_arr_sat = []
+            self.result = None
             if in_node:
                 self.__name = f"{self.cipher_instance.name}.IN"
                 self.__input_length = self.cipher_instance.input_length
@@ -1692,6 +1693,347 @@ class Cipher:
         root_node = TrailNode(self, model_options, results)
         root_node.verify_correctness()
         return root_node
+
+    # ------------------------------------------------------------------
+    # JSON export / import
+    # ------------------------------------------------------------------
+
+    def _to_dict(self):
+        r"""
+        Return a JSON-serializable dictionary representation of ``self``.
+
+        Used internally by :meth:`export` and :meth:`load`.
+        """
+        from civerly.component import (
+            I_CVL, C_CVL, RK_CVL, ConstXOR_CVL, RoundkeyXOR_CVL,
+            XOR_CVL, ModAdd_CVL, AND_CVL, LinearLayer_CVL,
+            PermuteLayer_CVL, RotateLayer_CVL, SBox_CVL, ROT_AND_CVL,
+        )
+
+        def _int_or_none(x):
+            return int(x) if x is not None else None
+
+        def node_to_dict(node):
+            if isinstance(node, Cipher.__Special_Node):
+                return {"type": "__Special_Node"}
+            # Check subclasses before their superclasses
+            if isinstance(node, RotateLayer_CVL):
+                return {
+                    "type": "RotateLayer_CVL",
+                    "name": node.name,
+                    "input_length": int(node.input_length),
+                    "r": int(node.r),
+                    "word_coarseness": int(node.word_coarseness),
+                }
+            if isinstance(node, PermuteLayer_CVL):
+                return {
+                    "type": "PermuteLayer_CVL",
+                    "name": node.name,
+                    "perm": [int(x) for x in node.perm],
+                    "word_coarseness": int(node.word_coarseness),
+                }
+            if isinstance(node, LinearLayer_CVL):
+                return {
+                    "type": "LinearLayer_CVL",
+                    "name": node.name,
+                    "binary_matrix": [
+                        [int(x) for x in row]
+                        for row in node.binary_matrix.rows()
+                    ],
+                    "branch_number_differential": _int_or_none(
+                        node.branch_number_differential
+                    ),
+                    "branch_number_linear": _int_or_none(
+                        node.branch_number_linear
+                    ),
+                }
+            if isinstance(node, RoundkeyXOR_CVL):
+                return {
+                    "type": "RoundkeyXOR_CVL",
+                    "name": node.name,
+                    "output_length": int(node.output_length),
+                    "const": int(node.const),
+                }
+            if isinstance(node, ConstXOR_CVL):
+                return {
+                    "type": "ConstXOR_CVL",
+                    "name": node.name,
+                    "output_length": int(node.output_length),
+                    "const": int(node.const),
+                }
+            if isinstance(node, RK_CVL):
+                return {
+                    "type": "RK_CVL",
+                    "name": node.name,
+                    "output_length": int(node.output_length),
+                    "const": int(node.const),
+                }
+            if isinstance(node, C_CVL):
+                return {
+                    "type": "C_CVL",
+                    "name": node.name,
+                    "output_length": int(node.output_length),
+                    "const": int(node.const),
+                }
+            if isinstance(node, I_CVL):
+                return {
+                    "type": "I_CVL",
+                    "name": node.name,
+                    "input_length": int(node.input_length),
+                }
+            if isinstance(node, XOR_CVL):
+                return {
+                    "type": "XOR_CVL",
+                    "name": node.name,
+                    "word_length": int(node.word_length),
+                }
+            if isinstance(node, ModAdd_CVL):
+                return {
+                    "type": "ModAdd_CVL",
+                    "name": node.name,
+                    "word_length": int(node.word_length),
+                }
+            if isinstance(node, AND_CVL):
+                return {
+                    "type": "AND_CVL",
+                    "name": node.name,
+                    "word_length": int(node.word_length),
+                }
+            if isinstance(node, SBox_CVL):
+                return {
+                    "type": "SBox_CVL",
+                    "name": node.name,
+                    "S": [int(x) for x in node.S],
+                }
+            if isinstance(node, ROT_AND_CVL):
+                return {
+                    "type": "ROT_AND_CVL",
+                    "name": node.name,
+                    "word_length": int(node.word_length),
+                    "r": int(node.r),
+                }
+            if isinstance(node, Cipher):
+                return {"type": "Cipher", "cipher": node._to_dict()}
+            raise ValueError(
+                f"Cannot serialize node of unknown type "
+                f"{type(node).__name__!r}"
+            )
+
+        # The OUT node is appended last when is_valid becomes True
+        out_idx = len(self.nodes) - 1 if self.is_valid else None
+
+        node_dicts = [
+            {**node_to_dict(n), "result": n.result}
+            for i, n in enumerate(self.nodes)
+            if out_idx is None or i != out_idx
+        ]
+
+        edge_dicts = [
+            [[a, b], [x, y]]
+            for (a, b), (x, y) in self.edges
+            if out_idx is None or b != out_idx
+        ]
+
+        output_dicts = [
+            list(entry) if entry is not None else None
+            for entry in self.outputs
+        ]
+
+        return {
+            "name": self.name,
+            "input_length": self.input_length,
+            "output_length": self.output_length,
+            "wordsize": self._wrd,
+            "nodes": node_dicts,
+            "edges": edge_dicts,
+            "outputs": output_dicts,
+            "result": self.result,
+        }
+
+    def export(self, path):
+        r"""
+        Write ``self`` to a JSON file at ``path``.
+
+        The file can be loaded back with :meth:`Cipher.load`.
+
+        INPUT:
+
+            - ``path`` -- string or path-like; Destination file path.
+              The ``.json`` extension is conventional but not enforced.
+
+        EXAMPLES::
+
+            sage: import tempfile, os
+            sage: from civerly.cipher import Cipher
+            sage: from civerly.component import SBox_CVL
+            sage: from sage.crypto.sbox import SBox
+            sage: cipher = Cipher(9, 9, name="test")
+            sage: sb = SBox_CVL(SBox([0, 6, 1, 4, 2, 3, 5, 7]))
+            sage: edges = [(cipher.IN, (i, i)) for i in range(3)]
+            sage: node0 = cipher.add_subcipher(sb, edges)
+            sage: edges = [(cipher.IN, (i + 3, i)) for i in range(3)]
+            sage: node1 = cipher.add_subcipher(sb, edges)
+            sage: edges = [(cipher.IN, (i + 6, i)) for i in range(3)]
+            sage: node2 = cipher.add_subcipher(sb, edges)
+            sage: cipher.add_output([(node0, (i, i)) for i in range(3)])
+            sage: cipher.add_output([(node1, (i, i + 3)) for i in range(3)])
+            sage: cipher.add_output([(node2, (i, i + 6)) for i in range(3)])
+            sage: with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            ....:     tmp = f.name
+
+        Before analysis, ``result`` is ``None`` and round-trips as such::
+
+            sage: cipher.export(tmp)
+            Object 'test' has been exported to ...
+            sage: loaded = Cipher.load(tmp)
+            sage: cipher == loaded and loaded.result is None
+            True
+
+        After analysis, ``result`` holds the trail bit-pattern and is
+        preserved verbatim through the JSON file::
+
+            sage: from civerly.model_options import *
+            sage: model_options = MODEL_OPTIONS(
+            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:   optimization=OPTIMIZATION.SAT,
+            ....:   granularity=GRANULARITY.BITWISE,
+            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:   sat_solver=CADICAL_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
+            ....:   path=Path("DOCTEST-Export"))
+            sage: cipher.analyse(model_options)
+            ...
+            2
+            sage: cipher.export(tmp)
+            Object 'test' has been exported to ...
+            sage: loaded = Cipher.load(tmp)
+            sage: os.unlink(tmp)
+            sage: cipher == loaded and loaded.result == cipher.result
+            True
+        """
+        with open(path, "w") as f:
+            json.dump(self._to_dict(), f, indent=2,
+                      default=lambda obj: int(obj))
+        print(f"Object '{self.name}' has been exported to {path}.")
+
+    @classmethod
+    def _from_dict(cls, d):
+        r"""
+        Reconstruct a :class:`Cipher` from a dictionary produced by
+        :meth:`_to_dict`.
+        """
+        from civerly.component import (
+            I_CVL, C_CVL, RK_CVL, ConstXOR_CVL, RoundkeyXOR_CVL,
+            XOR_CVL, ModAdd_CVL, AND_CVL, LinearLayer_CVL,
+            PermuteLayer_CVL, RotateLayer_CVL, SBox_CVL, ROT_AND_CVL,
+        )
+        from sage.crypto.sbox import SBox
+        from sage.matrix.constructor import Matrix as matrix
+
+        def node_from_dict(nd):
+            t = nd["type"]
+            name = nd.get("name")
+            if t == "I_CVL":
+                return I_CVL(nd["input_length"], name=name)
+            if t == "C_CVL":
+                return C_CVL(nd["output_length"], nd["const"], name=name)
+            if t == "RK_CVL":
+                return RK_CVL(nd["output_length"], nd["const"], name=name)
+            if t == "ConstXOR_CVL":
+                return ConstXOR_CVL(
+                    nd["output_length"], nd["const"], name=name
+                )
+            if t == "RoundkeyXOR_CVL":
+                return RoundkeyXOR_CVL(
+                    nd["output_length"], nd["const"], name=name
+                )
+            if t == "XOR_CVL":
+                return XOR_CVL(nd["word_length"], name=name)
+            if t == "ModAdd_CVL":
+                return ModAdd_CVL(nd["word_length"], name=name)
+            if t == "AND_CVL":
+                return AND_CVL(nd["word_length"], name=name)
+            if t == "LinearLayer_CVL":
+                mat = matrix(GF(2), nd["binary_matrix"])
+                return LinearLayer_CVL(
+                    mat,
+                    branch_number_differential=nd[
+                        "branch_number_differential"
+                    ],
+                    branch_number_linear=nd["branch_number_linear"],
+                    name=name,
+                )
+            if t == "PermuteLayer_CVL":
+                return PermuteLayer_CVL(
+                    nd["perm"],
+                    word_coarseness=nd["word_coarseness"],
+                    name=name,
+                )
+            if t == "RotateLayer_CVL":
+                return RotateLayer_CVL(
+                    nd["input_length"],
+                    nd["r"],
+                    word_coarseness=nd["word_coarseness"],
+                    name=name,
+                )
+            if t == "SBox_CVL":
+                return SBox_CVL(SBox(nd["S"]), name=name)
+            if t == "ROT_AND_CVL":
+                return ROT_AND_CVL(nd["word_length"], nd["r"], name=name)
+            if t == "Cipher":
+                return cls._from_dict(nd["cipher"])
+            raise ValueError(f"Unknown node type {t!r} in JSON")
+
+        cipher = cls(d["input_length"], d["output_length"], name=d["name"])
+        cipher._wrd = d["wordsize"]
+
+        # Restore the IN node's result (index 0)
+        cipher.nodes[0].result = d["nodes"][0].get("result")
+
+        # d["nodes"][0] is the IN node — always present, skip during
+        # reconstruction (its index 0 is implicit in the edge list)
+        for node_idx, nd in enumerate(d["nodes"][1:], start=1):
+            component = node_from_dict(nd)
+            incoming = [
+                (a, (x, y))
+                for [a, b], [x, y] in d["edges"]
+                if b == node_idx
+            ]
+            cipher.add_subcipher(component, incoming)
+            # For Cipher nodes, _from_dict already restored .result on the
+            # component before add_subcipher deepcopied it, so it is correct.
+            # For leaf Component nodes, restore .result explicitly.
+            if nd["type"] != "Cipher":
+                cipher.nodes[node_idx].result = nd.get("result")
+
+        output_edges = [
+            (a, (x, y))
+            for y, entry in enumerate(d["outputs"])
+            if entry is not None
+            for a, x in [entry]
+        ]
+        if output_edges:
+            cipher.add_output(output_edges)
+
+        cipher.result = d["result"]
+        return cipher
+
+    @classmethod
+    def load(cls, path):
+        r"""
+        Load and return a :class:`Cipher` from the JSON file at ``path``
+        that was previously written by :meth:`export`.
+
+        INPUT:
+
+            - ``path`` -- string or path-like; Path to the JSON file.
+
+        OUTPUT: A reconstructed :class:`Cipher` instance.
+        """
+        with open(path) as f:
+            d = json.load(f)
+        return cls._from_dict(d)
 
     def _latex_header(self, model_options, objective_value) -> str:
         r"""

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -34,10 +34,12 @@ EXAMPLES::
     '0x11119999'
 """
 
-from sage.modules.free_module_element import vector
 from sage.rings.finite_rings.finite_field_constructor import GF
 from sage.modules.vector_mod2_dense import Vector_mod2_dense
+from sage.matrix.constructor import Matrix as matrix
+from sage.modules.free_module_element import vector
 from sage.sat.solvers.dimacs import DIMACS
+from sage.crypto.sbox import SBox
 
 from collections.abc import Iterable
 from copy import deepcopy
@@ -1812,7 +1814,7 @@ class Cipher:
                     "r": int(node.r),
                 }
             if isinstance(node, Cipher):
-                return {"type": "Cipher", "cipher": node._to_dict()}
+                return {"type": type(node).__name__, "cipher": node._to_dict()}
             raise ValueError(
                 f"Cannot serialize node of unknown type "
                 f"{type(node).__name__!r}"
@@ -1838,11 +1840,20 @@ class Cipher:
             for entry in self.outputs
         ]
 
+        extra = {}
+        if hasattr(self, 'wordsize'):
+            extra["wordsize"] = int(self.wordsize)
+        if hasattr(self, 'rows'):
+            extra["rows"] = int(self.rows)
+        if hasattr(self, 'cols'):
+            extra["cols"] = int(self.cols)
+
         return {
+            "cipher_class": type(self).__name__,
             "name": self.name,
             "input_length": self.input_length,
             "output_length": self.output_length,
-            "wordsize": self._wrd,
+            **extra,
             "nodes": node_dicts,
             "edges": edge_dicts,
             "outputs": output_dicts,
@@ -1910,9 +1921,28 @@ class Cipher:
             sage: os.unlink(tmp)
             sage: cipher == loaded and loaded.result == cipher.result
             True
+
+        Again with a different cipher type::
+            
+            sage: import tempfile
+            sage: from civerly.cipher import Cipher
+            sage: from civerly.cipher_implementations.aes import AES_CVL
+            sage: aes = AES_CVL(4)
+            sage: with tempfile.NamedTemporaryFile(suffix='.json') as f:
+            ....:   tmp = f.name
+            ....:   aes.export(tmp)
+            ....:   loaded = Cipher.load(tmp)
+            ....:   aes == loaded
+            Object 'AES' has been exported to ...
+            True
+            sage: from civerly.aeslike import AESlike
+            sage: isinstance(loaded, AESlike)
+            True
+
+
         """
         with open(path, "w") as f:
-            json.dump(self._to_dict(), f, indent=2,
+            json.dump(self._to_dict(), f,
                       default=lambda obj: int(obj))
         print(f"Object '{self.name}' has been exported to {path}.")
 
@@ -1927,8 +1957,6 @@ class Cipher:
             XOR_CVL, ModAdd_CVL, AND_CVL, LinearLayer_CVL,
             PermuteLayer_CVL, RotateLayer_CVL, SBox_CVL, ROT_AND_CVL,
         )
-        from sage.crypto.sbox import SBox
-        from sage.matrix.constructor import Matrix as matrix
 
         def node_from_dict(nd):
             t = nd["type"]
@@ -1980,12 +2008,41 @@ class Cipher:
                 return SBox_CVL(SBox(nd["S"]), name=name)
             if t == "ROT_AND_CVL":
                 return ROT_AND_CVL(nd["word_length"], nd["r"], name=name)
-            if t == "Cipher":
+            if t in (
+                "Cipher", "WordBasedCipher", "SBoxCipher",
+                "WordSBoxCipher", "AddRX", "AndRX", "AESlike"
+            ):
                 return cls._from_dict(nd["cipher"])
             raise ValueError(f"Unknown node type {t!r} in JSON")
 
-        cipher = cls(d["input_length"], d["output_length"], name=d["name"])
-        cipher._wrd = d["wordsize"]
+        cipher_class_name = d.get("cipher_class", "Cipher")
+        if cipher_class_name == "SBoxCipher":
+            from civerly.sboxcipher import SBoxCipher
+            wordsize = 1
+            cipher = SBoxCipher(d["input_length"], d["output_length"], name=d["name"])
+        elif cipher_class_name == "WordBasedCipher":
+            from civerly.wordbasedcipher import WordBasedCipher
+            wordsize = d["wordsize"]
+            cipher = WordBasedCipher(wordsize, d["input_length"] // wordsize, d["output_length"] // wordsize, name=d["name"])
+        elif cipher_class_name == "WordSBoxCipher":
+            from civerly.wordsboxcipher import WordSBoxCipher
+            wordsize = d["wordsize"]
+            cipher = WordSBoxCipher(wordsize, d["input_length"] // wordsize, d["output_length"] // wordsize, name=d["name"])
+        elif cipher_class_name == "AddRX":
+            from civerly.addrx import AddRX
+            wordsize = d["wordsize"]
+            cipher = AddRX(wordsize, d["input_length"] // wordsize, d["output_length"] // wordsize, name=d["name"])
+        elif cipher_class_name == "AndRX":
+            from civerly.andrx import AndRX
+            wordsize = d["wordsize"]
+            cipher = AndRX(wordsize, d["input_length"] // wordsize, d["output_length"] // wordsize, name=d["name"])
+        elif cipher_class_name == "AESlike":
+            from civerly.aeslike import AESlike
+            wordsize = d["wordsize"]
+            cipher = AESlike(d["wordsize"], d["rows"], d["cols"], name=d["name"])
+        else:
+            wordsize = 1
+            cipher = cls(d["input_length"], d["output_length"], name=d["name"])
 
         # Restore the IN node's result (index 0)
         cipher.nodes[0].result = d["nodes"][0].get("result")
@@ -1994,11 +2051,12 @@ class Cipher:
         # reconstruction (its index 0 is implicit in the edge list)
         for node_idx, nd in enumerate(d["nodes"][1:], start=1):
             component = node_from_dict(nd)
-            incoming = [
-                (a, (x, y))
+            incoming = list(set([
+                (a, (x//wordsize, y//wordsize))
+                # (a, (x, y))
                 for [a, b], [x, y] in d["edges"]
                 if b == node_idx
-            ]
+            ]))
             cipher.add_subcipher(component, incoming)
             # For Cipher nodes, _from_dict already restored .result on the
             # component before add_subcipher deepcopied it, so it is correct.
@@ -2006,12 +2064,13 @@ class Cipher:
             if nd["type"] != "Cipher":
                 cipher.nodes[node_idx].result = nd.get("result")
 
-        output_edges = [
-            (a, (x, y))
+        output_edges = list(set([
+            (a, (x//wordsize, y//wordsize))
+            # (a, (x, y))
             for y, entry in enumerate(d["outputs"])
             if entry is not None
             for a, x in [entry]
-        ]
+        ]))
         if output_edges:
             cipher.add_output(output_edges)
 

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -1895,8 +1895,48 @@ class Cipher:
 
             sage: cipher.export(tmp)
             Object 'test' has been exported to ...
+            sage: import json
+            sage: with open(tmp, "r") as f:
+            ....:   dictionary = json.load(f)
+            sage: dictionary == {
+            ....:     'cipher_class': 'Cipher', 'name': 'test',
+            ....:     'input_length': 9, 'output_length': 9,
+            ....:     'nodes': [
+            ....:         {'type': '__Special_Node', 'result': None},
+            ....:         {
+            ....:             'type': 'SBox_CVL', 'name': 'Unnamed Component',
+            ....:             'S': [0, 6, 1, 4, 2, 3, 5, 7], 'result': None
+            ....:         },
+            ....:         {
+            ....:             'type': 'SBox_CVL', 'name': 'Unnamed Component',
+            ....:             'S': [0, 6, 1, 4, 2, 3, 5, 7], 'result': None
+            ....:         },
+            ....:         {
+            ....:             'type': 'SBox_CVL', 'name': 'Unnamed Component',
+            ....:             'S': [0, 6, 1, 4, 2, 3, 5, 7], 'result': None
+            ....:         }
+            ....:     ],
+            ....:     'edges': [
+            ....:         [[0, 1], [0, 0]],
+            ....:         [[0, 1], [1, 1]],
+            ....:         [[0, 1], [2, 2]],
+            ....:         [[0, 2], [3, 0]],
+            ....:         [[0, 2], [4, 1]],
+            ....:         [[0, 2], [5, 2]],
+            ....:         [[0, 3], [6, 0]],
+            ....:         [[0, 3], [7, 1]],
+            ....:         [[0, 3], [8, 2]]
+            ....:     ],
+            ....:     'outputs': [
+            ....:         [1, 0], [1, 1], [1, 2],
+            ....:         [2, 0], [2, 1], [2, 2],
+            ....:         [3, 0], [3, 1], [3, 2]
+            ....:     ],
+            ....:     'result': None
+            ....: }
+            True
             sage: loaded = Cipher.load(tmp)
-            sage: cipher == loaded and loaded.result is None
+            sage: cipher == loaded
             True
 
         After analysis, ``result`` holds the trail bit-pattern and is
@@ -1932,7 +1972,7 @@ class Cipher:
             ....:   tmp = f.name
             ....:   aes.export(tmp)
             ....:   loaded = Cipher.load(tmp)
-            ....:   aes == loaded
+            ....:   aes == loaded and aes.__dict__ == loaded.__dict__
             Object 'AES' has been exported to ...
             True
             sage: from civerly.aeslike import AESlike
@@ -2051,12 +2091,12 @@ class Cipher:
         # reconstruction (its index 0 is implicit in the edge list)
         for node_idx, nd in enumerate(d["nodes"][1:], start=1):
             component = node_from_dict(nd)
-            incoming = list(set([
+            incoming = sorted(list(set([
                 (a, (x//wordsize, y//wordsize))
                 # (a, (x, y))
                 for [a, b], [x, y] in d["edges"]
                 if b == node_idx
-            ]))
+            ])))
             cipher.add_subcipher(component, incoming)
             # For Cipher nodes, _from_dict already restored .result on the
             # component before add_subcipher deepcopied it, so it is correct.
@@ -2064,13 +2104,13 @@ class Cipher:
             if nd["type"] != "Cipher":
                 cipher.nodes[node_idx].result = nd.get("result")
 
-        output_edges = list(set([
+        output_edges = sorted(list(set([
             (a, (x//wordsize, y//wordsize))
             # (a, (x, y))
             for y, entry in enumerate(d["outputs"])
             if entry is not None
             for a, x in [entry]
-        ]))
+        ])))
         if output_edges:
             cipher.add_output(output_edges)
 

--- a/src/civerly/cipher_implementations/hurdle.py
+++ b/src/civerly/cipher_implementations/hurdle.py
@@ -254,22 +254,35 @@ class HURDLE_CVL:
             ....:   0x4bf15508812e06f0
             True
 
+        Model 4 rounds HURDLE-II:
+
+            sage: from civerly.cipher_implementations.hurdle import HURDLE_CVL
+            sage: from civerly.model_options import *
+            sage: from pathlib import Path
+            sage: import tempfile
+            sage: cipher = HURDLE_CVL(R=4)
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cadical  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            sage:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       sat_solver=CADICAL_CVL(),
+            ....:       path=Path(tmpdir)
+            ....:   )
+            sage:   cipher.analyse(model_options)
+            7168 variables and 88545 clauses were written to ...
+            [  0 ,100] (trying w =  50) : SAT
+            [  0 , 50] (trying w =  25) : SAT
+            [  0 , 25] (trying w =  12) : SAT
+            [  0 , 12] (trying w =   6) : UNSAT
+            [  7 , 12] (trying w =   9) : UNSAT
+            [ 10 , 12] (trying w =  11) : UNSAT
+            12
+
         """
-        # To run HURDLE modeling, execute:
-        # ------------------------------------
-        # sage: from civerly.cipher_implementations.hurdle import HURDLE_CVL
-        # sage: from civerly.model_options import *
-        # sage: from pathlib import Path
-        # sage: cipher = HURDLE_CVL(R=4)
-        # sage: model_options = MODEL_OPTIONS(
-        # ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
-        # ....:     optimization=OPTIMIZATION.SAT,
-        # ....:     granularity=GRANULARITY.BITWISE,
-        # ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
-        # ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-        # ....:     logic_minimizer=ESPRESSO_CVL(),
-        # ....:     path=Path("./DOCTEST-HURDLE-Models/"))
-        # sage: cipher.analyse(model_options)
 
         if name is None:
             name = "HURDLE-II"

--- a/src/civerly/cipher_implementations/hurdle.py
+++ b/src/civerly/cipher_implementations/hurdle.py
@@ -262,7 +262,7 @@ class HURDLE_CVL:
             sage: import tempfile
             sage: cipher = HURDLE_CVL(R=4)
             sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cadical  # optional - espresso  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-            sage:   model_options = MODEL_OPTIONS(
+            ....:   model_options = MODEL_OPTIONS(
             ....:       cryptanalysis=CRYPTANALYSIS.LINEAR,
             ....:       optimization=OPTIMIZATION.SAT,
             ....:       granularity=GRANULARITY.BITWISE,
@@ -272,7 +272,7 @@ class HURDLE_CVL:
             ....:       sat_solver=CADICAL_CVL(),
             ....:       path=Path(tmpdir)
             ....:   )
-            sage:   cipher.analyse(model_options)
+            ....:   cipher.analyse(model_options)
             7168 variables and 88545 clauses were written to ...
             [  0 ,100] (trying w =  50) : SAT
             [  0 , 50] (trying w =  25) : SAT

--- a/src/civerly/component.py
+++ b/src/civerly/component.py
@@ -100,6 +100,7 @@ class Component(ABC):
         self.__input_length = input_length
         self.__output_length = output_length
         self._return_immediately_ = False
+        self.result = None
 
     def __call__(self, x):
         r"""Evaluate this component."""

--- a/src/civerly/component.py
+++ b/src/civerly/component.py
@@ -289,6 +289,17 @@ class I_CVL(Component):
             return self.name
         return f"Identity({self.input_length})"
 
+    def _to_dict(self):
+        return {
+            "type": "I_CVL",
+            "name": self.name,
+            "input_length": int(self.input_length),
+        }
+
+    @classmethod
+    def _from_dict(cls, d):
+        return cls(d["input_length"], name=d.get("name"))
+
     def _model_milp(self, model_options):
         r"""
         Model this component in MILP.
@@ -367,6 +378,18 @@ class C_CVL(Component):
         if self.name is not None:
             return self.name
         return f"Constant({self.output_length})"
+
+    def _to_dict(self):
+        return {
+            "type": "C_CVL",
+            "name": self.name,
+            "output_length": int(self.output_length),
+            "const": int(self.const),
+        }
+
+    @classmethod
+    def _from_dict(cls, d):
+        return cls(d["output_length"], d["const"], name=d.get("name"))
 
     def _model_milp(self, model_options):
         self._init_model(model_options)
@@ -450,6 +473,18 @@ class RK_CVL(C_CVL):
             return self.name
         return f"Roundkey({self.output_length})"
 
+    def _to_dict(self):
+        return {
+            "type": "RK_CVL",
+            "name": self.name,
+            "output_length": int(self.output_length),
+            "const": int(self.const),
+        }
+
+    @classmethod
+    def _from_dict(cls, d):
+        return cls(d["output_length"], d["const"], name=d.get("name"))
+
 
 class ConstXOR_CVL(Component):
     r"""
@@ -517,6 +552,18 @@ class ConstXOR_CVL(Component):
         if self.name is not None:
             return self.name
         return f"ConstantXOR({self.output_length})"
+
+    def _to_dict(self):
+        return {
+            "type": "ConstXOR_CVL",
+            "name": self.name,
+            "output_length": int(self.output_length),
+            "const": int(self.const),
+        }
+
+    @classmethod
+    def _from_dict(cls, d):
+        return cls(d["output_length"], d["const"], name=d.get("name"))
 
     def _model_milp(self, model_options):
         self._init_model(model_options)
@@ -601,6 +648,18 @@ class RoundkeyXOR_CVL(ConstXOR_CVL):
             return self.name
         return f"RoundkeyXOR({self.output_length})"
 
+    def _to_dict(self):
+        return {
+            "type": "RoundkeyXOR_CVL",
+            "name": self.name,
+            "output_length": int(self.output_length),
+            "const": int(self.const),
+        }
+
+    @classmethod
+    def _from_dict(cls, d):
+        return cls(d["output_length"], d["const"], name=d.get("name"))
+
 
 class XOR_CVL(Component):
     r"""
@@ -645,6 +704,17 @@ class XOR_CVL(Component):
         if self.name is not None:
             return self.name
         return f"XOR({(self.word_length)})"
+
+    def _to_dict(self):
+        return {
+            "type": "XOR_CVL",
+            "name": self.name,
+            "word_length": int(self.word_length),
+        }
+
+    @classmethod
+    def _from_dict(cls, d):
+        return cls(d["word_length"], name=d.get("name"))
 
     def _model_milp(self, model_options):
         """
@@ -807,6 +877,17 @@ class ModAdd_CVL(Component):
         if self.name is not None:
             return self.name
         return f"ModAdd({self.word_length})"
+
+    def _to_dict(self):
+        return {
+            "type": "ModAdd_CVL",
+            "name": self.name,
+            "word_length": int(self.word_length),
+        }
+
+    @classmethod
+    def _from_dict(cls, d):
+        return cls(d["word_length"], name=d.get("name"))
 
     def _model_milp(self, model_options):
         raise InvalidModelOptionException(
@@ -971,6 +1052,17 @@ class AND_CVL(Component):
         if self.name is not None:
             return self.name
         return f"And({self.word_length})"
+
+    def _to_dict(self):
+        return {
+            "type": "AND_CVL",
+            "name": self.name,
+            "word_length": int(self.word_length),
+        }
+
+    @classmethod
+    def _from_dict(cls, d):
+        return cls(d["word_length"], name=d.get("name"))
 
     @property
     def word_length(self):
@@ -1177,6 +1269,33 @@ class LinearLayer_CVL(Component):
         if self.name is not None:
             return self.name
         return f"LL({self.input_length} -> {self.output_length})"
+
+    def _to_dict(self):
+        def _int_or_none(x):
+            return int(x) if x is not None else None
+        return {
+            "type": "LinearLayer_CVL",
+            "name": self.name,
+            "binary_matrix": [
+                [int(x) for x in row]
+                for row in self.binary_matrix.rows()
+            ],
+            "branch_number_differential": _int_or_none(
+                self.branch_number_differential
+            ),
+            "branch_number_linear": _int_or_none(self.branch_number_linear),
+        }
+
+    @classmethod
+    def _from_dict(cls, d):
+        from sage.matrix.constructor import Matrix as matrix
+        mat = matrix(GF(2), d["binary_matrix"])
+        return cls(
+            mat,
+            branch_number_differential=d["branch_number_differential"],
+            branch_number_linear=d["branch_number_linear"],
+            name=d.get("name"),
+        )
 
     def inv(self):
         r"""Create the inverse of the current instance."""
@@ -1698,6 +1817,18 @@ class PermuteLayer_CVL(LinearLayer_CVL):
             return self.name
         return f"PL({self.input_length})"
 
+    def _to_dict(self):
+        return {
+            "type": "PermuteLayer_CVL",
+            "name": self.name,
+            "perm": [int(x) for x in self.perm],
+            "word_coarseness": int(self.word_coarseness),
+        }
+
+    @classmethod
+    def _from_dict(cls, d):
+        return cls(d["perm"], word_coarseness=d["word_coarseness"], name=d.get("name"))
+
     def inv(self):
         r"""
         Creates an inverse instance of ``self``.
@@ -1858,6 +1989,23 @@ class RotateLayer_CVL(PermuteLayer_CVL):
             return self.name
         return f"RL({self.input_length})"
 
+    def _to_dict(self):
+        return {
+            "type": "RotateLayer_CVL",
+            "name": self.name,
+            "input_length": int(self.input_length),
+            "r": int(self.r),
+            "word_coarseness": int(self.word_coarseness),
+        }
+
+    @classmethod
+    def _from_dict(cls, d):
+        return cls(
+            d["input_length"], d["r"],
+            word_coarseness=d["word_coarseness"],
+            name=d.get("name"),
+        )
+
     def inv(self):
         r"""
         Creates an inverse instance of ``self``.
@@ -1923,6 +2071,17 @@ class SBox_CVL(Component):
         if self.name is not None:
             return self.name
         return f"SBox({self.S.input_size()} -> {self.S.output_size()})"
+
+    def _to_dict(self):
+        return {
+            "type": "SBox_CVL",
+            "name": self.name,
+            "S": [int(x) for x in self.S],
+        }
+
+    @classmethod
+    def _from_dict(cls, d):
+        return cls(SBox(d["S"]), name=d.get("name"))
 
     def _model_milp(self, model_options):
         self._init_model(model_options)
@@ -2598,6 +2757,18 @@ class ROT_AND_CVL(Component):
         if self.name is not None:
             return self.name
         return f"ROT_AND({self.word_length}, {self.r})"
+
+    def _to_dict(self):
+        return {
+            "type": "ROT_AND_CVL",
+            "name": self.name,
+            "word_length": int(self.word_length),
+            "r": int(self.r),
+        }
+
+    @classmethod
+    def _from_dict(cls, d):
+        return cls(d["word_length"], d["r"], name=d.get("name"))
 
     def _model_milp(self, model_options) -> MixedIntegerLinearProgram:
         raise InvalidModelOptionException(

--- a/src/civerly/model_options.py
+++ b/src/civerly/model_options.py
@@ -8,6 +8,9 @@ from pathlib import Path
 from civerly.solvers import SOLVER_CVL, LOGIC_MINIMIZER_CVL
 from civerly.solvers import MILP_SOLVER_CVL, SAT_SOLVER_CVL, LOGIC_MINIMIZER_CVL
 
+# Import all solvers, even though they are unused here.
+# This way, the user has access to ALL model options
+# when importing `civerly.model_options`.
 from civerly.solvers import NO_MILP_SOLVER_CVL, GUROBI_CVL, SCIP_CVL, GLPK_CVL
 from civerly.solvers import NO_SAT_SOLVER_CVL, CRYPTOMINISAT_CVL, CADICAL_CVL
 from civerly.solvers import NO_LOGIC_MINIMIZER_CVL, ESPRESSO_CVL

--- a/src/civerly/sboxcipher.py
+++ b/src/civerly/sboxcipher.py
@@ -53,6 +53,11 @@ class SBoxCipher(Cipher):
                 "not allowed in SBoxCiphers."
             )
 
+    def _to_dict(self):
+        d = super()._to_dict()
+        d["type"] = "SBoxCipher"
+        return d
+
     def _model_milp(self, model_options, _first_iter=False):
         r"""
         Generate the model for ``self`` according to the given

--- a/src/civerly/trail.py
+++ b/src/civerly/trail.py
@@ -127,6 +127,16 @@ class TrailNode:
                     )
                     bits_out[depths[comp_num]][bit_ind] = solution_bit_value
 
+        # Extract per-node result slices before None removal changes indexing
+        grid_in  = self.cipher_instance._construct_grid(divide_by=divide_by, input_side=True)
+        grid_out = self.cipher_instance._construct_grid(divide_by=divide_by, input_side=False)
+        _node_results = {}
+        for comp_num, comp in enumerate(nodes):
+            d = depths[comp_num]
+            comp_bits_in  = [bits_in[d][i]  for i, (n, _) in enumerate(grid_in[d])  if n == comp_num and bits_in[d][i]  is not None]
+            comp_bits_out = [bits_out[d][i] for i, (n, _) in enumerate(grid_out[d]) if n == comp_num and bits_out[d][i] is not None]
+            _node_results[comp_num] = {"in": comp_bits_in, "out": comp_bits_out}
+
         # realign bits_in, bits_out by removing any 'None' entries
         bits_in  = [[e for e in row if e is not None] for row in bits_in]
         bits_out = [[e for e in row if e is not None] for row in bits_out]
@@ -135,6 +145,11 @@ class TrailNode:
         self.bits_out = bits_out
         self.input  = bits_out[0]
         self.output = bits_out[-1]
+
+        # Set .result on this cipher and each of its direct nodes
+        self.cipher_instance.result = {"in": self.input, "out": self.output}
+        for comp_num, comp in enumerate(nodes):
+            comp.result = _node_results[comp_num]
         ################################################
 
         # Iterate through each subcipher

--- a/src/civerly/wordbasedcipher.py
+++ b/src/civerly/wordbasedcipher.py
@@ -77,6 +77,17 @@ class WordBasedCipher(Cipher):
         assert self.__wordsize > 0
         return int(self.__wordsize)
 
+    def _to_dict(self):
+        d = super()._to_dict()
+        d["type"] = "WordBasedCipher"
+        d["wordsize"] = self.wordsize
+        return d
+
+    @classmethod
+    def _init_from_dict(cls, d):
+        ws = d["wordsize"]
+        return cls(ws, d["input_length"] // ws, d["output_length"] // ws, name=d["name"])
+
     def add_subcipher(self, sub_cipher, edges):
         r"""
         The edges are now reduced. Instead of ``wordsize`` many edges going

--- a/src/civerly/wordsboxcipher.py
+++ b/src/civerly/wordsboxcipher.py
@@ -18,4 +18,8 @@ from civerly.sboxcipher import SBoxCipher
 
 
 class WordSBoxCipher(WordBasedCipher, SBoxCipher):
-    pass
+
+    def _to_dict(self):
+        d = super()._to_dict()
+        d["type"] = "WordSBoxCipher"
+        return d


### PR DESCRIPTION
Closes #8. Main changes:
- Each cipher is now equipped with the attribute `.result`, which contains the trail data and which will be updated after calling `.analyse`. 
- Ciphers can now be exported as and loaded from json files, via `.export` and `.load`
- (minor change): add doctest for hurdle back in