### PR TITLE
Flexible trails

### DIFF
--- a/docs/source/user_manual/export_trail.rst
+++ b/docs/source/user_manual/export_trail.rst
@@ -8,41 +8,35 @@ allowing to seamlessly incorporate them into your workflow.
 
 See the following example to understand how to export and load Cipher objects.
 
-.. code-block:: sage
-
+.. code-block::
     sage: # First, analyse some cipher
-    sage: import tempfile
     sage: from civerly.cipher_implementations.present import PRESENT_CVL
     sage: from civerly.model_options import *
     sage: cipher = PRESENT_CVL(4)
-    sage: with tempfile.TemporaryDirectory() as tmpdir:
-    ....:   model_options = MODEL_OPTIONS(
+    sage: model_options = MODEL_OPTIONS(
     ....:     optimization=OPTIMIZATION.MILP,
     ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
     ....:     granularity=GRANULARITY.BITWISE,
     ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-    ....:     milp_solver=SCIP_CVL(),
+    ....:     milp_solver=GUROBI_CVL(),
     ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
     ....:     logic_minimizer=ESPRESSO_CVL(),
-    ....:     path=Path(tmpdir))
-    ....:   cipher.analyse(model_options)
-    5312 variables and 8641 constraints were written to ...
+    ....:     path=Path("export-example")
+    ....: )
+    sage: cipher.analyse(model_options)
+    5312 variables and 8641 constraints were written to 'export-example/PRESENT.mps'
     12
-    sage: input_difference = cipher.result['in']
-    sage: output_difference = cipher.result['out']
-
+    sage: input_difference = cipher.results[0]['in']
+    sage: output_difference = cipher.results[0]['out']
     sage: # Export the cipher together with its results
     sage: import tempfile
     sage: with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
-    ....:   tmpfile_name = f.name
-    ....:   cipher.export(tmpfile_name)
-    ....:   # Load the cipher from scratch
-    ....:   loaded = cipher.load(tmpfile_name)
-    ....:   # The results are still the same
-    ....:   print(loaded.result['in'] == input_difference)
-    ....:   print(loaded.result['out'] == output_difference)
-    Object 'PRESENT' has been exported to ...
-    True
-    True
+    sage:     tmpfile_name = f.name
+    sage: cipher.export(tmpfile_name)
+    sage: # Load the cipher from scratch
+    sage: loaded = cipher.load(tmpfile_name)
+    sage: # The results are still the same
+    sage: loaded.results[0]['in'] == input_difference
+    sage: loaded.results[0]['out'] == output_difference
 
 

--- a/docs/source/user_manual/export_trail.rst
+++ b/docs/source/user_manual/export_trail.rst
@@ -18,7 +18,7 @@ See the following example to understand how to export and load Cipher objects.
     ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
     ....:     granularity=GRANULARITY.BITWISE,
     ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-    ....:     milp_solver=GUROBI_CVL(),
+    ....:     milp_solver=SCIP_CVL(),
     ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
     ....:     logic_minimizer=ESPRESSO_CVL(),
     ....:     path=Path("export-example")

--- a/docs/source/user_manual/export_trail.rst
+++ b/docs/source/user_manual/export_trail.rst
@@ -9,6 +9,8 @@ allowing to seamlessly incorporate them into your workflow.
 See the following example to understand how to export and load Cipher objects.
 
 .. code-block::
+
+    sage: # optional - scip, espresso
     sage: # First, analyse some cipher
     sage: from civerly.cipher_implementations.present import PRESENT_CVL
     sage: from civerly.model_options import *
@@ -30,13 +32,16 @@ See the following example to understand how to export and load Cipher objects.
     sage: output_difference = cipher.results[0]['out']
     sage: # Export the cipher together with its results
     sage: import tempfile
-    sage: with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
-    sage:     tmpfile_name = f.name
+    sage: f = tempfile.NamedTemporaryFile(suffix='.json', delete=False)
+    sage: tmpfile_name = f.name
     sage: cipher.export(tmpfile_name)
+    Object 'PRESENT' has been exported to ...
     sage: # Load the cipher from scratch
     sage: loaded = cipher.load(tmpfile_name)
     sage: # The results are still the same
     sage: loaded.results[0]['in'] == input_difference
+    True
     sage: loaded.results[0]['out'] == output_difference
+    True
 
 

--- a/docs/source/user_manual/generate_report.rst
+++ b/docs/source/user_manual/generate_report.rst
@@ -173,7 +173,7 @@ Now, in regards to the tree structure explained above, calling the method ``get_
 
 .. code-block:: sage
 
-   sage: cipher.get_trail(model_options)
+   sage: cipher.get_trail(model_options) # optional: scip
    -> cipher : 00f -> 00f
       -> sub-cipher-6-bit : 00 -> 00
          -> sub-sub-cipher-3-bit : 0 -> 0
@@ -184,7 +184,7 @@ Now, in regards to the tree structure explained above, calling the method ``get_
    :hide:
 
    sage: import shutil
-   sage: shutil.rmtree("./CVL-Example")
+   sage: shutil.rmtree("./CVL-Example") # optional: scip
 
 
 PDF

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -419,15 +419,8 @@ class Cipher:
         # analyse() for number_of_solutions > 1, one per solution.
         # Used by generate_report() and get_trail() to avoid re-reading
         # solution files.
-
-        self._custom_constraints = []
-        # User-added constraints from add_constraint(), stored as parsed tuples
-        # (lhs, op, rhs). Applied during model building.
-
+        
         self._blocking_constraints = []
-        # No-good cuts for by-hand multiple-solution enumeration. Each entry
-        # is a list of (comp_num, var_idx, value) triples derived from a solved
-        # MILP result. Reset at the start of each analyse() call.
 
     # Get-functions of various attributes:
     # --------------------------------------------------
@@ -1431,9 +1424,6 @@ class Cipher:
                             (-self.inv_dictionaries_sat[a][x+1],)
                         )
 
-        # Apply user-added custom constraints
-        self._apply_custom_constraints_sat(master_sat)
-
         model_options, model_options_ = model_options_, model_options
 
         return self._finish_sat(
@@ -1484,6 +1474,7 @@ class Cipher:
                 f"'{str(model_options.path / (self.name + '.cnf'))}'"
             )
 
+        self.sat_model = sat
         return sat
 
     def analyse(self, model_options):
@@ -1510,7 +1501,6 @@ class Cipher:
         # Reset per-analysis state.
         self.results = []
         self.trail_nodes = []
-        self._blocking_constraints = []
 
         if model_options.optimization == OPTIMIZATION.MILP:
             self.model(model_options)
@@ -1711,134 +1701,10 @@ class Cipher:
                 model_options.optimization, OPTIMIZATION
             )
 
-    # ------------------------------------------------------------------
-    # Custom-constraint and multiple-solution helpers
-    # ------------------------------------------------------------------
-
-    def add_constraint(self, expr: str) -> None:
-        r"""
-        Add a custom equality constraint to be incorporated into the model
-        at the next call to :meth:`model` or :meth:`analyse`.
-
-        Supported syntax::
-
-            "nodes[i].IN[j]  == nodes[k].IN[l]"
-            "nodes[i].IN[j]  == nodes[k].OUT[l]"
-            "nodes[i].OUT[j] == nodes[k].OUT[l]"
-            "nodes[i].IN[j]  == 0"   (force a bit inactive)
-            "nodes[i].IN[j]  == 1"   (force a bit active)
-
-        where ``i``, ``j``, ``k``, ``l`` are non-negative integers,
-        ``IN`` selects an *input* bit of the node, and ``OUT`` an *output* bit.
-
-        EXAMPLES::
-
-            sage: from civerly.cipher import Cipher
-            sage: cipher = Cipher(8, 8, name="test")
-            sage: cipher.add_constraint("nodes[0].OUT[3] == nodes[1].IN[0]")
-            sage: len(cipher._custom_constraints)
-            1
-
-        TESTS::
-
-            sage: # optional - cryptominisat  # optional - espresso
-            sage: from civerly.cipher_implementations.craft import CRAFT_CVL
-            sage: from civerly.model_options import *
-            sage: from civerly.util import vec_to_int
-            sage: import tempfile
-            sage: cipher = CRAFT_CVL(2)
-            sage: with tempfile.TemporaryDirectory(delete=False) as tmpdir:
-            ....:   model_options = MODEL_OPTIONS(
-            ....:      cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-            ....:      optimization=OPTIMIZATION.SAT,
-            ....:      granularity=GRANULARITY.BITWISE,
-            ....:      sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
-            ....:      linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-            ....:      sat_solver=CRYPTOMINISAT_CVL(),
-            ....:      logic_minimizer=ESPRESSO_CVL(),
-            ....:      path=Path(tmpdir))
-            sage: cipher.analyse(model_options)
-            5120 variables and 11681 clauses were written to ...
-            [  0 ,100] (trying w =  50) : SAT
-            [  0 , 50] (trying w =  25) : SAT
-            [  0 , 25] (trying w =  12) : SAT
-            [  0 , 12] (trying w =   6) : SAT
-            [  0 ,  6] (trying w =   3) : UNSAT
-            [  4 ,  6] (trying w =   5) : SAT
-            [  4 ,  5] (trying w =   4) : SAT
-            4
-        
-        Activate the entire input and analyse again:
-
-            sage: # optional - cryptominisat  # optional - espresso
-            sage: for i in range(cipher.input_length):
-            ....:   cipher.add_constraint(f"nodes[0].IN[{i}] == 1")
-            sage: cipher._custom_constraints
-            [(('var', 0, 'IN', 0), '==', ('const', 1)),
-            (('var', 0, 'IN', 1), '==', ('const', 1)),
-            ...
-            (('var', 0, 'IN', 62), '==', ('const', 1)),
-            (('var', 0, 'IN', 63), '==', ('const', 1))]
-            sage: cipher.analyse(model_options)
-            Using existing file ..., make sure it is up to date!
-            5120 variables and 11745 clauses were written to ...
-            [  0 ,100] (trying w =  50) : SAT
-            [  0 , 50] (trying w =  25) : UNSAT
-            [ 26 , 50] (trying w =  38) : SAT
-            [ 26 , 38] (trying w =  32) : SAT
-            [ 26 , 32] (trying w =  29) : UNSAT
-            [ 30 , 32] (trying w =  31) : UNSAT
-            32
-            sage: cipher.results[0]['in'] == [1]*cipher.input_length
-            True
-            sage: import shutil
-            sage: shutil.rmtree(tmpdir)
-
-        As expected, activating all input bits leads to a significantly worse trail.
-
-        """
-        self._custom_constraints.append(self._parse_constraint(expr))
-
-    @staticmethod
-    def _parse_constraint(expr: str):
-        r"""
-        Parse a constraint string into a structured triple ``(lhs, op, rhs)``.
-
-        Each side is either
-
-        * ``("var", node_idx: int, side: str, bit_idx: int)``  — a model variable
-        * ``("const", value: int)``  — a constant 0 or 1
-
-        and ``op`` is the string ``"=="``.
-        """
-        if "==" not in expr:
-            raise ValueError(
-                f"Unsupported constraint (only '==' is supported): {expr!r}"
-            )
-        lhs_str, rhs_str = expr.split("==", 1)
-
-        _var_pat = re.compile(
-            r'^\s*nodes\s*\[\s*(\d+)\s*\]\s*\.\s*(IN|OUT)\s*\[\s*(\d+)\s*\]\s*$'
-        )
-
-        def _parse_side(s: str):
-            m = _var_pat.match(s)
-            if m:
-                return ("var", int(m.group(1)), m.group(2), int(m.group(3)))
-            s = s.strip()
-            if s in ("0", "1"):
-                return ("const", int(s))
-            raise ValueError(
-                f"Cannot parse constraint operand: {s!r}\n"
-                "Expected 'nodes[i].IN/OUT[j]' or '0'/'1'."
-            )
-
-        return (_parse_side(lhs_str), "==", _parse_side(rhs_str))
-
-    def _add_milp_no_good(self, results: dict) -> None:
+    def _exclude_solution(self, results: dict) -> None:
         r"""
         Convert a MILP solution *results* dict (as returned by
-        ``process_solution_file``) into a no-good (blocking) constraint and
+        ``process_solution_file``) into a blocking constraint and
         append it to ``self._blocking_constraints``.
 
         The no-good ensures the exact solution cannot repeat on re-solve.
@@ -1851,56 +1717,12 @@ class Cipher:
             if var_name in ("IN", "OUT"):
                 continue
             try:
-                i = int(var_name[1:])   # "X3" → 3
+                i = int(var_name[1:])   # "X3" -> 3
             except (ValueError, IndexError):
                 continue
             for j, val in sub_dict.items():
                 bc.append((i, int(j), int(val)))
         self._blocking_constraints.append(bc)
-
-    def _apply_custom_constraints_sat(self, master_sat) -> None:
-        r"""
-        Translate ``self._custom_constraints`` into SAT clauses and add them
-        to *master_sat*.  Called from :meth:`_model_sat` after all component
-        SAT models have been assembled.
-        """
-        for lhs_parsed, op, rhs_parsed in self._custom_constraints:
-
-            def resolve(parsed):
-                """Return master SAT variable index, or None for constants."""
-                if parsed[0] == "const":
-                    return None, parsed[1]
-                _, node_idx, side, bit_idx = parsed
-                comp = self.nodes[node_idx]
-                if side == "IN":
-                    comp_rel = bit_idx + 1          # 1-based
-                else:  # "OUT"
-                    comp_rel = comp.input_length + bit_idx + 1
-                sat_var = self.inv_dictionaries_sat[node_idx].get(comp_rel)
-                if sat_var is None:
-                    raise ValueError(
-                        f"nodes[{node_idx}].{side}[{bit_idx}] not found in "
-                        "SAT dictionaries — check node index and bit index."
-                    )
-                return sat_var, None
-
-            lhs_var, lhs_const = resolve(lhs_parsed)
-            rhs_var, rhs_const = resolve(rhs_parsed)
-
-            if op != "==":
-                raise ValueError(f"Unsupported SAT constraint operator: {op!r}")
-
-            if lhs_var is not None and rhs_var is not None:
-                # x_lhs == x_rhs  →  two implications
-                master_sat.add_clause((-lhs_var,  rhs_var))
-                master_sat.add_clause(( lhs_var, -rhs_var))
-            elif lhs_var is not None and rhs_const is not None:
-                # x == constant
-                master_sat.add_clause((lhs_var if rhs_const else -lhs_var,))
-            elif lhs_const is not None and rhs_var is not None:
-                # constant == x
-                master_sat.add_clause((rhs_var if lhs_const else -rhs_var,))
-            # const == const: no clause needed (trivially true or contradictory)
 
     def generate_report(self, model_options):
         """

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -1496,11 +1496,12 @@ class Cipher:
               :class:`civerly.model_options.MODEL_OPTIONS`
 
         When ``model_options.number_of_solutions == 1`` (the default), a
-        single optimal trail is found and its weight is returned (matching the
-        existing behaviour).  When ``number_of_solutions > 1``, the solver
-        looks for that many distinct solutions; the method returns a **list**
-        of weights (one per solution found), and all trails are available in
-        ``self.results`` (list of ``{"in": ..., "out": ...}`` dicts).
+        single optimal trail is found and its weight is returned.
+        When ``number_of_solutions > 1``, the solver looks for that many
+        distinct solutions; the method returns a **list** of that many optimal
+        weights (one per solution found), sorted in ascending order.
+        Furthermore, all trails are available in ``self.results``
+        (list of ``{"in": ..., "out": ..., "weight": ...}`` dicts).
 
         .. WARNING::
 

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -1515,10 +1515,32 @@ class Cipher:
 
             Requires the specified solver to be installed.
         """
+        # Reset per-analysis state.
+        self.results = []
+        self.trail_nodes = []
+        self._blocking_constraints = []
+
         if model_options.optimization == OPTIMIZATION.MILP:
             self.model(model_options)
             if model_options.milp_solver is None:
                 raise NoSolverWarning()
+            if model_options.number_of_solutions > 1:
+                all_results = model_options.milp_solver.solve_multiple(
+                    input_file_name=model_options.path / (self.name + ".mps"),
+                    output_file_name=model_options.path / (self.name + ".sol"),
+                    model_options=model_options,
+                    n=model_options.number_of_solutions,
+                    cipher=self,
+                )
+                for results, weight in all_results:
+                    tn = TrailNode(self, model_options, results)
+                    self.trail_nodes.append(tn)
+                    self.results.append({
+                        "in": list(self.result["in"]),
+                        "out": list(self.result["out"]),
+                        "weight": weight,
+                    })
+                return [w for _, w in all_results]
             else:
                 model_options.milp_solver.solve(
                     input_file_name=model_options.path / (self.name + ".mps"),
@@ -1531,6 +1553,23 @@ class Cipher:
             self.model(model_options)
             if self._return_immediately_:
                 return
+            if model_options.number_of_solutions > 1:
+                all_results = model_options.sat_solver.solve_multiple(
+                    input_file_name=model_options.path / (self.name + ".cnf"),
+                    output_file_name=model_options.path / (self.name + ".sat"),
+                    model_options=model_options,
+                    n=model_options.number_of_solutions,
+                    cipher=self,
+                )
+                for results, weight in all_results:
+                    tn = TrailNode(self, model_options, results)
+                    self.trail_nodes.append(tn)
+                    self.results.append({
+                        "in": list(self.result["in"]),
+                        "out": list(self.result["out"]),
+                        "weight": weight,
+                    })
+                return [w for _, w in all_results]
             else:
                 # if no sat_solver has been selected, we generate all cnf-files
                 # for the given solve_range

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -1514,12 +1514,7 @@ class Cipher:
                 self._blocking_constraints = []
                 self.model(model_options)
             else:
-                # loop until proper answer is given
-                answer = None
-                while answer not in ('N', 'Y', 'n', 'y', ''):
-                    answer = input(INPUT_STRING)
-                # only model from scratch if user wants to overwrite old model
-                if answer not in ('N', 'n'):
+                if model_options.overwrite:
                     self._blocking_constraints = []
                     self.model(model_options)
                 else:
@@ -1555,12 +1550,7 @@ class Cipher:
             if self.sat_model is None:
                 self.model(model_options)
             else:
-                # loop until proper answer is given
-                answer = None
-                while answer not in ('N', 'Y', 'n', 'y', ''):
-                    answer = input(INPUT_STRING)
-                # only model from scratch if user wants to overwrite old model
-                if answer not in ('N', 'n'):
+                if model_options.overwrite:
                     self._blocking_constraints = []
                     self.model(model_options)
                 else:

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -396,6 +396,10 @@ class Cipher:
         self.__output_length = output_length
         self.__name = name
 
+        # self._wrd is used for generate_report, to determine the displayed
+        # wordsize. Any subclass of WordBasedCipher will overwrite this value
+        # with `self.wordsize`
+        self._wrd = getattr(self, '_wrd', 4)
         
         self.__is_valid = False
         self.__IN = Cipher.__Special_Node(self, in_node=True)
@@ -408,11 +412,7 @@ class Cipher:
         # number_of_solutions > 1. Each entry is a dict
         # {"in": [...], "out": [...], "weight": <value>}.
         self.results = []
-        
-        # self._wrd is used for generate_report, to determine the displayed
-        # wordsize. Any subclass of WordBasedCipher will overwrite this value
-        # with `self.wordsize`
-        self._wrd = getattr(self, '_wrd', 4)
+
 
         # self.trail_nodes stores the TrailNode objects built during
         # analyse() for number_of_solutions > 1, one per solution.

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -48,7 +48,6 @@ import json
 import subprocess
 import glob
 from math import ceil, sqrt
-import re
 
 from civerly.component import Component
 from civerly.model_options import OPTIMIZATION, GRANULARITY
@@ -421,8 +420,9 @@ class Cipher:
         # solution files.
         
         self._blocking_constraints = []
-        self.milp_model = None
-        self.sat_model = None
+        self.milp = None
+        self.sat = None
+        self.X = None
 
     # Get-functions of various attributes:
     # --------------------------------------------------
@@ -1476,7 +1476,7 @@ class Cipher:
                 f"'{str(model_options.path / (self.name + '.cnf'))}'"
             )
 
-        self.sat_model = sat
+        self.sat = sat
         return sat
 
     def analyse(self, model_options):
@@ -1510,7 +1510,7 @@ class Cipher:
         )
 
         if model_options.optimization == OPTIMIZATION.MILP:
-            if self.milp_model is None:
+            if self.milp is None:
                 self._blocking_constraints = []
                 self.model(model_options)
             else:
@@ -1522,7 +1522,7 @@ class Cipher:
                         "Using existing MILP model, make sure it is up to date!"
                     )
                     self._finish_milp(
-                        model_options, self.milp_model
+                        model_options, self.milp
                     )
             if model_options.milp_solver is None:
                 raise NoSolverWarning()
@@ -1547,7 +1547,7 @@ class Cipher:
                 return results_and_weight[1]
 
         elif model_options.optimization == OPTIMIZATION.SAT:
-            if self.sat_model is None:
+            if self.sat is None:
                 self.model(model_options)
             else:
                 if model_options.overwrite:
@@ -1558,7 +1558,7 @@ class Cipher:
                         "Using existing SAT model, make sure it is up to date!"
                     )
                     self._finish_sat(
-                        model_options, self.sat_model
+                        model_options, self.sat
                     )
             if self._return_immediately_:
                 return

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -100,7 +100,7 @@ class Cipher:
             self._return_immediately_ = False
             self.sum_arr_milp = []
             self.sum_arr_sat = []
-            self.result = None
+            self.results = []
             if in_node:
                 self.__name = f"{self.cipher_instance.name}.IN"
                 self.__input_length = self.cipher_instance.input_length
@@ -407,12 +407,6 @@ class Cipher:
         # self._wrd is used for generate_report, to determine the displayed
         # wordsize. Any subclass of WordBasedCipher will overwrite this value
         # with `self.wordsize`
-
-        self.result = None
-        # self.result stores the input/output of the last call to self.analyse
-        # as a dict {"in": [...], "out": [...]}. It is None until analyse is
-        # called for the first time, and is completely overwritten on each
-        # subsequent call.
 
         self.results = []
         # self.results stores all trails found by analyse() when
@@ -1507,9 +1501,7 @@ class Cipher:
         existing behaviour).  When ``number_of_solutions > 1``, the solver
         looks for that many distinct solutions; the method returns a **list**
         of weights (one per solution found), and all trails are available in
-        ``self.results`` (list of ``{"in": …, "out": …}`` dicts).
-        ``self.result`` continues to hold the *last* trail processed, for
-        backward compatibility.
+        ``self.results`` (list of ``{"in": ..., "out": ...}`` dicts).
 
         .. WARNING::
 
@@ -1532,23 +1524,17 @@ class Cipher:
                     n=model_options.number_of_solutions,
                     cipher=self,
                 )
-                for results, weight in all_results:
-                    tn = TrailNode(self, model_options, results)
-                    self.trail_nodes.append(tn)
-                    self.results.append({
-                        "in": list(self.result["in"]),
-                        "out": list(self.result["out"]),
-                        "weight": weight,
-                    })
+                for results_and_weight in all_results:
+                    TrailNode(self, model_options, results_and_weight)
                 return [w for _, w in all_results]
             else:
                 model_options.milp_solver.solve(
                     input_file_name=model_options.path / (self.name + ".mps"),
                     output_file_name=model_options.path / (self.name + ".sol")
                 )
-                results, weight = self.read_results(model_options)
-                TrailNode(self, model_options, results)
-                return weight
+                results_and_weight = self.read_results(model_options)
+                TrailNode(self, model_options, results_and_weight)
+                return results_and_weight[1]
 
         elif model_options.optimization == OPTIMIZATION.SAT:
             self.model(model_options)
@@ -1562,14 +1548,8 @@ class Cipher:
                     n=model_options.number_of_solutions,
                     cipher=self,
                 )
-                for results, weight in all_results:
-                    tn = TrailNode(self, model_options, results)
-                    self.trail_nodes.append(tn)
-                    self.results.append({
-                        "in": list(self.result["in"]),
-                        "out": list(self.result["out"]),
-                        "weight": weight,
-                    })
+                for results_and_weight in all_results:
+                    TrailNode(self, model_options, results_and_weight)
                 return [w for _, w in all_results]
             else:
                 # if no sat_solver has been selected, we generate all cnf-files
@@ -1583,9 +1563,9 @@ class Cipher:
                 if model_options.sat_solver is None:
                     raise NoSolverWarning()
                 else:
-                    results, weight = self.read_results(model_options)
-                    TrailNode(self, model_options, results)
-                    return weight
+                    results_and_weight = self.read_results(model_options)
+                    TrailNode(self, model_options, results_and_weight)
+                    return results_and_weight[1]
         else:
             raise InvalidModelOptionException(
                 model_options.optimization, OPTIMIZATION
@@ -1809,7 +1789,7 @@ class Cipher:
             [ 26 , 32] (trying w =  29) : UNSAT
             [ 30 , 32] (trying w =  31) : UNSAT
             32
-            sage: cipher.result['in'] == [1]*cipher.input_length
+            sage: cipher.results[0]['in'] == [1]*cipher.input_length
             True
             sage: import shutil
             sage: shutil.rmtree(tmpdir)
@@ -1947,13 +1927,13 @@ class Cipher:
         if model_options.number_of_solutions == 1:
             # ---- single-solution path (unchanged) --------------------------
             # 1. Get results
-            results, objective_value = self.read_results(model_options)
+            results_and_weight = self.read_results(model_options)
             # 2. Construct TrailNode
-            root_node = TrailNode(self, model_options, results)
+            root_node = TrailNode(self, model_options, results_and_weight)
             # 3. Verify correctness
             root_node.verify_correctness()
             # 4. Generate LaTeX string
-            string  = self._latex_header(model_options, objective_value)
+            string  = self._latex_header(model_options, results_and_weight[1])
             string += root_node.to_latex(model_options)
             string += "\\end{document}\n"
             # 5. Write to .tex file and compile to pdf
@@ -1995,8 +1975,8 @@ class Cipher:
         """
 
         if model_options.number_of_solutions == 1:
-            results, _ = self.read_results(model_options)
-            root_node = TrailNode(self, model_options, results)
+            results_and_weight = self.read_results(model_options)
+            root_node = TrailNode(self, model_options, results_and_weight)
             root_node.verify_correctness()
             return root_node
         else:
@@ -2019,7 +1999,7 @@ class Cipher:
         out_idx = len(self.nodes) - 1 if self.is_valid else None
 
         node_dicts = [
-            {**n._to_dict(), "result": n.result}
+            {**n._to_dict(), "results": n.results}
             for i, n in enumerate(self.nodes)
             if out_idx is None or i != out_idx
         ]
@@ -2043,7 +2023,7 @@ class Cipher:
             "nodes": node_dicts,
             "edges": edge_dicts,
             "outputs": output_dicts,
-            "result": self.result,
+            "results": self.results,
         }
 
     def export(self, path):
@@ -2077,15 +2057,15 @@ class Cipher:
             sage: with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
             ....:     tmp = f.name
 
-        Before analysis, ``result`` is ``None`` and round-trips as such::
+        Before analysis, ``results`` is ``[]`` and round-trips as such::
 
             sage: cipher.export(tmp)
             Object 'test' has been exported to ...
             sage: loaded = Cipher.load(tmp)
-            sage: cipher == loaded and loaded.result is None
+            sage: cipher == loaded and loaded.results == []
             True
 
-        After analysis, ``result`` holds the trail bit-pattern and is
+        After analysis, ``results`` holds the trail bit-patterns and is
         preserved verbatim through the JSON file::
 
             sage: from civerly.model_options import *
@@ -2105,7 +2085,7 @@ class Cipher:
             Object 'test' has been exported to ...
             sage: loaded = Cipher.load(tmp)
             sage: os.unlink(tmp)
-            sage: cipher == loaded and loaded.result == cipher.result
+            sage: cipher == loaded and loaded.results == cipher.results
             True
 
         Again with a different cipher type::
@@ -2138,7 +2118,7 @@ class Cipher:
     @staticmethod
     def _populate_from_dict(cipher, d):
         r"""
-        Restore nodes, edges, outputs and result onto an empty cipher shell
+        Restore nodes, edges, outputs and results onto an empty cipher shell
         using data from a dictionary produced by :meth:`_to_dict`.
         """
         from civerly.component import (
@@ -2183,7 +2163,7 @@ class Cipher:
             return class_var._from_dict(nd)
 
         # Restore the IN node's result (index 0)
-        cipher.nodes[0].result = d["nodes"][0]["result"]
+        cipher.nodes[0].results = d["nodes"][0]["results"]
         w = 1 if type(cipher) == Cipher else cipher.wordsize
 
         for node_idx, nd in enumerate(d["nodes"][1:], start=1):
@@ -2195,7 +2175,7 @@ class Cipher:
             ]))
             cipher.add_subcipher(component, incoming)
             if not isinstance(component, Cipher):
-                cipher.nodes[node_idx].result = nd["result"]
+                cipher.nodes[node_idx].results = nd["results"]
 
         output_edges = list(set([
             (a, (x//w, y//w))
@@ -2206,7 +2186,7 @@ class Cipher:
         if output_edges:
             cipher.add_output(output_edges)
 
-        cipher.result = d["result"]
+        cipher.results = d["results"]
 
     @classmethod
     def _from_dict(cls, d):

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -96,19 +96,19 @@ class Cipher:
                 True
 
             """
-            self.cipher_instance = cipher_instance
+            self._cipher_wordsize = getattr(cipher_instance, 'wordsize', None)
             self._return_immediately_ = False
             self.sum_arr_milp = []
             self.sum_arr_sat = []
             self.results = []
             if in_node:
-                self.__name = f"{self.cipher_instance.name}.IN"
-                self.__input_length = self.cipher_instance.input_length
-                self.__output_length = self.cipher_instance.input_length
+                self.__name = f"{cipher_instance.name}.IN"
+                self.__input_length = cipher_instance.input_length
+                self.__output_length = cipher_instance.input_length
             else:
-                self.__name = f"{self.cipher_instance.name}.OUT"
-                self.__input_length = self.cipher_instance.output_length
-                self.__output_length = self.cipher_instance.output_length
+                self.__name = f"{cipher_instance.name}.OUT"
+                self.__input_length = cipher_instance.output_length
+                self.__output_length = cipher_instance.output_length
             self.in_node = in_node
 
         def __hash__(self):
@@ -250,7 +250,7 @@ class Cipher:
             Component._init_model(self, model_options)
             if model_options.granularity == GRANULARITY.WORDWISE:
                 for i in range(
-                    self.input_length // self.cipher_instance.wordsize
+                    self.input_length // self._cipher_wordsize
                 ):
                     self.milp.add_constraint(
                         self.MILP_OUT[i] == self.MILP_IN[i]

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -2132,7 +2132,7 @@ class Cipher:
         STRING  = f"\\newpage\n"
         STRING += f"\\section{{{self.name.replace('_', '\\_')}}}\n"
 
-        w = int(trail_node.weight)
+        w = trail_node.weight
         if model_options.granularity == GRANULARITY.WORDWISE:
             STRING += f"Active SBoxes: ${w}$\n\n"
         elif model_options.granularity == GRANULARITY.BITWISE:

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -2303,14 +2303,32 @@ class Cipher:
         STRING += "\t\\end{tikzpicture}}\n\\end{center}\n\\endgroup\n"
         return STRING
 
-    def exclude_solution(self, model_options, results): 
+    def exclude_solution(self, model_options, results):
         if model_options.optimization == OPTIMIZATION.MILP:
             return self._exclude_solution_milp(results)
         elif model_options.optimization == OPTIMIZATION.SAT:
-            return self._exclude_solution_sat(results)
+            return self._exclude_solution_sat(results, model_options)
 
-    def _exclude_solution_sat(self):
-        return None # TODO
+    def _exclude_solution_sat(self, results, model_options):
+        input_file_name = model_options.path / (self.name + ".cnf")
+        sum_arr_file = model_options.path / (self.name + "sum.json")
+
+        with open(sum_arr_file, 'r') as f:
+            sum_arr = json.load(f)
+
+        sum_vars = {int(var) for _, var in sum_arr}
+        input_vars = set(range(1, self.input_length + 1))
+        blocking_var_list = sorted(sum_vars | input_vars)
+
+        blocking_clause = tuple(
+            (-v if results.get(v, 0) == 1 else v)
+            for v in blocking_var_list
+        )
+
+        sat = DIMACS()
+        sat.read(str(input_file_name))
+        sat.add_clause(blocking_clause)
+        sat.write(input_file_name)
 
     def _copy_over_dictionaries_recursively(self, prev, model_options):
         r"""

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -1758,6 +1758,64 @@ class Cipher:
             sage: cipher.add_constraint("nodes[0].OUT[3] == nodes[1].IN[0]")
             sage: len(cipher._custom_constraints)
             1
+
+        TESTS::
+
+            sage: # optional - cryptominisat  # optional - espresso
+            sage: from civerly.cipher_implementations.craft import CRAFT_CVL
+            sage: from civerly.model_options import *
+            sage: from civerly.util import vec_to_int
+            sage: import tempfile
+            sage: cipher = CRAFT_CVL(2)
+            sage: with tempfile.TemporaryDirectory(delete=False) as tmpdir:
+            ....:   model_options = MODEL_OPTIONS(
+            ....:      cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:      optimization=OPTIMIZATION.SAT,
+            ....:      granularity=GRANULARITY.BITWISE,
+            ....:      sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:      linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:      sat_solver=CRYPTOMINISAT_CVL(),
+            ....:      logic_minimizer=ESPRESSO_CVL(),
+            ....:      path=Path(tmpdir))
+            sage: cipher.analyse(model_options)
+            5120 variables and 11681 clauses were written to ...
+            [  0 ,100] (trying w =  50) : SAT
+            [  0 , 50] (trying w =  25) : SAT
+            [  0 , 25] (trying w =  12) : SAT
+            [  0 , 12] (trying w =   6) : SAT
+            [  0 ,  6] (trying w =   3) : UNSAT
+            [  4 ,  6] (trying w =   5) : SAT
+            [  4 ,  5] (trying w =   4) : SAT
+            4
+        
+        Activate the entire input and analyse again:
+
+            sage: # optional - cryptominisat  # optional - espresso
+            sage: for i in range(cipher.input_length):
+            ....:   cipher.add_constraint(f"nodes[0].IN[{i}] == 1")
+            sage: cipher._custom_constraints
+            [(('var', 0, 'IN', 0), '==', ('const', 1)),
+            (('var', 0, 'IN', 1), '==', ('const', 1)),
+            ...
+            (('var', 0, 'IN', 62), '==', ('const', 1)),
+            (('var', 0, 'IN', 63), '==', ('const', 1))]
+            sage: cipher.analyse(model_options)
+            Using existing file ..., make sure it is up to date!
+            5120 variables and 11745 clauses were written to ...
+            [  0 ,100] (trying w =  50) : SAT
+            [  0 , 50] (trying w =  25) : UNSAT
+            [ 26 , 50] (trying w =  38) : SAT
+            [ 26 , 38] (trying w =  32) : SAT
+            [ 26 , 32] (trying w =  29) : UNSAT
+            [ 30 , 32] (trying w =  31) : UNSAT
+            32
+            sage: cipher.result['in'] == [1]*cipher.input_length
+            True
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
+
+        As expected, activating all input bits leads to a significantly worse trail.
+
         """
         self._custom_constraints.append(self._parse_constraint(expr))
 

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -396,10 +396,6 @@ class Cipher:
         self.__output_length = output_length
         self.__name = name
 
-        # self._wrd is used for generate_report, to determine the displayed
-        # wordsize. Any subclass of WordBasedCipher will overwrite this value
-        # with `self.wordsize`
-        self._wrd = 4
         
         self.__is_valid = False
         self.__IN = Cipher.__Special_Node(self, in_node=True)
@@ -412,6 +408,11 @@ class Cipher:
         # number_of_solutions > 1. Each entry is a dict
         # {"in": [...], "out": [...], "weight": <value>}.
         self.results = []
+        
+        # self._wrd is used for generate_report, to determine the displayed
+        # wordsize. Any subclass of WordBasedCipher will overwrite this value
+        # with `self.wordsize`
+        self._wrd = getattr(self, '_wrd', 4)
 
         # self.trail_nodes stores the TrailNode objects built during
         # analyse() for number_of_solutions > 1, one per solution.

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -1250,8 +1250,14 @@ class Cipher:
             # check if component was modeled before
             for i_prev, prev in enumerate(self.nodes[:i_comp]):
                 if comp == prev:
+                    # copy over attributes related to modeling
+                    comp.sat         = prev.sat
+                    comp.SAT_IN      = prev.SAT_IN
+                    comp.SAT_OUT     = prev.SAT_OUT
+                    comp.sum_arr_sat = prev.sum_arr_sat
+
                     # copy the component sat programs
-                    sats.append(sats[i_prev])
+                    sats.append(comp.sat)
 
                     # copy the dictionaries
                     self.dictionaries_sat[i_comp] = {

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -2257,15 +2257,6 @@ class Cipher:
         STRING += "\\begin{document}\n"
         STRING += "\\maketitle\n"
 
-        if model_options.granularity == GRANULARITY.WORDWISE:
-            STRING += f"Total number of active SBoxes: ${objective_value}$ \n"
-        elif model_options.granularity == GRANULARITY.BITWISE:
-            obj_label = {
-                CRYPTANALYSIS.DIFFERENTIAL: "differential probability",
-                CRYPTANALYSIS.LINEAR:       "linear correlation",
-            }[model_options.cryptanalysis]
-            STRING += f"Maximal {obj_label}: $2^{{-{objective_value}}}$\n"
-
         return STRING
 
     def _write_and_compile_tex(self, string, model_options, _stem=None) -> None:
@@ -2320,7 +2311,20 @@ class Cipher:
         bits_in  = [row[:] for row in trail_node.bits_in]
         bits_out = [row[:] for row in trail_node.bits_out]
 
-        STRING  = f"\\section{{{self.name.replace('_', '\\_')}}}\n"
+
+        STRING  = f"\\newpage\n"
+        STRING += f"\\section{{{self.name.replace('_', '\\_')}}}\n"
+
+        w = int(trail_node.weight)
+        if model_options.granularity == GRANULARITY.WORDWISE:
+            STRING += f"Active SBoxes: ${w}$\n\n"
+        elif model_options.granularity == GRANULARITY.BITWISE:
+            obj_label = {
+                CRYPTANALYSIS.DIFFERENTIAL: "differential probability",
+                CRYPTANALYSIS.LINEAR:       "linear correlation",
+            }[model_options.cryptanalysis]
+            STRING += f"Maximal {obj_label}: $2^{{-{w}}}$\n\n"
+
         STRING += "\\begingroup\n"
 
         if isinstance(self, AESlike):

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -39,22 +39,22 @@ from sage.modules.vector_mod2_dense import Vector_mod2_dense
 from sage.matrix.constructor import Matrix as matrix
 from sage.modules.free_module_element import vector
 from sage.sat.solvers.dimacs import DIMACS
-from sage.crypto.sbox import SBox
 
 from collections.abc import Iterable
-from copy import deepcopy
 from dataclasses import replace
-import json
-import subprocess
-import glob
 from math import ceil, sqrt
+from copy import deepcopy
+import subprocess
+import json
+import glob
 
-from civerly.component import Component
+from civerly.util import translate_sat_clause
+from civerly.util import suppress_output
+from civerly.model_options import InvalidModelOptionException
 from civerly.model_options import OPTIMIZATION, GRANULARITY
 from civerly.model_options import CRYPTANALYSIS
-from civerly.model_options import InvalidModelOptionException
 from civerly.solvers import NoSolverWarning
-from civerly.util import suppress_output, translate_sat_clause
+from civerly.component import Component
 from civerly.trail import TrailNode
 
 

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -419,7 +419,6 @@ class Cipher:
         # Used by generate_report() and get_trail() to avoid re-reading
         # solution files.
         
-        self._blocking_constraints = []
         self.milp = None
         self.sat = None
         self.X = None
@@ -1504,18 +1503,11 @@ class Cipher:
         self.results = []
         self.trail_nodes = []
 
-        INPUT_STRING = (
-            "This cipher already stores a model from a previous analysis.\n"
-            "Do you want to delete it and model from scratch? [Y/n] "
-        )
-
         if model_options.optimization == OPTIMIZATION.MILP:
             if self.milp is None:
-                self._blocking_constraints = []
                 self.model(model_options)
             else:
                 if model_options.overwrite:
-                    self._blocking_constraints = []
                     self.model(model_options)
                 else:
                     print(
@@ -1528,11 +1520,8 @@ class Cipher:
                 raise NoSolverWarning()
             if model_options.number_of_solutions > 1:
                 all_results = model_options.milp_solver.solve_multiple(
-                    input_file_name=model_options.path / (self.name + ".mps"),
-                    output_file_name=model_options.path / (self.name + ".sol"),
                     model_options=model_options,
-                    n=model_options.number_of_solutions,
-                    cipher=self,
+                    cipher=self
                 )
                 for results_and_weight in all_results:
                     TrailNode(self, model_options, results_and_weight)
@@ -1551,7 +1540,6 @@ class Cipher:
                 self.model(model_options)
             else:
                 if model_options.overwrite:
-                    self._blocking_constraints = []
                     self.model(model_options)
                 else:
                     print(
@@ -1564,11 +1552,8 @@ class Cipher:
                 return
             if model_options.number_of_solutions > 1:
                 all_results = model_options.sat_solver.solve_multiple(
-                    input_file_name=model_options.path / (self.name + ".cnf"),
-                    output_file_name=model_options.path / (self.name + ".sat"),
                     model_options=model_options,
-                    n=model_options.number_of_solutions,
-                    cipher=self,
+                    cipher=self
                 )
                 for results_and_weight in all_results:
                     TrailNode(self, model_options, results_and_weight)
@@ -1732,29 +1717,6 @@ class Cipher:
             raise InvalidModelOptionException(
                 model_options.optimization, OPTIMIZATION
             )
-
-    def _exclude_solution(self, results: dict) -> None:
-        r"""
-        Convert a MILP solution *results* dict (as returned by
-        ``process_solution_file``) into a blocking constraint and
-        append it to ``self._blocking_constraints``.
-
-        The no-good ensures the exact solution cannot repeat on re-solve.
-        It is expressed as a list of ``(comp_num, var_idx, value)`` triples;
-        :meth:`civerly.sboxcipher.SBoxCipher._model_milp` adds the
-        corresponding linear constraint during the next model build.
-        """
-        bc = []
-        for var_name, sub_dict in results.items():
-            if var_name in ("IN", "OUT"):
-                continue
-            try:
-                i = int(var_name[1:])   # "X3" -> 3
-            except (ValueError, IndexError):
-                continue
-            for j, val in sub_dict.items():
-                bc.append((i, int(j), int(val)))
-        self._blocking_constraints.append(bc)
 
     def generate_report(self, model_options):
         """

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -1549,6 +1549,7 @@ class Cipher:
                 results, weight = self.read_results(model_options)
                 TrailNode(self, model_options, results)
                 return weight
+
         elif model_options.optimization == OPTIMIZATION.SAT:
             self.model(model_options)
             if self._return_immediately_:
@@ -1873,35 +1874,83 @@ class Cipher:
             - ``model_options`` -- see
               :class:`civerly.model_options.MODEL_OPTIONS`
 
-        OUTPUT: None, but writes a PDF file.
+        OUTPUT: None, but writes one or more PDF files.
+
+        When ``model_options.number_of_solutions == 1`` (default) a single
+        ``<name>.pdf`` is produced (existing behaviour).
+
+        When ``model_options.number_of_solutions > 1``, one PDF per solution
+        is produced, named ``<name>_sol0.pdf``, ``<name>_sol1.pdf``, …
+        The stored :attr:`trail_nodes` (populated by the preceding
+        :meth:`analyse` call) are used directly; no solution files are
+        re-read.
         """
-        # 1. Get results
-        results, objective_value = self.read_results(model_options)
 
-        # 2. Construct TrailNode tree
-        root_node = TrailNode(self, model_options, results)
-
-        # 3. Verify correctness
-        root_node.verify_correctness()
-
-        # 4. Generate LaTeX string
-        string  = self._latex_header(model_options, objective_value)
-        string += root_node.to_latex(model_options)
-        string += "\\end{document}\n"
-
-        # 5. Write to .tex file and compile to PDF
-        self._write_and_compile_tex(string, model_options)
+        if model_options.number_of_solutions == 1:
+            # ---- single-solution path (unchanged) --------------------------
+            # 1. Get results
+            results, objective_value = self.read_results(model_options)
+            # 2. Construct TrailNode
+            root_node = TrailNode(self, model_options, results)
+            # 3. Verify correctness
+            root_node.verify_correctness()
+            # 4. Generate LaTeX string
+            string  = self._latex_header(model_options, objective_value)
+            string += root_node.to_latex(model_options)
+            string += "\\end{document}\n"
+            # 5. Write to .tex file and compile to pdf
+            self._write_and_compile_tex(string, model_options)
+        else:
+            # ---- multi-solution path ---------------------------------------
+            if not self.trail_nodes:
+                raise RuntimeError(
+                    "generate_report() with number_of_solutions > 1 requires "
+                    "analyse() to have been called first with the same "
+                    "model_options."
+                )
+            for i, (tn, sol) in enumerate(zip(self.trail_nodes, self.results)):
+                # 3. Verify correctness
+                tn.verify_correctness()
+                # 4. Generate LaTeX string
+                string  = self._latex_header(model_options, sol["weight"])
+                string += tn.to_latex(model_options)
+                string += "\\end{document}\n"
+                # 5. Write to .tex file and compile to pdf
+                self._write_and_compile_tex(
+                    string, model_options,
+                    _stem=f"{self.name}_sol{i}"
+                )
 
     def get_trail(self, model_options):
         r"""
         After solving a MILP or SAT, converts the solution values to a
-        trail-like output as a ``TrailNode`` tree. Similar to
-        ``self.generate_report``, but returns the tree instead of a PDF.
+        trail-like output as a ``TrailNode`` tree.  Similar to
+        :meth:`generate_report`, but returns the tree instead of a PDF.
+
+        When ``model_options.number_of_solutions == 1`` (default), a single
+        :class:`civerly.trail.TrailNode` is returned (existing behaviour).
+
+        When ``model_options.number_of_solutions > 1``, a **list** of
+        :class:`civerly.trail.TrailNode` objects is returned (one per
+        solution, best first).  The stored :attr:`trail_nodes` (populated by
+        the preceding :meth:`analyse` call) are returned directly.
         """
-        results, _ = self.read_results(model_options)
-        root_node = TrailNode(self, model_options, results)
-        root_node.verify_correctness()
-        return root_node
+
+        if model_options.number_of_solutions == 1:
+            results, _ = self.read_results(model_options)
+            root_node = TrailNode(self, model_options, results)
+            root_node.verify_correctness()
+            return root_node
+        else:
+            if not self.trail_nodes:
+                raise RuntimeError(
+                    "get_trail() with number_of_solutions > 1 requires "
+                    "analyse() to have been called first with the same "
+                    "model_options."
+                )
+            for tn in self.trail_nodes:
+                tn.verify_correctness()
+            return list(self.trail_nodes)
 
     def _to_dict(self):
         r"""
@@ -2181,13 +2230,14 @@ class Cipher:
 
         return STRING
 
-    def _write_and_compile_tex(self, string, model_options) -> None:
+    def _write_and_compile_tex(self, string, model_options, _stem=None) -> None:
         r"""
         Writes ``string`` to a ``.tex`` file and compiles it to PDF via
         ``pdflatex``, then removes auxiliary build files.
         """
-        tex_file_name = model_options.path / (self.name + ".tex")
-        pdf_file_name = model_options.path / (self.name + ".pdf")
+        stem = _stem if _stem is not None else self.name
+        tex_file_name = model_options.path / (stem + ".tex")
+        pdf_file_name = model_options.path / (stem + ".pdf")
 
         with open(tex_file_name, 'w') as f:
             f.write(string)

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -1514,15 +1514,12 @@ class Cipher:
             if self.milp is None:
                 self.model(model_options)
             else:
-                if model_options.overwrite:
-                    self.model(model_options)
-                else:
-                    print(
-                        "Using existing MILP model, make sure it is up to date!"
-                    )
-                    self._finish_milp(
-                        model_options, self.milp
-                    )
+                print(
+                    "Using existing MILP model, make sure it is up to date!"
+                )
+                self._finish_milp(
+                    model_options, self.milp
+                )
             if model_options.milp_solver is None:
                 raise NoSolverWarning()
             if model_options.number_of_solutions > 1:
@@ -1546,15 +1543,12 @@ class Cipher:
             if self.sat is None:
                 self.model(model_options)
             else:
-                if model_options.overwrite:
-                    self.model(model_options)
-                else:
-                    print(
-                        "Using existing SAT model, make sure it is up to date!"
-                    )
-                    self._finish_sat(
-                        model_options, self.sat
-                    )
+                print(
+                    "Using existing SAT model, make sure it is up to date!"
+                )
+                self._finish_sat(
+                    model_options, self.sat
+                )
             if self._return_immediately_:
                 return
             if model_options.number_of_solutions > 1:

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -48,6 +48,7 @@ import json
 import subprocess
 import glob
 from math import ceil, sqrt
+import re
 
 from civerly.component import Component
 from civerly.model_options import OPTIMIZATION, GRANULARITY
@@ -412,6 +413,27 @@ class Cipher:
         # as a dict {"in": [...], "out": [...]}. It is None until analyse is
         # called for the first time, and is completely overwritten on each
         # subsequent call.
+
+        self.results = []
+        # self.results stores all trails found by analyse() when
+        # number_of_solutions > 1. Each entry is a dict
+        # {"in": [...], "out": [...], "weight": <value>}, populated in
+        # solution order (best first).
+
+        self.trail_nodes = []
+        # self.trail_nodes stores the TrailNode objects built during
+        # analyse() for number_of_solutions > 1, one per solution.
+        # Used by generate_report() and get_trail() to avoid re-reading
+        # solution files.
+
+        self._custom_constraints = []
+        # User-added constraints from add_constraint(), stored as parsed tuples
+        # (lhs, op, rhs). Applied during model building.
+
+        self._blocking_constraints = []
+        # No-good cuts for by-hand multiple-solution enumeration. Each entry
+        # is a list of (comp_num, var_idx, value) triples derived from a solved
+        # MILP result. Reset at the start of each analyse() call.
 
     # Get-functions of various attributes:
     # --------------------------------------------------
@@ -1415,6 +1437,9 @@ class Cipher:
                             (-self.inv_dictionaries_sat[a][x+1],)
                         )
 
+        # Apply user-added custom constraints
+        self._apply_custom_constraints_sat(master_sat)
+
         model_options, model_options_ = model_options_, model_options
 
         return self._finish_sat(
@@ -1476,6 +1501,15 @@ class Cipher:
 
             - ``model_options`` -- see
               :class:`civerly.model_options.MODEL_OPTIONS`
+
+        When ``model_options.number_of_solutions == 1`` (the default), a
+        single optimal trail is found and its weight is returned (matching the
+        existing behaviour).  When ``number_of_solutions > 1``, the solver
+        looks for that many distinct solutions; the method returns a **list**
+        of weights (one per solution found), and all trails are available in
+        ``self.results`` (list of ``{"in": …, "out": …}`` dicts).
+        ``self.result`` continues to hold the *last* trail processed, for
+        backward compatibility.
 
         .. WARNING::
 
@@ -1657,6 +1691,138 @@ class Cipher:
                 model_options.optimization, OPTIMIZATION
             )
 
+    # ------------------------------------------------------------------
+    # Custom-constraint and multiple-solution helpers
+    # ------------------------------------------------------------------
+
+    def add_constraint(self, expr: str) -> None:
+        r"""
+        Add a custom equality constraint to be incorporated into the model
+        at the next call to :meth:`model` or :meth:`analyse`.
+
+        Supported syntax::
+
+            "nodes[i].IN[j]  == nodes[k].IN[l]"
+            "nodes[i].IN[j]  == nodes[k].OUT[l]"
+            "nodes[i].OUT[j] == nodes[k].OUT[l]"
+            "nodes[i].IN[j]  == 0"   (force a bit inactive)
+            "nodes[i].IN[j]  == 1"   (force a bit active)
+
+        where ``i``, ``j``, ``k``, ``l`` are non-negative integers,
+        ``IN`` selects an *input* bit of the node, and ``OUT`` an *output* bit.
+
+        EXAMPLES::
+
+            sage: from civerly.cipher import Cipher
+            sage: cipher = Cipher(8, 8, name="test")
+            sage: cipher.add_constraint("nodes[0].OUT[3] == nodes[1].IN[0]")
+            sage: len(cipher._custom_constraints)
+            1
+        """
+        self._custom_constraints.append(self._parse_constraint(expr))
+
+    @staticmethod
+    def _parse_constraint(expr: str):
+        r"""
+        Parse a constraint string into a structured triple ``(lhs, op, rhs)``.
+
+        Each side is either
+
+        * ``("var", node_idx: int, side: str, bit_idx: int)``  — a model variable
+        * ``("const", value: int)``  — a constant 0 or 1
+
+        and ``op`` is the string ``"=="``.
+        """
+        if "==" not in expr:
+            raise ValueError(
+                f"Unsupported constraint (only '==' is supported): {expr!r}"
+            )
+        lhs_str, rhs_str = expr.split("==", 1)
+
+        _var_pat = re.compile(
+            r'^\s*nodes\s*\[\s*(\d+)\s*\]\s*\.\s*(IN|OUT)\s*\[\s*(\d+)\s*\]\s*$'
+        )
+
+        def _parse_side(s: str):
+            m = _var_pat.match(s)
+            if m:
+                return ("var", int(m.group(1)), m.group(2), int(m.group(3)))
+            s = s.strip()
+            if s in ("0", "1"):
+                return ("const", int(s))
+            raise ValueError(
+                f"Cannot parse constraint operand: {s!r}\n"
+                "Expected 'nodes[i].IN/OUT[j]' or '0'/'1'."
+            )
+
+        return (_parse_side(lhs_str), "==", _parse_side(rhs_str))
+
+    def _add_milp_no_good(self, results: dict) -> None:
+        r"""
+        Convert a MILP solution *results* dict (as returned by
+        ``process_solution_file``) into a no-good (blocking) constraint and
+        append it to ``self._blocking_constraints``.
+
+        The no-good ensures the exact solution cannot repeat on re-solve.
+        It is expressed as a list of ``(comp_num, var_idx, value)`` triples;
+        :meth:`civerly.sboxcipher.SBoxCipher._model_milp` adds the
+        corresponding linear constraint during the next model build.
+        """
+        bc = []
+        for var_name, sub_dict in results.items():
+            if var_name in ("IN", "OUT"):
+                continue
+            try:
+                i = int(var_name[1:])   # "X3" → 3
+            except (ValueError, IndexError):
+                continue
+            for j, val in sub_dict.items():
+                bc.append((i, int(j), int(val)))
+        self._blocking_constraints.append(bc)
+
+    def _apply_custom_constraints_sat(self, master_sat) -> None:
+        r"""
+        Translate ``self._custom_constraints`` into SAT clauses and add them
+        to *master_sat*.  Called from :meth:`_model_sat` after all component
+        SAT models have been assembled.
+        """
+        for lhs_parsed, op, rhs_parsed in self._custom_constraints:
+
+            def resolve(parsed):
+                """Return master SAT variable index, or None for constants."""
+                if parsed[0] == "const":
+                    return None, parsed[1]
+                _, node_idx, side, bit_idx = parsed
+                comp = self.nodes[node_idx]
+                if side == "IN":
+                    comp_rel = bit_idx + 1          # 1-based
+                else:  # "OUT"
+                    comp_rel = comp.input_length + bit_idx + 1
+                sat_var = self.inv_dictionaries_sat[node_idx].get(comp_rel)
+                if sat_var is None:
+                    raise ValueError(
+                        f"nodes[{node_idx}].{side}[{bit_idx}] not found in "
+                        "SAT dictionaries — check node index and bit index."
+                    )
+                return sat_var, None
+
+            lhs_var, lhs_const = resolve(lhs_parsed)
+            rhs_var, rhs_const = resolve(rhs_parsed)
+
+            if op != "==":
+                raise ValueError(f"Unsupported SAT constraint operator: {op!r}")
+
+            if lhs_var is not None and rhs_var is not None:
+                # x_lhs == x_rhs  →  two implications
+                master_sat.add_clause((-lhs_var,  rhs_var))
+                master_sat.add_clause(( lhs_var, -rhs_var))
+            elif lhs_var is not None and rhs_const is not None:
+                # x == constant
+                master_sat.add_clause((lhs_var if rhs_const else -lhs_var,))
+            elif lhs_const is not None and rhs_var is not None:
+                # constant == x
+                master_sat.add_clause((rhs_var if lhs_const else -rhs_var,))
+            # const == const: no clause needed (trivially true or contradictory)
 
     def generate_report(self, model_options):
         """

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -95,7 +95,7 @@ class Cipher:
                 True
 
             """
-            self._cipher_wordsize = getattr(cipher_instance, 'wordsize', None)
+            self._cipher_wordsize = getattr(cipher_instance, 'wordsize', 1)
             self._return_immediately_ = False
             self.sum_arr_milp = []
             self.sum_arr_sat = []

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -395,6 +395,12 @@ class Cipher:
         self.__input_length = input_length
         self.__output_length = output_length
         self.__name = name
+
+        # self._wrd is used for generate_report, to determine the displayed
+        # wordsize. Any subclass of WordBasedCipher will overwrite this value
+        # with `self.wordsize`
+        self._wrd = 4
+        
         self.__is_valid = False
         self.__IN = Cipher.__Special_Node(self, in_node=True)
         self.__OUT = Cipher.__Special_Node(self, in_node=False)
@@ -402,22 +408,16 @@ class Cipher:
         self.__edges = []
         self.__outputs = [Cipher.NOT_SET]*self.__output_length
 
-        self._wrd = 4
-        # self._wrd is used for generate_report, to determine the displayed
-        # wordsize. Any subclass of WordBasedCipher will overwrite this value
-        # with `self.wordsize`
-
-        self.results = []
         # self.results stores all trails found by analyse() when
         # number_of_solutions > 1. Each entry is a dict
-        # {"in": [...], "out": [...], "weight": <value>}, populated in
-        # solution order (best first).
+        # {"in": [...], "out": [...], "weight": <value>}.
+        self.results = []
 
-        self.trail_nodes = []
         # self.trail_nodes stores the TrailNode objects built during
         # analyse() for number_of_solutions > 1, one per solution.
         # Used by generate_report() and get_trail() to avoid re-reading
         # solution files.
+        self.trail_nodes = []
         
         self.milp = None
         self.sat = None

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -95,7 +95,7 @@ class Cipher:
                 True
 
             """
-            self._cipher_wordsize = getattr(cipher_instance, 'wordsize', 1)
+            self._cipher_wordsize = cipher_instance._wrd
             self._return_immediately_ = False
             self.sum_arr_milp = []
             self.sum_arr_sat = []

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -2302,7 +2302,14 @@ class Cipher:
         STRING += "\t\\end{tikzpicture}}\n\\end{center}\n\\endgroup\n"
         return STRING
 
+    def exclude_solution(self, model_options, results): 
+        if model_options.optimization == OPTIMIZATION.MILP:
+            return self._exclude_solution_milp(results)
+        elif model_options.optimization == OPTIMIZATION.SAT:
+            return self._exclude_solution_sat(results)
 
+    def _exclude_solution_sat(self):
+        return None # TODO
 
     def _copy_over_dictionaries_recursively(self, prev, model_options):
         r"""

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -421,6 +421,8 @@ class Cipher:
         # solution files.
         
         self._blocking_constraints = []
+        self.milp_model = None
+        self.sat_model = None
 
     # Get-functions of various attributes:
     # --------------------------------------------------
@@ -1502,8 +1504,31 @@ class Cipher:
         self.results = []
         self.trail_nodes = []
 
+        INPUT_STRING = (
+            "This cipher already stores a model from a previous analysis.\n"
+            "Do you want to delete it and model from scratch? [Y/n] "
+        )
+
         if model_options.optimization == OPTIMIZATION.MILP:
-            self.model(model_options)
+            if self.milp_model is None:
+                self._blocking_constraints = []
+                self.model(model_options)
+            else:
+                # loop until proper answer is given
+                answer = None
+                while answer not in ('N', 'Y', 'n', 'y', ''):
+                    answer = input(INPUT_STRING)
+                # only model from scratch if user wants to overwrite old model
+                if answer not in ('N', 'n'):
+                    self._blocking_constraints = []
+                    self.model(model_options)
+                else:
+                    print(
+                        "Using existing MILP model, make sure it is up to date!"
+                    )
+                    self._finish_milp(
+                        model_options, self.milp_model
+                    )
             if model_options.milp_solver is None:
                 raise NoSolverWarning()
             if model_options.number_of_solutions > 1:
@@ -1527,7 +1552,24 @@ class Cipher:
                 return results_and_weight[1]
 
         elif model_options.optimization == OPTIMIZATION.SAT:
-            self.model(model_options)
+            if self.sat_model is None:
+                self.model(model_options)
+            else:
+                # loop until proper answer is given
+                answer = None
+                while answer not in ('N', 'Y', 'n', 'y', ''):
+                    answer = input(INPUT_STRING)
+                # only model from scratch if user wants to overwrite old model
+                if answer not in ('N', 'n'):
+                    self._blocking_constraints = []
+                    self.model(model_options)
+                else:
+                    print(
+                        "Using existing SAT model, make sure it is up to date!"
+                    )
+                    self._finish_sat(
+                        model_options, self.sat_model
+                    )
             if self._return_immediately_:
                 return
             if model_options.number_of_solutions > 1:

--- a/src/civerly/cipher_implementations/speck.py
+++ b/src/civerly/cipher_implementations/speck.py
@@ -168,6 +168,32 @@ class SPECK_CVL:
             9
             Output file in: ...
 
+        Find multiple solutions in SPECK:
+
+            sage: from civerly.cipher_implementations.speck import SPECK_CVL
+            sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cadical  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            ....:   cipher = SPECK_CVL(32, 64, R=3)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,
+            ....:     optimization=OPTIMIZATION.SAT,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     sat_solver=CADICAL_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     number_of_solutions=5,
+            ....:     path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            1392 variables and 3516 clauses were written to ...
+            [  0 ,100] (trying w =  50) : SAT
+            [  0 , 50] (trying w =  25) : SAT
+            [  0 , 25] (trying w =  12) : SAT
+            [  0 , 12] (trying w =   6) : SAT
+            [  0 ,  6] (trying w =   3) : SAT
+            [  0 ,  3] (trying w =   1) : SAT
+            [  0 ,  1] (trying w =   0) : UNSAT
+            [1, 1, 1, 2, 2]
 
         """
         if name is None:

--- a/src/civerly/cipher_implementations/speck.py
+++ b/src/civerly/cipher_implementations/speck.py
@@ -173,7 +173,7 @@ class SPECK_CVL:
             sage: from civerly.cipher_implementations.speck import SPECK_CVL
             sage: from civerly.model_options import *
             sage: import tempfile
-            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cadical  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            sage: with tempfile.TemporaryDirectory() as tmpdir:  # optional - cadical
             ....:   cipher = SPECK_CVL(32, 64, R=3)
             ....:   model_options = MODEL_OPTIONS(
             ....:     cryptanalysis=CRYPTANALYSIS.LINEAR,

--- a/src/civerly/cipher_implementations/toy_ciphers/toy7.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy7.py
@@ -79,7 +79,8 @@ class Toy7:
             sage: del cipher
             sage: cipher = Toy7()
             sage: model_options.number_of_solutions = 30
-            sage: res =cipher.analyse(model_options=model_options)
+            sage: res = cipher.analyse(model_options=model_options)
+            ...
             sage: res == [3]*30
             True
 

--- a/src/civerly/cipher_implementations/toy_ciphers/toy7.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy7.py
@@ -42,6 +42,54 @@ class Toy7:
             3
             Output file in: ...
 
+            sage: # optional - gurobi # optional - espresso
+            sage: from civerly.cipher_implementations.toy_ciphers.toy7 \
+            ....:   import Toy7
+            sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: with tempfile.TemporaryDirectory(delete=False) as tmpdir:
+            ....:   cipher = Toy7()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.MILP,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       milp_solver=GUROBI_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       solve_range=(0, 10),
+            ....:       number_of_solutions=1,
+            ....:       path=Path(tmpdir))
+            sage: cipher.analyse(model_options=model_options)
+            Using existing file ..., make sure it is up to date!
+            Using existing file ..., make sure it is up to date!
+            Using existing file ..., make sure it is up to date!
+            1356 variables and 2507 constraints were written to '...'
+            3
+        
+        Try to find multiple solutions with gurobi:
+
+            sage: # optional - gurobi # optional - espresso
+            sage: del cipher
+            sage: cipher = Toy7()
+            sage: model_options.number_of_solutions = 5
+            sage: cipher.analyse(model_options=model_options)
+            ...
+            [3, 3, 3, 3, 3]
+            sage: # optional - gurobi # optional - espresso
+            sage: del cipher
+            sage: cipher = Toy7()
+            sage: model_options.number_of_solutions = 30
+            sage: res =cipher.analyse(model_options=model_options)
+            sage: res == [3]*30
+            True
+
+
+        Delete files:
+
+            sage: # optional - gurobi # optional - espresso
+            sage: import shutil 
+            sage: shutil.rmtree(tmpdir)
+            
         """
 
         cipher = SBoxCipher(24, 64, name="Toy7")

--- a/src/civerly/cipher_implementations/weak_present.py
+++ b/src/civerly/cipher_implementations/weak_present.py
@@ -111,11 +111,13 @@ class WEAK_PRESENT_CVL:
             sage: import builtins
             sage: model_options.overwrite = False
             sage: for i in range(cipher.input_length):
-            ....:     cipher.milp_model.add_constraint(cipher.nodes[0].MILP_OUT[i] == 1)
+            ....:     cipher.milp.add_constraint(cipher.nodes[0].MILP_OUT[i] == 1)
             sage: cipher.analyse(model_options)
             Using existing MILP model, make sure it is up to date!
             3648 variables and 6529 constraints were written to ...
             61.8300749986
+            sage: cipher.results[0]['in'] == [1]*64
+            True
             
         Now overwrite the old model:
             

--- a/src/civerly/cipher_implementations/weak_present.py
+++ b/src/civerly/cipher_implementations/weak_present.py
@@ -81,6 +81,58 @@ class WEAK_PRESENT_CVL:
             ....:   weak_cipher.analyse(model_options)
             2560 variables and 4321 constraints were written to '...'
             1.2451124979
+
+        Below we generate a custom model by adding constraints.
+        First analyse the cipher as per usual:
+            
+            sage: # optional - scip, espresso
+            sage: from civerly.cipher_implementations.weak_present \
+            ....:   import WEAK_PRESENT_CVL
+            sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: with tempfile.TemporaryDirectory(delete=False) as tmpdir: 
+            ....:   cipher = WEAK_PRESENT_CVL(R=3)
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     milp_solver=SCIP_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     path=Path(tmpdir))
+            sage: cipher.analyse(model_options)
+            3648 variables and 6465 constraints were written to ...
+            5.4150374993
+        
+        Set all input bits to active and analyse again:
+
+            sage: # optional - scip, espresso
+            sage: import builtins
+            sage: builtins.input = lambda _: "n" # simulates user input
+            sage: for i in range(cipher.input_length):
+            ....:     cipher.milp_model.add_constraint(cipher.nodes[0].MILP_OUT[i] == 1)
+            sage: cipher.analyse(model_options)
+            Using existing MILP model, make sure it is up to date!
+            3648 variables and 6529 constraints were written to ...
+            61.8300749986
+            
+        Now overwrite the old model:
+            
+            sage: # optional - scip, espresso
+            sage: builtins.input = lambda _: "y" # simulates user input
+            sage: cipher.analyse(model_options)
+            Using existing file ..., make sure it is up to date!
+            3648 variables and 6465 constraints were written to ...
+            5.4150374993
+            
+        Remove temporary files:
+
+            sage: # optional - scip, espresso
+            sage: import shutil
+            sage: shutil.rmtree(tmpdir)
+
+        
         """
         if name is None:
             name = "WEAK_PRESENT"

--- a/src/civerly/cipher_implementations/weak_present.py
+++ b/src/civerly/cipher_implementations/weak_present.py
@@ -109,7 +109,7 @@ class WEAK_PRESENT_CVL:
 
             sage: # optional - scip, espresso
             sage: import builtins
-            sage: builtins.input = lambda _: "n" # simulates user input
+            sage: model_options.overwrite = False
             sage: for i in range(cipher.input_length):
             ....:     cipher.milp_model.add_constraint(cipher.nodes[0].MILP_OUT[i] == 1)
             sage: cipher.analyse(model_options)
@@ -120,7 +120,7 @@ class WEAK_PRESENT_CVL:
         Now overwrite the old model:
             
             sage: # optional - scip, espresso
-            sage: builtins.input = lambda _: "y" # simulates user input
+            sage: model_options.overwrite = True
             sage: cipher.analyse(model_options)
             Using existing file ..., make sure it is up to date!
             3648 variables and 6465 constraints were written to ...

--- a/src/civerly/cipher_implementations/weak_present.py
+++ b/src/civerly/cipher_implementations/weak_present.py
@@ -108,8 +108,6 @@ class WEAK_PRESENT_CVL:
         Set all input bits to active and analyse again:
 
             sage: # optional - scip, espresso
-            sage: import builtins
-            sage: model_options.overwrite = False
             sage: for i in range(cipher.input_length):
             ....:     cipher.milp.add_constraint(cipher.nodes[0].MILP_OUT[i] == 1)
             sage: cipher.analyse(model_options)
@@ -118,15 +116,6 @@ class WEAK_PRESENT_CVL:
             61.8300749986
             sage: cipher.results[0]['in'] == [1]*64
             True
-            
-        Now overwrite the old model:
-            
-            sage: # optional - scip, espresso
-            sage: model_options.overwrite = True
-            sage: cipher.analyse(model_options)
-            Using existing file ..., make sure it is up to date!
-            3648 variables and 6465 constraints were written to ...
-            5.4150374993
             
         Remove temporary files:
 

--- a/src/civerly/component.py
+++ b/src/civerly/component.py
@@ -100,7 +100,7 @@ class Component(ABC):
         self.__input_length = input_length
         self.__output_length = output_length
         self._return_immediately_ = False
-        self.result = None
+        self.results = []
 
     def __call__(self, x):
         r"""Evaluate this component."""

--- a/src/civerly/component.py
+++ b/src/civerly/component.py
@@ -27,17 +27,17 @@ from sage.sat.solvers.dimacs import DIMACS
 from sage.numerical.mip import MixedIntegerLinearProgram
 from sage.geometry.polyhedron.constructor import Polyhedron
 
-from civerly.util import vec_to_int, int_to_vec
 from civerly.util import list_of_predecessor_vector_indices
 from civerly.util import hw, hw_tau, suppress_output
+from civerly.util import reduction_algorithm_ST17
+from civerly.util import vec_to_int, int_to_vec
 from civerly.util import _write_espresso_input
 from civerly.util import _read_espresso_output
-from civerly.util import reduction_algorithm_ST17
 from civerly.util import translate_sat_clause
-from civerly.model_options import CRYPTANALYSIS, OPTIMIZATION
 from civerly.model_options import GRANULARITY, LINEAR_LAYER_MODELING
-from civerly.model_options import SBOX_MODELING
+from civerly.model_options import CRYPTANALYSIS, OPTIMIZATION
 from civerly.model_options import InvalidModelOptionException
+from civerly.model_options import SBOX_MODELING
 from civerly.distorted_balls import distorted_balls
 from civerly.solvers import ESPRESSO_CVL, NO_MILP_SOLVER_CVL, NO_LOGIC_MINIMIZER_CVL
 

--- a/src/civerly/model_options.py
+++ b/src/civerly/model_options.py
@@ -302,10 +302,10 @@ class MODEL_OPTIONS:
 
         if self.solve_range is not None:
             if self.solve_range[0] < 0 or \
-                    self.solve_range[0] >= self.solve_range[1]:
+                    self.solve_range[0] > self.solve_range[1]:
                 raise InvalidModelOptionException(
                     self.solve_range,
-                    message=f"{self.solve_range} is not valid!"
+                    message=f"solve_range = {self.solve_range} is not valid!"
                 )
         if self.sat_precision >= 5:
             raise InvalidModelOptionException(

--- a/src/civerly/model_options.py
+++ b/src/civerly/model_options.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
+from sage.rings.integer import Integer
+
 from civerly.solvers import SOLVER_CVL, LOGIC_MINIMIZER_CVL
 from civerly.solvers import MILP_SOLVER_CVL, SAT_SOLVER_CVL, LOGIC_MINIMIZER_CVL
 
@@ -288,7 +290,7 @@ class MODEL_OPTIONS:
             attribute for <enum 'CRYPTANALYSIS'>! Only DIFFERENTIAL,
             LINEAR allowed.
         """
-        if not isinstance(self.number_of_solutions, int) \
+        if not isinstance(self.number_of_solutions, (int, Integer)) \
                 or self.number_of_solutions < 1:
             raise InvalidModelOptionException(
                 self.number_of_solutions,

--- a/src/civerly/model_options.py
+++ b/src/civerly/model_options.py
@@ -170,6 +170,7 @@ class MODEL_OPTIONS:
             -> logic_minimizer : <class 'civerly.solvers.NO_LOGIC_MINIMIZER_CVL'>
             -> solve_range : None
             -> sat_precision : 0
+            -> number_of_solutions : 1
             -> path : CiVerLy-Models
         sage: model_options = MODEL_OPTIONS(
         ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -191,6 +192,7 @@ class MODEL_OPTIONS:
             -> logic_minimizer : <class 'civerly.solvers.NO_LOGIC_MINIMIZER_CVL'>
             -> solve_range : None
             -> sat_precision : 0
+            -> number_of_solutions : 1
             -> path : CiVerLy-Models
     """
 
@@ -205,9 +207,9 @@ class MODEL_OPTIONS:
     logic_minimizer: LOGIC_MINIMIZER_CVL = None
     solve_range: tuple = None
     sat_precision: int = 0
+    number_of_solutions: int = 1
     path: Path = None
     write_to_file: bool = True
-    number_of_solutions: int = 1
 
     def __repr__(self):
         string = "MODEL_OPTIONS:"

--- a/src/civerly/model_options.py
+++ b/src/civerly/model_options.py
@@ -207,6 +207,7 @@ class MODEL_OPTIONS:
     sat_precision: int = 0
     path: Path = None
     write_to_file: bool = True
+    number_of_solutions: int = 1
 
     def __repr__(self):
         string = "MODEL_OPTIONS:"
@@ -285,6 +286,16 @@ class MODEL_OPTIONS:
             attribute for <enum 'CRYPTANALYSIS'>! Only DIFFERENTIAL,
             LINEAR allowed.
         """
+        if not isinstance(self.number_of_solutions, int) \
+                or self.number_of_solutions < 1:
+            raise InvalidModelOptionException(
+                self.number_of_solutions,
+                message=(
+                    "number_of_solutions must be a positive integer, "
+                    f"got {self.number_of_solutions!r}."
+                )
+            )
+
         if self.solve_range is not None:
             if self.solve_range[0] < 0 or \
                     self.solve_range[0] >= self.solve_range[1]:

--- a/src/civerly/model_options.py
+++ b/src/civerly/model_options.py
@@ -212,7 +212,6 @@ class MODEL_OPTIONS:
     number_of_solutions: int = 1
     path: Path = None
     write_to_file: bool = True
-    overwrite: bool = True
 
     def __repr__(self):
         string = "MODEL_OPTIONS:"

--- a/src/civerly/model_options.py
+++ b/src/civerly/model_options.py
@@ -212,6 +212,7 @@ class MODEL_OPTIONS:
     number_of_solutions: int = 1
     path: Path = None
     write_to_file: bool = True
+    overwrite: bool = True
 
     def __repr__(self):
         string = "MODEL_OPTIONS:"

--- a/src/civerly/sboxcipher.py
+++ b/src/civerly/sboxcipher.py
@@ -571,9 +571,37 @@ class SBoxCipher(Cipher):
         It is expressed as a list of ``(comp_num, var_idx, value)`` triples;
         :meth:`civerly.sboxcipher.SBoxCipher._model_milp` adds the
         corresponding linear constraint during the next model build.
+
+        TESTS::
+
+            sage: # optional - scip, espresso
+            sage: from civerly.cipher_implementations.present \
+            ....:   import PRESENT_CVL
+            sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: present_cipher = PRESENT_CVL(R=4)
+            sage: with tempfile.TemporaryDirectory(delete=False) as tmpdir:
+            ....:   model_options = MODEL_OPTIONS(
+            ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:     optimization=OPTIMIZATION.MILP,
+            ....:     granularity=GRANULARITY.BITWISE,
+            ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:     milp_solver=SCIP_CVL(),
+            ....:     logic_minimizer=ESPRESSO_CVL(),
+            ....:     number_of_solutions=2,
+            ....:     path=Path(tmpdir))
+            ....:   present_cipher.analyse(model_options)
+            ...
+            [12, 12]
+            sage: t1, t2 = present_cipher.get_trail(model_options)
+            sage: t1 == t2
+            False 
+
+
         """
-        bc = []
-        n_active = 0
+        from civerly.util import translate_var
+
         for var_name, sub_dict in results.items():
             if var_name in ("IN", "OUT"):
                 continue
@@ -581,16 +609,12 @@ class SBoxCipher(Cipher):
                 # 'X3' -> 3
                 i = int(var_name[1:])
 
+            # add \sum_{x_ij = 0} x_ij + \sum_{x_ij = 1} (1 - x_ij) \geq 1 
+            lhs = 0
+            n_active = 0
             for j, val in sub_dict.items():
-                assert val in (0, 1)
+                assert val in (0, 1), f"{val} is not binary"
                 n_active += val
-                bc.append((i, int(j), int(val)))
+                lhs += ((-1) ** val) * translate_var(self, i, self.X[i][j])
 
-        n_active = sum(1 for (_, _, v) in bc if v == 1)
-        # Build lhs = \sum_{val=0} x_ij  − \sum_{val=1} x_ij
-        lhs = None
-        for (i, j, val) in bc:
-            term = self.X[i][j] if val == 0 else ((-1) * self.X[i][j])
-            lhs = term if lhs is None else lhs + term
-        if lhs is not None:
             self.milp.add_constraint(lhs >= 1 - n_active)

--- a/src/civerly/sboxcipher.py
+++ b/src/civerly/sboxcipher.py
@@ -474,14 +474,15 @@ class SBoxCipher(Cipher):
                 master_milp.add_constraint(lhs >= 1 - n_active)
         # -----------------------------------
 
+        self.X = X
 
         # change back s.t. toplevel milp is written to file
         model_options, model_options_ = model_options_, model_options
 
-        return self._finish_milp(model_options, master_milp, X,
+        return self._finish_milp(model_options, master_milp,
                                  _first_iter=_first_iter)
 
-    def _finish_milp(self, model_options, milp, X, _first_iter=False):
+    def _finish_milp(self, model_options, milp, _first_iter=False):
         r"""
         Finish the given ``MixedIntegerLinearProgram``. That is, add a
         constraint that ensures that the input is active and add the objective
@@ -524,7 +525,7 @@ class SBoxCipher(Cipher):
         for factor, entry in self.sum_arr_milp:
             # negative factor since we want to MINIMIZE the MILP
             # while MAXIMIZING the propagation probability.
-            summation_result += -factor * X[
+            summation_result += -factor * self.X[
                 _before_brackets(entry)][_between_brackets(entry)]
 
         if len(self.MILP_IN.items()) == 0:

--- a/src/civerly/sboxcipher.py
+++ b/src/civerly/sboxcipher.py
@@ -565,5 +565,5 @@ class SBoxCipher(Cipher):
             with suppress_output():
                 milp.write_mps(str(model_options.path / (self.name + ".mps")))
 
-        self.milp_model = milp
+        self.milp = milp
         return milp

--- a/src/civerly/sboxcipher.py
+++ b/src/civerly/sboxcipher.py
@@ -196,8 +196,14 @@ class SBoxCipher(Cipher):
             # check if component was modeled before
             for i_prev, prev in enumerate(self.nodes[:i_comp]):
                 if comp == prev:
+                    # copy over attributes related to modeling
+                    comp.milp         = prev.milp
+                    comp.MILP_IN      = prev.MILP_IN
+                    comp.MILP_OUT     = prev.MILP_OUT
+                    comp.sum_arr_milp = prev.sum_arr_milp
+
                     # copy the component milp programs
-                    milps.append(milps[i_prev])
+                    milps.append(comp.milp)
 
                     for key, val in self.dictionaries_milp[i_prev].items():
                         assert key[:key.index('X') + 1] == "X"
@@ -588,4 +594,3 @@ class SBoxCipher(Cipher):
             lhs = term if lhs is None else lhs + term
         if lhs is not None:
             self.milp.add_constraint(lhs >= 1 - n_active)
-            print(self.milp.constraints()[-1])

--- a/src/civerly/sboxcipher.py
+++ b/src/civerly/sboxcipher.py
@@ -461,19 +461,6 @@ class SBoxCipher(Cipher):
                             X[_before_brackets(tmp)][_between_brackets(tmp)] == 0
                         )
 
-        # apply blocking constraints
-        # -----------------------------------
-        for bc in self._blocking_constraints:
-            n_active = sum(1 for (_, _, v) in bc if v == 1)
-            # Build lhs = \sum_{val=0} x_ij  − \sum_{val=1} x_ij
-            lhs = None
-            for (i, j, val) in bc:
-                term = X[i][j] if val == 0 else ((-1) * X[i][j])
-                lhs = term if lhs is None else lhs + term
-            if lhs is not None:
-                master_milp.add_constraint(lhs >= 1 - n_active)
-        # -----------------------------------
-
         self.X = X
 
         # change back s.t. toplevel milp is written to file
@@ -567,3 +554,38 @@ class SBoxCipher(Cipher):
 
         self.milp = milp
         return milp
+
+    def _exclude_solution_milp(self, results: dict) -> None:
+        r"""
+        Convert a MILP solution *results* dict (as returned by
+        ``process_solution_file``) into a blocking constraint and
+        add it to ``self.milp``.
+
+        The no-good ensures the exact solution cannot repeat on re-solve.
+        It is expressed as a list of ``(comp_num, var_idx, value)`` triples;
+        :meth:`civerly.sboxcipher.SBoxCipher._model_milp` adds the
+        corresponding linear constraint during the next model build.
+        """
+        bc = []
+        n_active = 0
+        for var_name, sub_dict in results.items():
+            if var_name in ("IN", "OUT"):
+                continue
+            if var_name[0] == 'X':
+                # 'X3' -> 3
+                i = int(var_name[1:])
+
+            for j, val in sub_dict.items():
+                assert val in (0, 1)
+                n_active += val
+                bc.append((i, int(j), int(val)))
+
+        n_active = sum(1 for (_, _, v) in bc if v == 1)
+        # Build lhs = \sum_{val=0} x_ij  − \sum_{val=1} x_ij
+        lhs = None
+        for (i, j, val) in bc:
+            term = self.X[i][j] if val == 0 else ((-1) * self.X[i][j])
+            lhs = term if lhs is None else lhs + term
+        if lhs is not None:
+            self.milp.add_constraint(lhs >= 1 - n_active)
+            print(self.milp.constraints()[-1])

--- a/src/civerly/sboxcipher.py
+++ b/src/civerly/sboxcipher.py
@@ -461,74 +461,27 @@ class SBoxCipher(Cipher):
                             X[_before_brackets(tmp)][_between_brackets(tmp)] == 0
                         )
 
-        # Apply user-added equality constraints and no-good blocking constraints
-        self._apply_custom_constraints_milp(master_milp, X)
-
-        self.X = X
-
-        # change back s.t. toplevel milp is written to file
-        model_options, model_options_ = model_options_, model_options
-
-        return self._finish_milp(model_options, master_milp,
-                                 _first_iter=_first_iter)
-
-    def _apply_custom_constraints_milp(self, master_milp, X) -> None:
-        r"""
-        Translate ``self._custom_constraints`` into MILP equality constraints
-        and ``self._blocking_constraints`` into linear no-good cuts, then add
-        them all to *master_milp*.
-
-        Custom constraints reference model variables through
-        ``self.inv_dictionaries_milp``, which must already be populated before
-        this method is called (i.e., call it at the end of the component loop
-        in :meth:`_model_milp`).
-
-        Each blocking constraint is a list of ``(comp_num, var_idx, val)``
-        triples that collectively describe one previously found solution.  The
-        corresponding no-good linear cut is::
-
-            sum_{val=0} X[i][j] − sum_{val=1} X[i][j]  ≥  1 − n_active
-
-        which prevents the exact same assignment from reoccurring.
-        """
-        # ---- custom equality constraints -----------------------------------
-        for lhs_parsed, op, rhs_parsed in self._custom_constraints:
-
-            def resolve_milp(parsed):
-                if parsed[0] == "const":
-                    return parsed[1]   # plain integer
-                _, node_idx, side, bit_idx = parsed
-                key = f"{side}[{bit_idx}]"
-                master_key = self.inv_dictionaries_milp[node_idx].get(key)
-                if master_key is None:
-                    raise ValueError(
-                        f"nodes[{node_idx}].{side}[{bit_idx}] not found in "
-                        "MILP dictionaries — check node index and bit index."
-                    )
-                return X[_before_brackets(master_key)][
-                    _between_brackets(master_key)
-                ]
-
-            lhs_var = resolve_milp(lhs_parsed)
-            rhs_var = resolve_milp(rhs_parsed)
-
-            if op == "==":
-                master_milp.add_constraint(lhs_var == rhs_var)
-
-        # ---- no-good blocking constraints ----------------------------------
+        # apply blocking constraints
+        # -----------------------------------
         for bc in self._blocking_constraints:
-            if not bc:
-                continue
             n_active = sum(1 for (_, _, v) in bc if v == 1)
-            # Build  lhs = Σ_{val=0} x_ij  −  Σ_{val=1} x_ij
+            # Build lhs = \sum_{val=0} x_ij  − \sum_{val=1} x_ij
             lhs = None
             for (i, j, val) in bc:
                 term = X[i][j] if val == 0 else ((-1) * X[i][j])
                 lhs = term if lhs is None else lhs + term
             if lhs is not None:
                 master_milp.add_constraint(lhs >= 1 - n_active)
+        # -----------------------------------
 
-    def _finish_milp(self, model_options, milp, _first_iter=False):
+
+        # change back s.t. toplevel milp is written to file
+        model_options, model_options_ = model_options_, model_options
+
+        return self._finish_milp(model_options, master_milp, X,
+                                 _first_iter=_first_iter)
+
+    def _finish_milp(self, model_options, milp, X, _first_iter=False):
         r"""
         Finish the given ``MixedIntegerLinearProgram``. That is, add a
         constraint that ensures that the input is active and add the objective
@@ -571,7 +524,7 @@ class SBoxCipher(Cipher):
         for factor, entry in self.sum_arr_milp:
             # negative factor since we want to MINIMIZE the MILP
             # while MAXIMIZING the propagation probability.
-            summation_result += -factor * self.X[
+            summation_result += -factor * X[
                 _before_brackets(entry)][_between_brackets(entry)]
 
         if len(self.MILP_IN.items()) == 0:
@@ -611,4 +564,5 @@ class SBoxCipher(Cipher):
             with suppress_output():
                 milp.write_mps(str(model_options.path / (self.name + ".mps")))
 
+        self.milp_model = milp
         return milp

--- a/src/civerly/sboxcipher.py
+++ b/src/civerly/sboxcipher.py
@@ -23,6 +23,7 @@ from civerly.component import SBox_CVL, LinearLayer_CVL, XOR_CVL
 from civerly.component import RK_CVL, C_CVL, I_CVL, RoundkeyXOR_CVL, ConstXOR_CVL
 from civerly.util import _before_brackets, _between_brackets, suppress_output
 from civerly.util import translate_milp_constraint
+from civerly.util import translate_var
 from civerly.model_options import OPTIMIZATION, GRANULARITY, CRYPTANALYSIS
 from civerly.model_options import InvalidModelOptionException
 
@@ -568,9 +569,9 @@ class SBoxCipher(Cipher):
         add it to ``self.milp``.
 
         The no-good ensures the exact solution cannot repeat on re-solve.
-        It is expressed as a list of ``(comp_num, var_idx, value)`` triples;
-        :meth:`civerly.sboxcipher.SBoxCipher._model_milp` adds the
-        corresponding linear constraint during the next model build.
+        The constraint is added directly to ``self.milp``; callers must
+        flush ``self.milp`` to the MPS file (via ``_finish_milp``) before
+        invoking the solver again.
 
         TESTS::
 
@@ -580,7 +581,7 @@ class SBoxCipher(Cipher):
             sage: from civerly.model_options import *
             sage: import tempfile
             sage: present_cipher = PRESENT_CVL(R=4)
-            sage: with tempfile.TemporaryDirectory(delete=False) as tmpdir:
+            sage: with tempfile.TemporaryDirectory() as tmpdir:
             ....:   model_options = MODEL_OPTIONS(
             ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
             ....:     optimization=OPTIMIZATION.MILP,
@@ -589,32 +590,31 @@ class SBoxCipher(Cipher):
             ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
             ....:     milp_solver=SCIP_CVL(),
             ....:     logic_minimizer=ESPRESSO_CVL(),
-            ....:     number_of_solutions=2,
+            ....:     number_of_solutions=3,
             ....:     path=Path(tmpdir))
             ....:   present_cipher.analyse(model_options)
-            ...
-            [12, 12]
-            sage: t1, t2 = present_cipher.get_trail(model_options)
-            sage: t1 == t2
-            False 
+            5312 variables and 8641 constraints were written to ...
+            5312 variables and 8642 constraints were written to ...
+            5312 variables and 8643 constraints were written to ...
+            [12, 12, 12]
+            sage: t1, t2, t3 = present_cipher.get_trail(model_options)
+            sage: t1 == t2 or t1 == t3 or t2 == t3
+            False
 
 
         """
-        from civerly.util import translate_var
-
+        # add \sum_{x_ij = 0} x_ij + \sum_{x_ij = 1} (1 - x_ij) \geq 1
+        lhs = 0
+        n_active = 0
         for var_name, sub_dict in results.items():
             if var_name in ("IN", "OUT"):
                 continue
             if var_name[0] == 'X':
                 # 'X3' -> 3
                 i = int(var_name[1:])
-
-            # add \sum_{x_ij = 0} x_ij + \sum_{x_ij = 1} (1 - x_ij) \geq 1 
-            lhs = 0
-            n_active = 0
             for j, val in sub_dict.items():
                 assert val in (0, 1), f"{val} is not binary"
                 n_active += val
-                lhs += ((-1) ** val) * translate_var(self, i, self.X[i][j])
+                lhs += ((-1) ** val) * translate_var(self, self.nodes[i], self.X[i][j])
 
-            self.milp.add_constraint(lhs >= 1 - n_active)
+        self.milp.add_constraint(lhs >= 1 - n_active)

--- a/src/civerly/sboxcipher.py
+++ b/src/civerly/sboxcipher.py
@@ -278,7 +278,6 @@ class SBoxCipher(Cipher):
                     val = asg[:asg.index("=")].strip(" ")
                     key = f"X{i_comp}[{ind}]"
                     self.dictionaries_milp[i_comp][key] = val
-                    # self.dictionaries_milp[i_comp][ind] = val
 
                 self.inv_dictionaries_milp[i_comp] = {
                     v: k for k, v in self.dictionaries_milp[i_comp].items()

--- a/src/civerly/sboxcipher.py
+++ b/src/civerly/sboxcipher.py
@@ -564,10 +564,10 @@ class SBoxCipher(Cipher):
     def _exclude_solution_milp(self, results: dict) -> None:
         r"""
         Convert a MILP solution *results* dict (as returned by
-        ``process_solution_file``) into a blocking constraint and
-        add it to ``self.milp``.
+        ``process_solution_file``) into a constraint which forbids this
+        solution and add it to ``self.milp``.
 
-        The no-good ensures the exact solution cannot repeat on re-solve.
+        This ensures the exact solution cannot be found again on re-solve.
         The constraint is added directly to ``self.milp``; callers must
         flush ``self.milp`` to the MPS file (via ``_finish_milp``) before
         invoking the solver again.

--- a/src/civerly/sboxcipher.py
+++ b/src/civerly/sboxcipher.py
@@ -461,6 +461,9 @@ class SBoxCipher(Cipher):
                             X[_before_brackets(tmp)][_between_brackets(tmp)] == 0
                         )
 
+        # Apply user-added equality constraints and no-good blocking constraints
+        self._apply_custom_constraints_milp(master_milp, X)
+
         self.X = X
 
         # change back s.t. toplevel milp is written to file
@@ -468,6 +471,62 @@ class SBoxCipher(Cipher):
 
         return self._finish_milp(model_options, master_milp,
                                  _first_iter=_first_iter)
+
+    def _apply_custom_constraints_milp(self, master_milp, X) -> None:
+        r"""
+        Translate ``self._custom_constraints`` into MILP equality constraints
+        and ``self._blocking_constraints`` into linear no-good cuts, then add
+        them all to *master_milp*.
+
+        Custom constraints reference model variables through
+        ``self.inv_dictionaries_milp``, which must already be populated before
+        this method is called (i.e., call it at the end of the component loop
+        in :meth:`_model_milp`).
+
+        Each blocking constraint is a list of ``(comp_num, var_idx, val)``
+        triples that collectively describe one previously found solution.  The
+        corresponding no-good linear cut is::
+
+            sum_{val=0} X[i][j] − sum_{val=1} X[i][j]  ≥  1 − n_active
+
+        which prevents the exact same assignment from reoccurring.
+        """
+        # ---- custom equality constraints -----------------------------------
+        for lhs_parsed, op, rhs_parsed in self._custom_constraints:
+
+            def resolve_milp(parsed):
+                if parsed[0] == "const":
+                    return parsed[1]   # plain integer
+                _, node_idx, side, bit_idx = parsed
+                key = f"{side}[{bit_idx}]"
+                master_key = self.inv_dictionaries_milp[node_idx].get(key)
+                if master_key is None:
+                    raise ValueError(
+                        f"nodes[{node_idx}].{side}[{bit_idx}] not found in "
+                        "MILP dictionaries — check node index and bit index."
+                    )
+                return X[_before_brackets(master_key)][
+                    _between_brackets(master_key)
+                ]
+
+            lhs_var = resolve_milp(lhs_parsed)
+            rhs_var = resolve_milp(rhs_parsed)
+
+            if op == "==":
+                master_milp.add_constraint(lhs_var == rhs_var)
+
+        # ---- no-good blocking constraints ----------------------------------
+        for bc in self._blocking_constraints:
+            if not bc:
+                continue
+            n_active = sum(1 for (_, _, v) in bc if v == 1)
+            # Build  lhs = Σ_{val=0} x_ij  −  Σ_{val=1} x_ij
+            lhs = None
+            for (i, j, val) in bc:
+                term = X[i][j] if val == 0 else ((-1) * X[i][j])
+                lhs = term if lhs is None else lhs + term
+            if lhs is not None:
+                master_milp.add_constraint(lhs >= 1 - n_active)
 
     def _finish_milp(self, model_options, milp, _first_iter=False):
         r"""

--- a/src/civerly/solvers.py
+++ b/src/civerly/solvers.py
@@ -375,40 +375,19 @@ class SAT_SOLVER_CVL(SOLVER_CVL):
         if n <= 1:
             return all_results
 
-        # --- Determine variables to block on --------------------------------
+        # sum_arr is needed for weight-escalation (rebuilding CNF at a new bound).
         sum_arr_file = (
             input_file_name.parent / f"{input_file_name.stem}sum.json"
         )
         with open(sum_arr_file, 'r') as _f:
             sum_arr = json.load(_f)
 
-        sum_vars = {int(var) for _, var in sum_arr}
-        # Also block on SAT_IN (vars 1 ... input_length) to distinguish trails
-        # with identical S-box activity but different input differences.
-        input_vars: set = (
-            set(range(1, cipher.input_length + 1))
-            if cipher is not None else set()
-        )
-        blocking_var_list = sorted(sum_vars | input_vars)
-
         # --- Step 2: enumerate additional solutions -------------------------
         solution_index = 1
         while solution_index < n:
             prev_result = all_results[-1][0]
 
-            # Build blocking clause: negate each variable according to its
-            # value in the previous solution, so that this solution is excluded.
-            blocking_clause = tuple(
-                (-v if prev_result.get(v, 0) == 1 else v)
-                for v in blocking_var_list
-            )
-
-            # Load the current CNF (which already has the weight constraint and
-            # all previous blocking clauses), add the new clause, and overwrite.
-            sat = DIMACS()
-            sat.read(str(input_file_name))
-            sat.add_clause(blocking_clause)
-            sat.write(input_file_name)
+            cipher.exclude_solution(model_options, prev_result)
 
             tmp_sat_file = (
                 input_file_name.parent

--- a/src/civerly/solvers.py
+++ b/src/civerly/solvers.py
@@ -828,9 +828,8 @@ class SCIP_CVL(MILP_SOLVER_CVL):
         r"""
         Find up to *n* solutions using a by-hand blocking approach.
 
-        After each solve the solution is converted to a no-good linear
-        constraint (via ``cipher._exclude_solution_milp``), the MILP model is
-        regenerated (via ``cipher.model``), and SCIP is invoked again.
+        After each solve the solution is excluded (via ``cipher.exclude_solution``),
+        the MILP model is regenerated (via ``cipher.model``), and the solver is invoked again.
 
         When all solutions at the current optimal weight are exhausted, the
         weight lower bound is increased by one and the search continues at the
@@ -848,7 +847,6 @@ class SCIP_CVL(MILP_SOLVER_CVL):
         n = model_options.number_of_solutions
 
         all_results = []
-        current_weight = None  # weight of the most recently found solution
         solution_index = 0
 
         while solution_index < n:
@@ -860,38 +858,13 @@ class SCIP_CVL(MILP_SOLVER_CVL):
                     / f"{output_file_name.stem}_{solution_index}{output_file_name.suffix}"
                 )
             self.invoke(input_file_name, sol_file, time_limit=time_limit)
-            try:
-                r, w = self.process_solution_file(sol_file)
-            except (ValueError, AssertionError):
-                # No (more) solutions found.
-                if (current_weight is None or cipher is None
-                        or model_options is None):
-                    break  # never found a solution, or cannot rebuild
-                orig_sr = model_options.solve_range
-                if orig_sr is None:
-                    # Without an explicit range the solver minimises freely and
-                    # naturally advances to the next-best weight via the
-                    # blocking constraints. Infeasibility here means
-                    # no solutions exist at any weight — stop.
-                    break
-                # Explicit solve_range: raise the lower bound by one so the
-                # solver finds solutions at the next weight level.  Keep
-                # existing no-good constraints so lower-weight solutions are
-                # not re-discovered.
-                current_weight += 1
-                if current_weight >= orig_sr[1]:
-                    break  # exceeded the allowed range
-                model_options.solve_range = (current_weight, orig_sr[1])
-                cipher.model(model_options)
-                model_options.solve_range = orig_sr
-                continue  # retry at the new weight without advancing solution_index
+            r, w = self.process_solution_file(sol_file)
 
             all_results.append((r, w))
-            current_weight = w
             solution_index += 1
 
             if solution_index < n and cipher is not None:
-                cipher._exclude_solution_milp(r)
+                cipher.exclude_solution(model_options, r)
                 cipher._finish_milp(model_options, cipher.milp)
 
         return all_results
@@ -1036,7 +1009,6 @@ class GLPK_CVL(MILP_SOLVER_CVL):
         n = model_options.number_of_solutions
 
         all_results = []
-        current_weight = None  # weight of the most recently found solution
         solution_index = 0
 
         while solution_index < n:
@@ -1047,40 +1019,14 @@ class GLPK_CVL(MILP_SOLVER_CVL):
                     output_file_name.parent
                     / f"{output_file_name.stem}_{solution_index}{output_file_name.suffix}"
                 )
-
             self.invoke(input_file_name, sol_file, time_limit=time_limit)
-            try:
-                r, w = self.process_solution_file(sol_file)
-            except (ValueError, AssertionError):
-                # No (more) solutions found.
-                if (current_weight is None or cipher is None
-                        or model_options is None):
-                    break  # never found a solution, or cannot rebuild
-                orig_sr = model_options.solve_range
-                if orig_sr is None:
-                    # Without an explicit range the solver minimises freely and
-                    # naturally advances to the next-best weight via the
-                    # accumulated no-good constraints.  Infeasibility here means
-                    # no solutions exist at any weight — stop.
-                    break
-                # Explicit solve_range: raise the lower bound by one so the
-                # solver finds solutions at the next weight level.  Keep
-                # existing no-good constraints so lower-weight solutions are
-                # not re-discovered.
-                current_weight += 1
-                if current_weight >= orig_sr[1]:
-                    break  # exceeded the allowed range
-                model_options.solve_range = (current_weight, orig_sr[1])
-                cipher.model(model_options)
-                model_options.solve_range = orig_sr
-                continue  # retry at the new weight without advancing solution_index
+            r, w = self.process_solution_file(sol_file)
 
             all_results.append((r, w))
-            current_weight = w
             solution_index += 1
 
             if solution_index < n and cipher is not None:
-                cipher._exclude_solution_milp(r)
+                cipher.exclude_solution(model_options, r)
                 cipher._finish_milp(model_options, cipher.milp)
 
         return all_results

--- a/src/civerly/solvers.py
+++ b/src/civerly/solvers.py
@@ -311,6 +311,113 @@ class SAT_SOLVER_CVL(SOLVER_CVL):
             return int(W_MIN)
         return float(W_MIN/10**pr)
 
+    def solve_multiple(self, input_file_name, output_file_name,
+                       model_options=None, n=1, cipher=None,
+                       time_limit=None):
+        r"""
+        Find up to *n* solutions at the minimum SAT weight.
+
+        **Strategy (by-hand blocking)**
+
+        1. Call :meth:`solve` to find the minimum weight *W* and the first
+           solution (binary search).  After this call, *input_file_name* holds
+           the CNF with the weight constraint ``≤ W`` (the file is overwritten
+           by :meth:`solve`).
+
+        2. For each subsequent solution:
+
+           a. Build a *blocking clause* from the variables in ``sum_arr`` and
+              the ``SAT_IN`` variables (indices ``1 … cipher.input_length``).
+              For each variable *v* in this set, the clause literal is
+              ``¬v`` if *v* was **1** in the previous solution, or ``v``
+              otherwise.  This ensures the next solution must differ in at
+              least one of these bits.
+
+           b. Append the clause to *input_file_name* (accumulating across
+              iterations) and invoke the solver.
+
+           c. If the result is UNSAT, stop — no more distinct solutions exist
+              at weight *W*.
+
+        Returns a list of ``(results_dict, objective_value)`` pairs (first
+        solution is the optimal one; subsequent ones have the same objective
+        weight).
+        """
+        assert isinstance(input_file_name, Path)
+        assert isinstance(output_file_name, Path)
+
+        pr = model_options.sat_precision if model_options is not None else 0
+
+        # --- Step 1: find minimum weight and first solution -----------------
+        weight = self.solve(
+            input_file_name, output_file_name,
+            model_options=model_options, time_limit=time_limit
+        )
+        first_result, _ = self.process_solution_file(output_file_name)
+        all_results = [(first_result, weight)]
+
+        if n <= 1:
+            return all_results
+
+        # --- Determine variables to block on --------------------------------
+        sum_arr_file = (
+            input_file_name.parent / f"{input_file_name.stem}sum.json"
+        )
+        with open(sum_arr_file, 'r') as _f:
+            sum_arr = json.load(_f)
+
+        sum_vars = {int(var) for _, var in sum_arr}
+        # Also block on SAT_IN (vars 1 … input_length) to distinguish trails
+        # with identical S-box activity but different input differences.
+        input_vars: set = (
+            set(range(1, cipher.input_length + 1))
+            if cipher is not None else set()
+        )
+        blocking_var_list = sorted(sum_vars | input_vars)
+
+        # --- Step 2: enumerate additional solutions -------------------------
+        for sol_idx in range(1, n):
+            prev_result = all_results[-1][0]
+
+            # Build blocking clause: negate each variable according to its
+            # value in the previous solution.
+            blocking_clause = tuple(
+                (-v if prev_result.get(v, 0) == 1 else v)
+                for v in blocking_var_list
+            )
+
+            # Load the current CNF (which already has the weight constraint and
+            # all previous blocking clauses), add the new clause, and overwrite.
+            sat = DIMACS()
+            sat.read(str(input_file_name))
+            sat.add_clause(blocking_clause)
+            sat.write(input_file_name)
+
+            tmp_sat_file = (
+                input_file_name.parent
+                / f"{input_file_name.stem}_sol{sol_idx}.sat"
+            )
+
+            status = self.invoke(input_file_name, tmp_sat_file,
+                                 time_limit=time_limit)
+            if status is not None:
+                break  # solver error or timeout
+
+            with open(tmp_sat_file, 'r') as _f:
+                result_line = _f.readlines()[0].strip()
+
+            if result_line in ("UNSAT", "s UNSATISFIABLE"):
+                break  # no more solutions at this weight
+
+            # Append the weight so process_solution_file() can read it.
+            with open(tmp_sat_file, 'a') as _f:
+                _f.write(str(float(weight)) + "\n")
+
+            result, w = self.process_solution_file(tmp_sat_file)
+            all_results.append((result, w))
+
+        return all_results
+
 
 class LOGIC_MINIMIZER_CVL(SOLVER_CVL):
     """
@@ -435,6 +542,89 @@ class GUROBI_CVL(MILP_SOLVER_CVL):
         return _to_dict(results), objective_value
 
 
+    def solve_multiple(self, input_file_name, output_file_name,
+                       model_options=None, n=1, cipher=None,
+                       time_limit=None):
+        r"""
+        Find up to *n* solutions using Gurobi's native solution pool.
+
+        Gurobi parameters used:
+
+        - ``PoolSolutions=n``   – keep at most *n* solutions.
+        - ``PoolSearchMode=2``  – systematically search for the *n* best
+          solutions (lowest objective value).
+        - ``SolFiles=<prefix>`` – write pool solutions as
+          ``<prefix>0.sol``, ``<prefix>1.sol``, …
+
+        Returns a list of ``(results_dict, objective_value)`` pairs ordered
+        from best to worst objective (at most *n* entries).
+        """
+        assert isinstance(input_file_name, Path)
+        assert isinstance(output_file_name, Path)
+
+        parent = output_file_name.parent
+        stem = output_file_name.stem
+        log_file_name = parent / f"{stem}_{self.name}.log"
+
+        # Pool solution files will be <pool_prefix>0.sol, <pool_prefix>1.sol …
+        pool_prefix = parent / f"{stem}_pool"
+
+        command = [
+            "gurobi_cl",
+            f"ResultFile={output_file_name}",
+            f"LogFile={log_file_name}",
+            f"PoolSolutions={n}",
+            "PoolSearchMode=2",
+            f"SolFiles={pool_prefix}",
+            str(input_file_name),
+        ]
+        if time_limit is not None:
+            command.insert(2, f"TimeLimit={time_limit}")
+
+        # Disable CIVERLY_DISABLE env-var check (same as invoke())
+        ENV_DISABLE_PREFIX = "CIVERLY_DISABLE_"
+        if ENV_DISABLE_PREFIX + self.name in os.environ:
+            raise ValueError(
+                f"{self.name} was disabled by setting environment variable "
+                f"{ENV_DISABLE_PREFIX + self.name}"
+            )
+
+        with suppress_output():
+            process = subprocess.Popen(command)
+            errno = process.wait()
+
+        if errno != 0:
+            self.status = SOLVING_STATUS.ERROR
+
+        if log_file_name.exists():
+            with open(log_file_name, 'r') as file:
+                content = file.read()
+            if re.search(self.timeout_string, content, re.MULTILINE):
+                self.status = SOLVING_STATUS.TIMEOUT
+
+        # Collect all pool solution files that were created
+        all_results = []
+        for i in range(n):
+            sol_file = parent / f"{stem}_pool{i}.sol"
+            if not sol_file.exists():
+                break
+            try:
+                r, w = self.process_solution_file(sol_file)
+                all_results.append((r, w))
+            except (AssertionError, ValueError):
+                break
+
+        # Fall back to the main solution file when no pool files exist
+        if not all_results and output_file_name.exists():
+            try:
+                r, w = self.process_solution_file(output_file_name)
+                all_results.append((r, w))
+            except (AssertionError, ValueError):
+                pass
+
+        return all_results
+
+
 class SCIP_CVL(MILP_SOLVER_CVL):
     def __init__(self):
         super().__init__()
@@ -544,6 +734,50 @@ class SCIP_CVL(MILP_SOLVER_CVL):
             results[name] = value
 
         return _to_dict(results), objective_value
+
+    def solve_multiple(self, input_file_name, output_file_name,
+                       model_options=None, n=1, cipher=None,
+                       time_limit=None):
+        r"""
+        Find up to *n* solutions using a by-hand blocking approach.
+
+        After each solve the solution is converted to a no-good linear
+        constraint (via ``cipher._add_milp_no_good``), the MILP model is
+        regenerated (via ``cipher.model``), and SCIP is invoked again.
+        This repeats until *n* solutions are found or the model becomes
+        infeasible.
+
+        Returns a list of ``(results_dict, objective_value)`` pairs (best
+        solution first).
+        """
+        assert isinstance(input_file_name, Path)
+        assert isinstance(output_file_name, Path)
+
+        all_results = []
+        for i in range(n):
+            # Direct output file for this iteration
+            if i == 0:
+                sol_file = output_file_name
+            else:
+                sol_file = (
+                    output_file_name.parent
+                    / f"{output_file_name.stem}_{i}{output_file_name.suffix}"
+                )
+
+            self.status = SOLVING_STATUS.SUCCESS
+            self.invoke(input_file_name, sol_file, time_limit=time_limit)
+            try:
+                r, w = self.process_solution_file(sol_file)
+            except (ValueError, AssertionError):
+                break   # infeasible – no more solutions
+
+            all_results.append((r, w))
+
+            if i < n - 1 and cipher is not None:
+                cipher._add_milp_no_good(r)
+                cipher.model(model_options)
+
+        return all_results
 
 
 class GLPK_CVL(MILP_SOLVER_CVL):
@@ -666,6 +900,43 @@ class GLPK_CVL(MILP_SOLVER_CVL):
             value = line[i+1:i+2]
             results[name] = value
         return _to_dict(results), objective_value
+
+    def solve_multiple(self, input_file_name, output_file_name,
+                       model_options=None, n=1, cipher=None,
+                       time_limit=None):
+        r"""
+        Find up to *n* solutions using a by-hand blocking approach (GLPK does
+        not support a solution pool natively).
+
+        Identical in structure to :meth:`civerly.solvers.SCIP_CVL.solve_multiple`.
+        """
+        assert isinstance(input_file_name, Path)
+        assert isinstance(output_file_name, Path)
+
+        all_results = []
+        for i in range(n):
+            if i == 0:
+                sol_file = output_file_name
+            else:
+                sol_file = (
+                    output_file_name.parent
+                    / f"{output_file_name.stem}_{i}{output_file_name.suffix}"
+                )
+
+            self.status = SOLVING_STATUS.SUCCESS
+            self.invoke(input_file_name, sol_file, time_limit=time_limit)
+            try:
+                r, w = self.process_solution_file(sol_file)
+            except (ValueError, AssertionError):
+                break
+
+            all_results.append((r, w))
+
+            if i < n - 1 and cipher is not None:
+                cipher._add_milp_no_good(r)
+                cipher.model(model_options)
+
+        return all_results
 
 
 class CRYPTOMINISAT_CVL(SAT_SOLVER_CVL):
@@ -889,6 +1160,11 @@ class NO_MILP_SOLVER_CVL(MILP_SOLVER_CVL):
     def solve(self, input_file_name, output_file_name, time_limit=None):
         raise NoSolverWarning()
 
+    def solve_multiple(self, input_file_name, output_file_name,
+                       model_options=None, n=1, cipher=None,
+                       time_limit=None):
+        raise NoSolverWarning()
+
     def process_solution_file(self, solution_file_name):
         """
         Internal helper method to process the solution file.
@@ -991,6 +1267,11 @@ class NO_SAT_SOLVER_CVL(SAT_SOLVER_CVL):
             return CRYPTOMINISAT_CVL().process_solution_file(solution_file_name)
         else:
             raise ValueError("Unknown solution format")
+
+    def solve_multiple(self, input_file_name, output_file_name,
+                       model_options=None, n=1, cipher=None,
+                       time_limit=None):
+        raise NoSolverWarning()
 
 
 class NO_LOGIC_MINIMIZER_CVL(LOGIC_MINIMIZER_CVL):

--- a/src/civerly/solvers.py
+++ b/src/civerly/solvers.py
@@ -570,30 +570,53 @@ class GUROBI_CVL(MILP_SOLVER_CVL):
 
     def solve_multiple(self, model_options, cipher=None, time_limit=None):
         r"""
-        Find up to *n* solutions using Gurobi's solution pool with weight
-        enforcement.
+        Find up to *n* optimal solutions using Gurobi's solution pool.
 
-        Strategy:
-
-        1. Run a standard solve to find the optimal weight *W*.
-        2. Rebuild the model with an equality constraint ``sum_arr == W``
-           and run Gurobi's pool (``PoolSearchMode=2``, ``PoolGap=0``) to
-           collect up to *n* solutions at that exact weight.
-        3. If fewer than *n* solutions are found, increment *W* by one and
-           repeat from step 2 until *n* solutions are collected or the
-           upper bound of ``model_options.solve_range`` is reached.
+        A single Gurobi invocation with ``PoolSearchMode=2`` and ``PoolGap=0``
+        finds the optimum and then systematically enumerates additional
+        solutions of equal quality, writing each to a numbered ``.sol`` file.
 
         Gurobi pool parameters used:
 
-        - ``PoolSolutions=k``  – keep at most *k* more solutions.
+        - ``PoolSolutions=n``  – keep at most *n* solutions.
         - ``PoolSearchMode=2`` – systematically enumerate pool solutions.
-        - ``PoolGap=0``        – only accept solutions matching the weight.
+        - ``PoolGap=0``        – only accept solutions matching the optimum.
         - ``SolFiles=<prefix>``– write pool solutions as
           ``<prefix>0.sol``, ``<prefix>1.sol``, …
 
-        Returns a list of ``(results_dict, objective_value)`` pairs ordered
-        from best to worst objective (at most *n* entries).
+        Returns a list of ``(results_dict, objective_value)`` pairs
+        (at most *n* entries).
         """
+
+        def solutionpooljson_to_solfiles(json_file_name, output_file_name):
+            """
+            The optimal solutions in the Gurobi solution pool can only be retrieved
+            in form of a JSON file. In order to make the program flow coherent
+            to the other solvers, write each solution into a new .sol file.
+            """
+            with open(json_file_name, 'r') as f:
+                data = json.load(f)
+
+            num_solutions = data['SolutionInfo']['SolCount']
+
+            for sol_idx in range(num_solutions):
+                obj_val = data['SolutionInfo']['PoolNObjVal'][sol_idx]
+                
+                sol_file = (
+                    output_file_name.parent
+                    / f"{output_file_name.stem}_{sol_idx}.sol"
+                )
+
+                with open(sol_file, 'w') as f:
+                    f.write(f"# Objective value = {obj_val}\n")
+                    
+                    for var in data['Vars']:
+                        var_name = var['VarName']
+                        var_value = var['PoolNX'][sol_idx]
+                        f.write(f"{var_name} {var_value}\n")
+            return
+
+
         input_file_name  = model_options.path / (cipher.name + ".mps")
         output_file_name = model_options.path / (cipher.name + ".sol")
         assert isinstance(input_file_name, Path)
@@ -604,93 +627,60 @@ class GUROBI_CVL(MILP_SOLVER_CVL):
         parent = output_file_name.parent
         stem = output_file_name.stem
         log_file_name = parent / f"{stem}_{self.name}.log"
-        pool_prefix = parent / f"{stem}_pool"
+        json_file_name = parent / f"{stem}_pool.json"
+        command = [
+            "gurobi_cl",
+            "PoolSearchMode=2",
+            f"LogFile={log_file_name}",
+            f"PoolSolutions={n}",
+            "JSONSolDetail=1",
+            f"ResultFile={json_file_name}",
+            str(input_file_name)
+        ]
 
-        # Step 1: find the optimal weight via a standard solve
-        self.invoke(input_file_name, output_file_name,
-                    log_file_name=log_file_name, time_limit=time_limit)
-        first_result, optimal_weight = self.process_solution_file(
-            output_file_name
-        )
+        if time_limit is not None:
+            command.insert(2, f"TimeLimit={time_limit}")
 
-        if n <= 1 or cipher is None or model_options is None:
-            return [(first_result, optimal_weight)]
+        with suppress_output():
+            process = subprocess.Popen(command)
+            errno = process.wait()
 
-        # Step 2: enforce equality weight and collect solutions via pooling
-        orig_sr = model_options.solve_range
-        current_weight = optimal_weight
-        all_results = []
+        if errno != 0:
+            self.status = SOLVING_STATUS.ERROR
 
-        while len(all_results) < n:
-            if orig_sr is not None and (
-                current_weight < orig_sr[0] or current_weight > orig_sr[1]
-            ):
-                break
-
-            remaining = n - len(all_results)
-
-            # Rebuild the model with sum_arr <= current_weight
-            model_options.solve_range = (0, current_weight)
-            cipher.model(model_options)
-            model_options.solve_range = orig_sr
-
-            command = [
-                "gurobi_cl",
-                f"ResultFile={output_file_name}",
-                f"LogFile={log_file_name}",
-                f"PoolSolutions={remaining}",
-                "PoolSearchMode=2",
-                "PoolGap=0",
-                f"SolFiles={pool_prefix}",
-                str(input_file_name),
-            ]
-            if time_limit is not None:
-                command.insert(2, f"TimeLimit={time_limit}")
-
-            with suppress_output():
-                process = subprocess.Popen(command)
-                errno = process.wait()
-
-            if errno != 0:
-                self.status = SOLVING_STATUS.ERROR
-
-            if log_file_name.exists():
-                with open(log_file_name, 'r') as file:
-                    content = file.read()
-                if re.search(self.timeout_string, content, re.MULTILINE):
+        if log_file_name.exists():
+            with open(log_file_name, 'r') as file:
+                if re.search(self.timeout_string, file.read(), re.MULTILINE):
                     self.status = SOLVING_STATUS.TIMEOUT
 
-            # Collect pool solution files for this weight level
-            results_for_current_weight = []
-            for i in range(remaining):
-                sol_file = parent / f"{stem}_pool_{i}.sol"
-                if not sol_file.exists():
-                    break
-                try:
-                    rw = self.process_solution_file(sol_file)
-                    results_for_current_weight.append(rw)
-                except (AssertionError, ValueError):
-                    continue
+        if self.status != SOLVING_STATUS.SUCCESS:
+            raise SolverException(self.status)
+        
+        # convert to seperate .sol files
+        solutionpooljson_to_solfiles(
+            json_file_name=json_file_name, output_file_name=output_file_name
+        )
 
-            # Fall back to the main solution file when no pool files exist
-            if results_for_current_weight == [] and output_file_name.exists():
-                try:
-                    rw = self.process_solution_file(output_file_name)
-                    results_for_current_weight.append(rw)
-                    break
-                except (AssertionError, ValueError):
-                    pass
+        results = []
+        for i in range(n):
+            sol_file = (
+                output_file_name.parent
+                / f"{output_file_name.stem}_{i}.sol"
+            )
+            if not sol_file.exists():
+                print(f"{sol_file} doesnt exist")
+                continue
+            try:
+                results.append(self.process_solution_file(sol_file))
+            except (AssertionError, ValueError):
+                print(f"process solution file failed for {sol_file}")
+                continue
 
-            all_results += results_for_current_weight
+        # Gurobi always writes the best solution to ResultFile; use as fallback
+        if not results and output_file_name.exists():
+            results.append(self.process_solution_file(output_file_name))
 
-            # If the pool returned fewer than asked, all solutions at this
-            # weight are exhausted – move to the next weight level
-            if len(results_for_current_weight) < remaining:
-                current_weight += 1
-            else:
-                break
-
-        return all_results
+        return results
 
 
 class SCIP_CVL(MILP_SOLVER_CVL):

--- a/src/civerly/solvers.py
+++ b/src/civerly/solvers.py
@@ -397,7 +397,7 @@ class SAT_SOLVER_CVL(SOLVER_CVL):
             prev_result = all_results[-1][0]
 
             # Build blocking clause: negate each variable according to its
-            # value in the previous solution.
+            # value in the previous solution, so that this solution is excluded.
             blocking_clause = tuple(
                 (-v if prev_result.get(v, 0) == 1 else v)
                 for v in blocking_var_list
@@ -847,10 +847,6 @@ class SCIP_CVL(MILP_SOLVER_CVL):
 
         n = model_options.number_of_solutions
 
-        # disable overwrite
-        tmp_overwrite = model_options.overwrite
-        model_options.overwrite = False
-
         all_results = []
         current_weight = None  # weight of the most recently found solution
         solution_index = 0
@@ -898,8 +894,6 @@ class SCIP_CVL(MILP_SOLVER_CVL):
                 cipher._exclude_solution_milp(r)
                 cipher._finish_milp(model_options, cipher.milp)
 
-        # set overwrite back to old value
-        model_options.overwrite = tmp_overwrite
         return all_results
 
 
@@ -1041,10 +1035,6 @@ class GLPK_CVL(MILP_SOLVER_CVL):
 
         n = model_options.number_of_solutions
 
-        # disable overwrite
-        tmp_overwrite = model_options.overwrite
-        model_options.overwrite = False
-
         all_results = []
         current_weight = None  # weight of the most recently found solution
         solution_index = 0
@@ -1093,8 +1083,6 @@ class GLPK_CVL(MILP_SOLVER_CVL):
                 cipher._exclude_solution_milp(r)
                 cipher._finish_milp(model_options, cipher.milp)
 
-        # set overwrite back to old value
-        model_options.overwrite = tmp_overwrite
         return all_results
 
 

--- a/src/civerly/solvers.py
+++ b/src/civerly/solvers.py
@@ -121,6 +121,46 @@ class SOLVER_CVL:
 class MILP_SOLVER_CVL(SOLVER_CVL):
     def __init__(self):
         super().__init__()
+        
+    def solve_multiple(self, model_options, cipher=None, time_limit=None):
+        r"""
+        Find up to *n* solutions using a by-hand blocking approach.
+
+        After each solve the solution is excluded (via ``cipher.exclude_solution``),
+        the MILP model is regenerated (via ``cipher.model``), and the solver is invoked again.
+
+        Returns a list of ``(results_dict, objective_value)`` pairs ordered
+        from best to worst objective weight.
+        """
+        input_file_name  = model_options.path / (cipher.name + ".mps")
+        output_file_name = model_options.path / (cipher.name + ".sol")
+        assert isinstance(input_file_name, Path)
+        assert isinstance(output_file_name, Path)
+
+        n = model_options.number_of_solutions
+
+        all_results = []
+        solution_index = 0
+
+        while solution_index < n:
+            if solution_index == 0:
+                sol_file = output_file_name
+            else:
+                sol_file = (
+                    output_file_name.parent
+                    / f"{output_file_name.stem}_{solution_index}{output_file_name.suffix}"
+                )
+            self.invoke(input_file_name, sol_file, time_limit=time_limit)
+            r, w = self.process_solution_file(sol_file)
+
+            all_results.append((r, w))
+            solution_index += 1
+
+            if solution_index < n and cipher is not None:
+                cipher.exclude_solution(model_options, r)
+                cipher._finish_milp(model_options, cipher.milp)
+
+        return all_results
 
 
 class SAT_SOLVER_CVL(SOLVER_CVL):
@@ -796,46 +836,6 @@ class SCIP_CVL(MILP_SOLVER_CVL):
 
         return _to_dict(results), objective_value
 
-    def solve_multiple(self, model_options, cipher=None, time_limit=None):
-        r"""
-        Find up to *n* solutions using a by-hand blocking approach.
-
-        After each solve the solution is excluded (via ``cipher.exclude_solution``),
-        the MILP model is regenerated (via ``cipher.model``), and the solver is invoked again.
-
-        Returns a list of ``(results_dict, objective_value)`` pairs ordered
-        from best to worst objective weight.
-        """
-        input_file_name  = model_options.path / (cipher.name + ".mps")
-        output_file_name = model_options.path / (cipher.name + ".sol")
-        assert isinstance(input_file_name, Path)
-        assert isinstance(output_file_name, Path)
-
-        n = model_options.number_of_solutions
-
-        all_results = []
-        solution_index = 0
-
-        while solution_index < n:
-            if solution_index == 0:
-                sol_file = output_file_name
-            else:
-                sol_file = (
-                    output_file_name.parent
-                    / f"{output_file_name.stem}_{solution_index}{output_file_name.suffix}"
-                )
-            self.invoke(input_file_name, sol_file, time_limit=time_limit)
-            r, w = self.process_solution_file(sol_file)
-
-            all_results.append((r, w))
-            solution_index += 1
-
-            if solution_index < n and cipher is not None:
-                cipher.exclude_solution(model_options, r)
-                cipher._finish_milp(model_options, cipher.milp)
-
-        return all_results
-
 
 class GLPK_CVL(MILP_SOLVER_CVL):
     def __init__(self):
@@ -957,45 +957,6 @@ class GLPK_CVL(MILP_SOLVER_CVL):
             value = line[i+1:i+2]
             results[name] = value
         return _to_dict(results), objective_value
-
-    def solve_multiple(self, model_options, cipher=None, time_limit=None):
-        r"""
-        Find up to *n* solutions using a by-hand blocking approach (GLPK does
-        not support a solution pool natively).
-
-        Identical in structure to :meth:`civerly.solvers.SCIP_CVL.solve_multiple`.
-        Search for optimal solution, exclude it, and restart the solving process.
-        
-        """
-        input_file_name  = model_options.path / (cipher.name + ".mps")
-        output_file_name = model_options.path / (cipher.name + ".sol")
-        assert isinstance(input_file_name, Path)
-        assert isinstance(output_file_name, Path)
-
-        n = model_options.number_of_solutions
-
-        all_results = []
-        solution_index = 0
-
-        while solution_index < n:
-            if solution_index == 0:
-                sol_file = output_file_name
-            else:
-                sol_file = (
-                    output_file_name.parent
-                    / f"{output_file_name.stem}_{solution_index}{output_file_name.suffix}"
-                )
-            self.invoke(input_file_name, sol_file, time_limit=time_limit)
-            r, w = self.process_solution_file(sol_file)
-
-            all_results.append((r, w))
-            solution_index += 1
-
-            if solution_index < n and cipher is not None:
-                cipher.exclude_solution(model_options, r)
-                cipher._finish_milp(model_options, cipher.milp)
-
-        return all_results
 
 
 class CRYPTOMINISAT_CVL(SAT_SOLVER_CVL):

--- a/src/civerly/solvers.py
+++ b/src/civerly/solvers.py
@@ -315,14 +315,14 @@ class SAT_SOLVER_CVL(SOLVER_CVL):
                        model_options=None, n=1, cipher=None,
                        time_limit=None):
         r"""
-        Find up to *n* solutions at the minimum SAT weight.
+        Find up to *n* solutions ordered by weight (best first).
 
-        **Strategy (by-hand blocking)**
+        **Strategy (by-hand blocking with weight escalation)**
 
         1. Call :meth:`solve` to find the minimum weight *W* and the first
-           solution (binary search).  After this call, *input_file_name* holds
-           the CNF with the weight constraint ``≤ W`` (the file is overwritten
-           by :meth:`solve`).
+           solution (binary search).  Before this call the base CNF is saved;
+           after the call *input_file_name* holds the CNF with the weight
+           constraint ``<= W``.
 
         2. For each subsequent solution:
 
@@ -336,23 +336,37 @@ class SAT_SOLVER_CVL(SOLVER_CVL):
            b. Append the clause to *input_file_name* (accumulating across
               iterations) and invoke the solver.
 
-           c. If the result is UNSAT, stop — no more distinct solutions exist
-              at weight *W*.
+           c. If the result is UNSAT, all solutions at the current weight are
+              exhausted.  The weight bound is incremented by one, the CNF is
+              rebuilt from the saved base file with the new ``<= W+1``
+              constraint, and solving continues.  This repeats until SAT is
+              found or the upper bound (``model_options.solve_range[1]``) is
+              reached.
 
-        Returns a list of ``(results_dict, objective_value)`` pairs (first
-        solution is the optimal one; subsequent ones have the same objective
-        weight).
+        Returns a list of ``(results_dict, objective_value)`` pairs ordered
+        best to worst objective weight.
         """
         assert isinstance(input_file_name, Path)
         assert isinstance(output_file_name, Path)
 
         pr = model_options.sat_precision if model_options is not None else 0
+        W_MAX_INT = (
+            int(model_options.solve_range[1] * 10**pr)
+            if model_options is not None else 100
+        )
+
+        # Save the base CNF before solve() overwrites input_file_name.
+        base_cnf_file = (
+            input_file_name.parent / f"{input_file_name.stem}_base.cnf"
+        )
+        shutil.copyfile(input_file_name, base_cnf_file)
 
         # --- Step 1: find minimum weight and first solution -----------------
         weight = self.solve(
             input_file_name, output_file_name,
             model_options=model_options, time_limit=time_limit
         )
+        current_weight_int = int(round(weight * 10**pr))
         first_result, _ = self.process_solution_file(output_file_name)
         all_results = [(first_result, weight)]
 
@@ -376,7 +390,8 @@ class SAT_SOLVER_CVL(SOLVER_CVL):
         blocking_var_list = sorted(sum_vars | input_vars)
 
         # --- Step 2: enumerate additional solutions -------------------------
-        for sol_idx in range(1, n):
+        sol_idx = 1
+        while sol_idx < n:
             prev_result = all_results[-1][0]
 
             # Build blocking clause: negate each variable according to its
@@ -407,14 +422,44 @@ class SAT_SOLVER_CVL(SOLVER_CVL):
                 result_line = _f.readlines()[0].strip()
 
             if result_line in ("UNSAT", "s UNSATISFIABLE"):
-                break  # no more solutions at this weight
+                # All solutions at current_weight_int are exhausted.
+                # Rebuild from the base CNF at increasing weights until SAT.
+                advanced = False
+                while current_weight_int < W_MAX_INT:
+                    current_weight_int += 1
+                    base_sat = DIMACS()
+                    base_sat.read(str(base_cnf_file))
+                    new_cnf = _generate_constraints_sum_leq_int_LS24(
+                        base_sat, sum_arr, current_weight_int
+                    )
+                    new_cnf.write(input_file_name)
 
-            # Append the weight so process_solution_file() can read it.
+                    status = self.invoke(input_file_name, tmp_sat_file,
+                                         time_limit=time_limit)
+                    if status is not None:
+                        break  # solver error or timeout
+
+                    with open(tmp_sat_file, 'r') as _f:
+                        result_line = _f.readlines()[0].strip()
+
+                    if result_line not in ("UNSAT", "s UNSATISFIABLE"):
+                        advanced = True
+                        break
+
+                if not advanced or status is not None:
+                    break  # no more solutions in range
+
+            # Process the SAT result (whether at the original weight or a new one).
+            current_weight = (
+                current_weight_int if pr == 0
+                else float(current_weight_int / 10**pr)
+            )
             with open(tmp_sat_file, 'a') as _f:
-                _f.write(str(float(weight)) + "\n")
+                _f.write(str(float(current_weight)) + "\n")
 
             result, w = self.process_solution_file(tmp_sat_file)
             all_results.append((result, w))
+            sol_idx += 1
 
         return all_results
 
@@ -744,24 +789,29 @@ class SCIP_CVL(MILP_SOLVER_CVL):
         After each solve the solution is converted to a no-good linear
         constraint (via ``cipher._add_milp_no_good``), the MILP model is
         regenerated (via ``cipher.model``), and SCIP is invoked again.
-        This repeats until *n* solutions are found or the model becomes
-        infeasible.
 
-        Returns a list of ``(results_dict, objective_value)`` pairs (best
-        solution first).
+        When all solutions at the current optimal weight are exhausted, the
+        weight lower bound is increased by one and the search continues at the
+        next weight level until *n* solutions are found or no more solutions
+        exist within the allowed range.
+
+        Returns a list of ``(results_dict, objective_value)`` pairs ordered
+        from best to worst objective weight.
         """
         assert isinstance(input_file_name, Path)
         assert isinstance(output_file_name, Path)
 
         all_results = []
-        for i in range(n):
-            # Direct output file for this iteration
-            if i == 0:
+        current_weight = None  # weight of the most recently found solution
+        sol_idx = 0
+
+        while sol_idx < n:
+            if sol_idx == 0:
                 sol_file = output_file_name
             else:
                 sol_file = (
                     output_file_name.parent
-                    / f"{output_file_name.stem}_{i}{output_file_name.suffix}"
+                    / f"{output_file_name.stem}_{sol_idx}{output_file_name.suffix}"
                 )
 
             self.status = SOLVING_STATUS.SUCCESS
@@ -769,11 +819,34 @@ class SCIP_CVL(MILP_SOLVER_CVL):
             try:
                 r, w = self.process_solution_file(sol_file)
             except (ValueError, AssertionError):
-                break   # infeasible – no more solutions
+                # No (more) solutions found.
+                if (current_weight is None or cipher is None
+                        or model_options is None):
+                    break  # never found a solution, or cannot rebuild
+                orig_sr = model_options.solve_range
+                if orig_sr is None:
+                    # Without an explicit range the solver minimises freely and
+                    # naturally advances to the next-best weight via the
+                    # accumulated no-good constraints.  Infeasibility here means
+                    # no solutions exist at any weight — stop.
+                    break
+                # Explicit solve_range: raise the lower bound by one so the
+                # solver finds solutions at the next weight level.  Keep
+                # existing no-good constraints so lower-weight solutions are
+                # not re-discovered.
+                current_weight += 1
+                if current_weight >= orig_sr[1]:
+                    break  # exceeded the allowed range
+                model_options.solve_range = (current_weight, orig_sr[1])
+                cipher.model(model_options)
+                model_options.solve_range = orig_sr
+                continue  # retry at the new weight without advancing sol_idx
 
             all_results.append((r, w))
+            current_weight = w
+            sol_idx += 1
 
-            if i < n - 1 and cipher is not None:
+            if sol_idx < n and cipher is not None:
                 cipher._add_milp_no_good(r)
                 cipher.model(model_options)
 
@@ -908,19 +981,25 @@ class GLPK_CVL(MILP_SOLVER_CVL):
         Find up to *n* solutions using a by-hand blocking approach (GLPK does
         not support a solution pool natively).
 
-        Identical in structure to :meth:`civerly.solvers.SCIP_CVL.solve_multiple`.
+        Identical in structure to :meth:`civerly.solvers.SCIP_CVL.solve_multiple`:
+        when all solutions at the current optimal weight are exhausted, the
+        weight lower bound is increased by one and the search continues at the
+        next weight level.
         """
         assert isinstance(input_file_name, Path)
         assert isinstance(output_file_name, Path)
 
         all_results = []
-        for i in range(n):
-            if i == 0:
+        current_weight = None  # weight of the most recently found solution
+        sol_idx = 0
+
+        while sol_idx < n:
+            if sol_idx == 0:
                 sol_file = output_file_name
             else:
                 sol_file = (
                     output_file_name.parent
-                    / f"{output_file_name.stem}_{i}{output_file_name.suffix}"
+                    / f"{output_file_name.stem}_{sol_idx}{output_file_name.suffix}"
                 )
 
             self.status = SOLVING_STATUS.SUCCESS
@@ -928,11 +1007,34 @@ class GLPK_CVL(MILP_SOLVER_CVL):
             try:
                 r, w = self.process_solution_file(sol_file)
             except (ValueError, AssertionError):
-                break
+                # No (more) solutions found.
+                if (current_weight is None or cipher is None
+                        or model_options is None):
+                    break  # never found a solution, or cannot rebuild
+                orig_sr = model_options.solve_range
+                if orig_sr is None:
+                    # Without an explicit range the solver minimises freely and
+                    # naturally advances to the next-best weight via the
+                    # accumulated no-good constraints.  Infeasibility here means
+                    # no solutions exist at any weight — stop.
+                    break
+                # Explicit solve_range: raise the lower bound by one so the
+                # solver finds solutions at the next weight level.  Keep
+                # existing no-good constraints so lower-weight solutions are
+                # not re-discovered.
+                current_weight += 1
+                if current_weight >= orig_sr[1]:
+                    break  # exceeded the allowed range
+                model_options.solve_range = (current_weight, orig_sr[1])
+                cipher.model(model_options)
+                model_options.solve_range = orig_sr
+                continue  # retry at the new weight without advancing sol_idx
 
             all_results.append((r, w))
+            current_weight = w
+            sol_idx += 1
 
-            if i < n - 1 and cipher is not None:
+            if sol_idx < n and cipher is not None:
                 cipher._add_milp_no_good(r)
                 cipher.model(model_options)
 

--- a/src/civerly/solvers.py
+++ b/src/civerly/solvers.py
@@ -896,7 +896,7 @@ class SCIP_CVL(MILP_SOLVER_CVL):
 
             if solution_index < n and cipher is not None:
                 cipher._exclude_solution_milp(r)
-                cipher.model(model_options)
+                cipher._finish_milp(model_options, cipher.milp)
 
         # set overwrite back to old value
         model_options.overwrite = tmp_overwrite
@@ -1091,7 +1091,7 @@ class GLPK_CVL(MILP_SOLVER_CVL):
 
             if solution_index < n and cipher is not None:
                 cipher._exclude_solution_milp(r)
-                cipher.model(model_options)
+                cipher._finish_milp(model_options, cipher.milp)
 
         # set overwrite back to old value
         model_options.overwrite = tmp_overwrite

--- a/src/civerly/solvers.py
+++ b/src/civerly/solvers.py
@@ -476,10 +476,13 @@ class GUROBI_CVL(MILP_SOLVER_CVL):
         )
         command = [
             "gurobi_cl", f"ResultFile={output_file_name}",
-            f"LogFile={log_file_name}", str(input_file_name)
+            str(input_file_name)
         ]
         if time_limit is not None:
             command.insert(2, f"TimeLimit={time_limit}")
+            
+        if log_file_name is not None:
+            command.insert(2, f"LogFile={log_file_name}")
 
         with suppress_output():
             process = subprocess.Popen(command)

--- a/src/civerly/solvers.py
+++ b/src/civerly/solvers.py
@@ -381,7 +381,7 @@ class SAT_SOLVER_CVL(SOLVER_CVL):
             sum_arr = json.load(_f)
 
         sum_vars = {int(var) for _, var in sum_arr}
-        # Also block on SAT_IN (vars 1 … input_length) to distinguish trails
+        # Also block on SAT_IN (vars 1 ... input_length) to distinguish trails
         # with identical S-box activity but different input differences.
         input_vars: set = (
             set(range(1, cipher.input_length + 1))
@@ -390,8 +390,8 @@ class SAT_SOLVER_CVL(SOLVER_CVL):
         blocking_var_list = sorted(sum_vars | input_vars)
 
         # --- Step 2: enumerate additional solutions -------------------------
-        sol_idx = 1
-        while sol_idx < n:
+        solution_index = 1
+        while solution_index < n:
             prev_result = all_results[-1][0]
 
             # Build blocking clause: negate each variable according to its
@@ -410,7 +410,7 @@ class SAT_SOLVER_CVL(SOLVER_CVL):
 
             tmp_sat_file = (
                 input_file_name.parent
-                / f"{input_file_name.stem}_sol{sol_idx}.sat"
+                / f"{input_file_name.stem}_sol{solution_index}.sat"
             )
 
             status = self.invoke(input_file_name, tmp_sat_file,
@@ -459,7 +459,7 @@ class SAT_SOLVER_CVL(SOLVER_CVL):
 
             result, w = self.process_solution_file(tmp_sat_file)
             all_results.append((result, w))
-            sol_idx += 1
+            solution_index += 1
 
         return all_results
 
@@ -787,7 +787,7 @@ class SCIP_CVL(MILP_SOLVER_CVL):
         Find up to *n* solutions using a by-hand blocking approach.
 
         After each solve the solution is converted to a no-good linear
-        constraint (via ``cipher._add_milp_no_good``), the MILP model is
+        constraint (via ``cipher._exclude_solution``), the MILP model is
         regenerated (via ``cipher.model``), and SCIP is invoked again.
 
         When all solutions at the current optimal weight are exhausted, the
@@ -803,15 +803,15 @@ class SCIP_CVL(MILP_SOLVER_CVL):
 
         all_results = []
         current_weight = None  # weight of the most recently found solution
-        sol_idx = 0
+        solution_index = 0
 
-        while sol_idx < n:
-            if sol_idx == 0:
+        while solution_index < n:
+            if solution_index == 0:
                 sol_file = output_file_name
             else:
                 sol_file = (
                     output_file_name.parent
-                    / f"{output_file_name.stem}_{sol_idx}{output_file_name.suffix}"
+                    / f"{output_file_name.stem}_{solution_index}{output_file_name.suffix}"
                 )
 
             self.status = SOLVING_STATUS.SUCCESS
@@ -827,7 +827,7 @@ class SCIP_CVL(MILP_SOLVER_CVL):
                 if orig_sr is None:
                     # Without an explicit range the solver minimises freely and
                     # naturally advances to the next-best weight via the
-                    # accumulated no-good constraints.  Infeasibility here means
+                    # blocking constraints. Infeasibility here means
                     # no solutions exist at any weight — stop.
                     break
                 # Explicit solve_range: raise the lower bound by one so the
@@ -840,14 +840,14 @@ class SCIP_CVL(MILP_SOLVER_CVL):
                 model_options.solve_range = (current_weight, orig_sr[1])
                 cipher.model(model_options)
                 model_options.solve_range = orig_sr
-                continue  # retry at the new weight without advancing sol_idx
+                continue  # retry at the new weight without advancing solution_index
 
             all_results.append((r, w))
             current_weight = w
-            sol_idx += 1
+            solution_index += 1
 
-            if sol_idx < n and cipher is not None:
-                cipher._add_milp_no_good(r)
+            if solution_index < n and cipher is not None:
+                cipher._exclude_solution(r)
                 cipher.model(model_options)
 
         return all_results
@@ -991,15 +991,15 @@ class GLPK_CVL(MILP_SOLVER_CVL):
 
         all_results = []
         current_weight = None  # weight of the most recently found solution
-        sol_idx = 0
+        solution_index = 0
 
-        while sol_idx < n:
-            if sol_idx == 0:
+        while solution_index < n:
+            if solution_index == 0:
                 sol_file = output_file_name
             else:
                 sol_file = (
                     output_file_name.parent
-                    / f"{output_file_name.stem}_{sol_idx}{output_file_name.suffix}"
+                    / f"{output_file_name.stem}_{solution_index}{output_file_name.suffix}"
                 )
 
             self.status = SOLVING_STATUS.SUCCESS
@@ -1028,14 +1028,14 @@ class GLPK_CVL(MILP_SOLVER_CVL):
                 model_options.solve_range = (current_weight, orig_sr[1])
                 cipher.model(model_options)
                 model_options.solve_range = orig_sr
-                continue  # retry at the new weight without advancing sol_idx
+                continue  # retry at the new weight without advancing solution_index
 
             all_results.append((r, w))
             current_weight = w
-            sol_idx += 1
+            solution_index += 1
 
-            if sol_idx < n and cipher is not None:
-                cipher._add_milp_no_good(r)
+            if solution_index < n and cipher is not None:
+                cipher._exclude_solution(r)
                 cipher.model(model_options)
 
         return all_results

--- a/src/civerly/solvers.py
+++ b/src/civerly/solvers.py
@@ -591,14 +591,25 @@ class GUROBI_CVL(MILP_SOLVER_CVL):
                        model_options=None, n=1, cipher=None,
                        time_limit=None):
         r"""
-        Find up to *n* solutions using Gurobi's native solution pool.
+        Find up to *n* solutions using Gurobi's solution pool with weight
+        enforcement.
 
-        Gurobi parameters used:
+        Strategy:
 
-        - ``PoolSolutions=n``   – keep at most *n* solutions.
-        - ``PoolSearchMode=2``  – systematically search for the *n* best
-          solutions (lowest objective value).
-        - ``SolFiles=<prefix>`` – write pool solutions as
+        1. Run a standard solve to find the optimal weight *W*.
+        2. Rebuild the model with an equality constraint ``sum_arr == W``
+           and run Gurobi's pool (``PoolSearchMode=2``, ``PoolGap=0``) to
+           collect up to *n* solutions at that exact weight.
+        3. If fewer than *n* solutions are found, increment *W* by one and
+           repeat from step 2 until *n* solutions are collected or the
+           upper bound of ``model_options.solve_range`` is reached.
+
+        Gurobi pool parameters used:
+
+        - ``PoolSolutions=k``  – keep at most *k* more solutions.
+        - ``PoolSearchMode=2`` – systematically enumerate pool solutions.
+        - ``PoolGap=0``        – only accept solutions matching the weight.
+        - ``SolFiles=<prefix>``– write pool solutions as
           ``<prefix>0.sol``, ``<prefix>1.sol``, …
 
         Returns a list of ``(results_dict, objective_value)`` pairs ordered
@@ -610,62 +621,93 @@ class GUROBI_CVL(MILP_SOLVER_CVL):
         parent = output_file_name.parent
         stem = output_file_name.stem
         log_file_name = parent / f"{stem}_{self.name}.log"
-
-        # Pool solution files will be <pool_prefix>0.sol, <pool_prefix>1.sol …
         pool_prefix = parent / f"{stem}_pool"
 
-        command = [
-            "gurobi_cl",
-            f"ResultFile={output_file_name}",
-            f"LogFile={log_file_name}",
-            f"PoolSolutions={n}",
-            "PoolSearchMode=2",
-            f"SolFiles={pool_prefix}",
-            str(input_file_name),
-        ]
-        if time_limit is not None:
-            command.insert(2, f"TimeLimit={time_limit}")
+        # Step 1: find the optimal weight via a standard solve
+        self.status = SOLVING_STATUS.SUCCESS
+        self.invoke(input_file_name, output_file_name,
+                    log_file_name=log_file_name, time_limit=time_limit)
+        first_result, optimal_weight = self.process_solution_file(
+            output_file_name
+        )
 
-        # Disable CIVERLY_DISABLE env-var check (same as invoke())
-        ENV_DISABLE_PREFIX = "CIVERLY_DISABLE_"
-        if ENV_DISABLE_PREFIX + self.name in os.environ:
-            raise ValueError(
-                f"{self.name} was disabled by setting environment variable "
-                f"{ENV_DISABLE_PREFIX + self.name}"
-            )
+        if n <= 1 or cipher is None or model_options is None:
+            return [(first_result, optimal_weight)]
 
-        with suppress_output():
-            process = subprocess.Popen(command)
-            errno = process.wait()
-
-        if errno != 0:
-            self.status = SOLVING_STATUS.ERROR
-
-        if log_file_name.exists():
-            with open(log_file_name, 'r') as file:
-                content = file.read()
-            if re.search(self.timeout_string, content, re.MULTILINE):
-                self.status = SOLVING_STATUS.TIMEOUT
-
-        # Collect all pool solution files that were created
+        # Step 2: enforce equality weight and collect solutions via pooling
+        orig_sr = model_options.solve_range
+        current_weight = optimal_weight
         all_results = []
-        for i in range(n):
-            sol_file = parent / f"{stem}_pool{i}.sol"
-            if not sol_file.exists():
-                break
-            try:
-                r, w = self.process_solution_file(sol_file)
-                all_results.append((r, w))
-            except (AssertionError, ValueError):
+
+        while len(all_results) < n:
+            if orig_sr is not None and (
+                current_weight < orig_sr[0] or current_weight > orig_sr[1]
+            ):
                 break
 
-        # Fall back to the main solution file when no pool files exist
-        if not all_results and output_file_name.exists():
-            try:
-                r, w = self.process_solution_file(output_file_name)
-                all_results.append((r, w))
-            except (AssertionError, ValueError):
-                pass
+            remaining = n - len(all_results)
+
+            # Rebuild the model with sum_arr == current_weight
+            model_options.solve_range = (current_weight, current_weight)
+            cipher.model(model_options)
+            model_options.solve_range = orig_sr
+
+            command = [
+                "gurobi_cl",
+                f"ResultFile={output_file_name}",
+                f"LogFile={log_file_name}",
+                f"PoolSolutions={remaining}",
+                "PoolSearchMode=2",
+                "PoolGap=0",
+                f"SolFiles={pool_prefix}",
+                str(input_file_name),
+            ]
+            if time_limit is not None:
+                command.insert(2, f"TimeLimit={time_limit}")
+
+            self.status = SOLVING_STATUS.SUCCESS
+            with suppress_output():
+                process = subprocess.Popen(command)
+                errno = process.wait()
+
+            if errno != 0:
+                self.status = SOLVING_STATUS.ERROR
+
+            if log_file_name.exists():
+                with open(log_file_name, 'r') as file:
+                    content = file.read()
+                if re.search(self.timeout_string, content, re.MULTILINE):
+                    self.status = SOLVING_STATUS.TIMEOUT
+
+            # Collect pool solution files for this weight level
+            results_for_current_weight = []
+            for i in range(remaining):
+                sol_file = parent / f"{stem}_pool_{i}.sol"
+                if not sol_file.exists():
+                    break
+                try:
+                    rw = self.process_solution_file(sol_file)
+                    results_for_current_weight.append(rw)
+                except (AssertionError, ValueError):
+                    continue
+
+            # Fall back to the main solution file when no pool files exist
+            if results_for_current_weight == [] and output_file_name.exists():
+                try:
+                    rw = self.process_solution_file(output_file_name)
+                    results_for_current_weight.append(rw)
+                    break
+                except (AssertionError, ValueError):
+                    pass
+
+            all_results += results_for_current_weight
+
+            # If the pool returned fewer than asked, all solutions at this
+            # weight are exhausted – move to the next weight level
+            if len(results_for_current_weight) < remaining:
+                current_weight += 1
+            else:
+                break
 
         return all_results
 

--- a/src/civerly/solvers.py
+++ b/src/civerly/solvers.py
@@ -629,8 +629,8 @@ class GUROBI_CVL(MILP_SOLVER_CVL):
 
             remaining = n - len(all_results)
 
-            # Rebuild the model with sum_arr == current_weight
-            model_options.solve_range = (current_weight, current_weight)
+            # Rebuild the model with sum_arr <= current_weight
+            model_options.solve_range = (0, current_weight)
             cipher.model(model_options)
             model_options.solve_range = orig_sr
 
@@ -810,11 +810,6 @@ class SCIP_CVL(MILP_SOLVER_CVL):
         After each solve the solution is excluded (via ``cipher.exclude_solution``),
         the MILP model is regenerated (via ``cipher.model``), and the solver is invoked again.
 
-        When all solutions at the current optimal weight are exhausted, the
-        weight lower bound is increased by one and the search continues at the
-        next weight level until *n* solutions are found or no more solutions
-        exist within the allowed range.
-
         Returns a list of ``(results_dict, objective_value)`` pairs ordered
         from best to worst objective weight.
         """
@@ -975,10 +970,9 @@ class GLPK_CVL(MILP_SOLVER_CVL):
         Find up to *n* solutions using a by-hand blocking approach (GLPK does
         not support a solution pool natively).
 
-        Identical in structure to :meth:`civerly.solvers.SCIP_CVL.solve_multiple`:
-        when all solutions at the current optimal weight are exhausted, the
-        weight lower bound is increased by one and the search continues at the
-        next weight level.
+        Identical in structure to :meth:`civerly.solvers.SCIP_CVL.solve_multiple`.
+        Search for optimal solution, exclude it, and restart the solving process.
+        
         """
         input_file_name  = model_options.path / (cipher.name + ".mps")
         output_file_name = model_options.path / (cipher.name + ".sol")

--- a/src/civerly/solvers.py
+++ b/src/civerly/solvers.py
@@ -311,9 +311,7 @@ class SAT_SOLVER_CVL(SOLVER_CVL):
             return int(W_MIN)
         return float(W_MIN/10**pr)
 
-    def solve_multiple(self, input_file_name, output_file_name,
-                       model_options=None, n=1, cipher=None,
-                       time_limit=None):
+    def solve_multiple(self, model_options, cipher=None, time_limit=None):
         r"""
         Find up to *n* solutions ordered by weight (best first).
 
@@ -346,8 +344,12 @@ class SAT_SOLVER_CVL(SOLVER_CVL):
         Returns a list of ``(results_dict, objective_value)`` pairs ordered
         best to worst objective weight.
         """
+        input_file_name  = model_options.path / (cipher.name + ".cnf")
+        output_file_name = model_options.path / (cipher.name + ".sat")
         assert isinstance(input_file_name, Path)
         assert isinstance(output_file_name, Path)
+
+        n = model_options.number_of_solutions
 
         pr = model_options.sat_precision if model_options is not None else 0
         W_MAX_INT = (
@@ -587,9 +589,7 @@ class GUROBI_CVL(MILP_SOLVER_CVL):
         return _to_dict(results), objective_value
 
 
-    def solve_multiple(self, input_file_name, output_file_name,
-                       model_options=None, n=1, cipher=None,
-                       time_limit=None):
+    def solve_multiple(self, model_options, cipher=None, time_limit=None):
         r"""
         Find up to *n* solutions using Gurobi's solution pool with weight
         enforcement.
@@ -615,8 +615,12 @@ class GUROBI_CVL(MILP_SOLVER_CVL):
         Returns a list of ``(results_dict, objective_value)`` pairs ordered
         from best to worst objective (at most *n* entries).
         """
+        input_file_name  = model_options.path / (cipher.name + ".mps")
+        output_file_name = model_options.path / (cipher.name + ".sol")
         assert isinstance(input_file_name, Path)
         assert isinstance(output_file_name, Path)
+
+        n = model_options.number_of_solutions
 
         parent = output_file_name.parent
         stem = output_file_name.stem
@@ -624,7 +628,6 @@ class GUROBI_CVL(MILP_SOLVER_CVL):
         pool_prefix = parent / f"{stem}_pool"
 
         # Step 1: find the optimal weight via a standard solve
-        self.status = SOLVING_STATUS.SUCCESS
         self.invoke(input_file_name, output_file_name,
                     log_file_name=log_file_name, time_limit=time_limit)
         first_result, optimal_weight = self.process_solution_file(
@@ -665,7 +668,6 @@ class GUROBI_CVL(MILP_SOLVER_CVL):
             if time_limit is not None:
                 command.insert(2, f"TimeLimit={time_limit}")
 
-            self.status = SOLVING_STATUS.SUCCESS
             with suppress_output():
                 process = subprocess.Popen(command)
                 errno = process.wait()
@@ -822,14 +824,12 @@ class SCIP_CVL(MILP_SOLVER_CVL):
 
         return _to_dict(results), objective_value
 
-    def solve_multiple(self, input_file_name, output_file_name,
-                       model_options=None, n=1, cipher=None,
-                       time_limit=None):
+    def solve_multiple(self, model_options, cipher=None, time_limit=None):
         r"""
         Find up to *n* solutions using a by-hand blocking approach.
 
         After each solve the solution is converted to a no-good linear
-        constraint (via ``cipher._exclude_solution``), the MILP model is
+        constraint (via ``cipher._exclude_solution_milp``), the MILP model is
         regenerated (via ``cipher.model``), and SCIP is invoked again.
 
         When all solutions at the current optimal weight are exhausted, the
@@ -840,8 +840,16 @@ class SCIP_CVL(MILP_SOLVER_CVL):
         Returns a list of ``(results_dict, objective_value)`` pairs ordered
         from best to worst objective weight.
         """
+        input_file_name  = model_options.path / (cipher.name + ".mps")
+        output_file_name = model_options.path / (cipher.name + ".sol")
         assert isinstance(input_file_name, Path)
         assert isinstance(output_file_name, Path)
+
+        n = model_options.number_of_solutions
+
+        # disable overwrite
+        tmp_overwrite = model_options.overwrite
+        model_options.overwrite = False
 
         all_results = []
         current_weight = None  # weight of the most recently found solution
@@ -855,8 +863,6 @@ class SCIP_CVL(MILP_SOLVER_CVL):
                     output_file_name.parent
                     / f"{output_file_name.stem}_{solution_index}{output_file_name.suffix}"
                 )
-
-            self.status = SOLVING_STATUS.SUCCESS
             self.invoke(input_file_name, sol_file, time_limit=time_limit)
             try:
                 r, w = self.process_solution_file(sol_file)
@@ -889,9 +895,11 @@ class SCIP_CVL(MILP_SOLVER_CVL):
             solution_index += 1
 
             if solution_index < n and cipher is not None:
-                cipher._exclude_solution(r)
+                cipher._exclude_solution_milp(r)
                 cipher.model(model_options)
 
+        # set overwrite back to old value
+        model_options.overwrite = tmp_overwrite
         return all_results
 
 
@@ -1016,9 +1024,7 @@ class GLPK_CVL(MILP_SOLVER_CVL):
             results[name] = value
         return _to_dict(results), objective_value
 
-    def solve_multiple(self, input_file_name, output_file_name,
-                       model_options=None, n=1, cipher=None,
-                       time_limit=None):
+    def solve_multiple(self, model_options, cipher=None, time_limit=None):
         r"""
         Find up to *n* solutions using a by-hand blocking approach (GLPK does
         not support a solution pool natively).
@@ -1028,8 +1034,16 @@ class GLPK_CVL(MILP_SOLVER_CVL):
         weight lower bound is increased by one and the search continues at the
         next weight level.
         """
+        input_file_name  = model_options.path / (cipher.name + ".mps")
+        output_file_name = model_options.path / (cipher.name + ".sol")
         assert isinstance(input_file_name, Path)
         assert isinstance(output_file_name, Path)
+
+        n = model_options.number_of_solutions
+
+        # disable overwrite
+        tmp_overwrite = model_options.overwrite
+        model_options.overwrite = False
 
         all_results = []
         current_weight = None  # weight of the most recently found solution
@@ -1044,7 +1058,6 @@ class GLPK_CVL(MILP_SOLVER_CVL):
                     / f"{output_file_name.stem}_{solution_index}{output_file_name.suffix}"
                 )
 
-            self.status = SOLVING_STATUS.SUCCESS
             self.invoke(input_file_name, sol_file, time_limit=time_limit)
             try:
                 r, w = self.process_solution_file(sol_file)
@@ -1077,9 +1090,11 @@ class GLPK_CVL(MILP_SOLVER_CVL):
             solution_index += 1
 
             if solution_index < n and cipher is not None:
-                cipher._exclude_solution(r)
+                cipher._exclude_solution_milp(r)
                 cipher.model(model_options)
 
+        # set overwrite back to old value
+        model_options.overwrite = tmp_overwrite
         return all_results
 
 
@@ -1304,9 +1319,7 @@ class NO_MILP_SOLVER_CVL(MILP_SOLVER_CVL):
     def solve(self, input_file_name, output_file_name, time_limit=None):
         raise NoSolverWarning()
 
-    def solve_multiple(self, input_file_name, output_file_name,
-                       model_options=None, n=1, cipher=None,
-                       time_limit=None):
+    def solve_multiple(self, model_options, cipher=None, time_limit=None):
         raise NoSolverWarning()
 
     def process_solution_file(self, solution_file_name):
@@ -1412,9 +1425,7 @@ class NO_SAT_SOLVER_CVL(SAT_SOLVER_CVL):
         else:
             raise ValueError("Unknown solution format")
 
-    def solve_multiple(self, input_file_name, output_file_name,
-                       model_options=None, n=1, cipher=None,
-                       time_limit=None):
+    def solve_multiple(self, model_options, cipher=None, time_limit=None):
         raise NoSolverWarning()
 
 

--- a/src/civerly/trail.py
+++ b/src/civerly/trail.py
@@ -58,7 +58,7 @@ class TrailNode:
             ....:    model_options=model_options,
             ....:    time_limit=None)
             ...
-            sage: results, weight = cipher.read_results(model_options)
+            sage: results_and_weight = cipher.read_results(model_options)
             sage: cipher.results == []
             True
             
@@ -66,9 +66,9 @@ class TrailNode:
             
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.trail import TrailNode
-            sage: node = TrailNode(cipher, model_options, results)
+            sage: node = TrailNode(cipher, model_options, results_and_weight)
             sage: cipher.results[0]
-            {'in': [...], 'out': [...]}
+            {'in': [...], 'out': [...], 'weight': ...}
             sage: import shutil 
             sage: shutil.rmtree(tmpdir)
         
@@ -310,7 +310,6 @@ class TrailNode:
 
         TESTS:
 
-            sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.trail import TrailNode
             sage: from civerly.cipher_implementations.speck import SPECK_CVL
             sage: from civerly.model_options import * 
@@ -325,10 +324,11 @@ class TrailNode:
             ....:     sat_solver=CRYPTOMINISAT_CVL(),
             ....:     logic_minimizer=ESPRESSO_CVL(),
             ....:     path=Path(tmpdir))
-            sage: cipher.analyse(model_options)
+            sage: cipher.analyse(model_options) # optional - cryptominisat espresso
             ...
-            sage: results, weight = cipher.read_results(model_options)
-            sage: TrailNode(cipher, model_options, results)
+            sage: # optional - cryptominisat espresso
+            sage: results_and_weight = cipher.read_results(model_options)
+            sage: TrailNode(cipher, model_options, results_and_weight)
             -> speck : ... -> ...
                 -> speck_round : ... -> ...
                 -> speck_round : ... -> ...
@@ -382,6 +382,7 @@ class TrailNode:
 
     Analyse the cipher:
 
+            sage: # optional - scip
             sage: from civerly.model_options import *
             sage: from pathlib import Path
             sage: import tempfile
@@ -393,10 +394,10 @@ class TrailNode:
             ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND,
             ....:     milp_solver=SCIP_CVL(),
             ....:     path=Path(tmpdir))
-            sage: cipher.analyse(model_options) # optional - scip
+            sage: cipher.analyse(model_options)
             206 variables and 1711 constraints were written to ...
             0
-            sage: cipher.get_trail(model_options) # optional - scip
+            sage: cipher.get_trail(model_options)
             -> cipher : 00... -> 00...
                 -> sub-cipher-6-bit : 00 -> 00
                     -> sub-sub-cipher-3-bit : 0 -> 0

--- a/src/civerly/trail.py
+++ b/src/civerly/trail.py
@@ -8,7 +8,7 @@ from civerly.model_options import OPTIMIZATION, GRANULARITY
 from civerly.util import _between_brackets
 
 class TrailNode:
-    def __init__(self, cipher_instance, model_options, results,
+    def __init__(self, cipher_instance, model_options, results_and_weight,
                  _parent_depth=None) -> None:
         r"""
         Initialize the recursive TrailNode structure, which contains the results 
@@ -84,6 +84,9 @@ class TrailNode:
         self.name = cipher_instance.name
         self.input_length = cipher_instance.input_length
         self.output_length = cipher_instance.output_length
+
+        cipher_instance.trail_nodes.append(self)
+        results, self.weight = results_and_weight
 
         # obtain dictionaries
         opt_to_attr = {OPTIMIZATION.MILP: 'dictionaries_milp', OPTIMIZATION.SAT: 'dictionaries_sat'}
@@ -209,10 +212,12 @@ class TrailNode:
         self.input  = bits_out[0]
         self.output = bits_out[-1]
 
-        # Set .result on this cipher and each of its direct nodes
-        self.cipher_instance.result = {"in": self.input, "out": self.output}
-        for comp_num, comp in enumerate(nodes):
-            comp.result = _node_results[comp_num]
+        # Set .results on this cipher and each of its direct nodes
+        self.cipher_instance.results.append(
+            {"in": self.input, "out": self.output, "weight": self.weight}
+        )
+        # for comp_num, comp in enumerate(nodes):
+        #     comp.results.append(_node_results[comp_num])
         ################################################
 
         # Iterate through each subcipher
@@ -231,6 +236,19 @@ class TrailNode:
                     tr_ind = int(tr_rest.rstrip(']'))
                     sub_results.setdefault(tr_name, {})[tr_ind] = \
                         solution_bit_value
+                # Compute the weight of this subcipher's trail from the
+                # parent's objective contributions for comp_num.
+                prefix = f"X{comp_num}["
+                if hasattr(self.cipher_instance, 'sum_arr_milp'):
+                    sub_weight = sum(
+                        -factor * results.get(f"X{comp_num}", {}).get(
+                            int(v[len(prefix):-1]), 0
+                        )
+                        for factor, v in self.cipher_instance.sum_arr_milp
+                        if v.startswith(prefix)
+                    )
+                else:
+                    sub_weight = 0
             else:  # SAT
                 sub_results = {}
                 for s, solution_bit_value in results.items():
@@ -239,12 +257,24 @@ class TrailNode:
                         # dictionaries
                         sub_results[dictionaries[comp_num][s]] = \
                             solution_bit_value
+                # Compute the weight of this subcipher's trail from the
+                # parent's objective contributions for comp_num.
+                if hasattr(self.cipher_instance, 'sum_arr_sat'):
+                    comp_vars = set(dictionaries[comp_num].keys())
+                    pr = model_options.sat_precision
+                    sub_weight = sum(
+                        factor * results.get(sat_var, 0)
+                        for factor, sat_var in self.cipher_instance.sum_arr_sat
+                        if sat_var in comp_vars
+                    ) / (10 ** pr)
+                else:
+                    sub_weight = 0
             # recurse
             if not isinstance(comp, Component):
                 self.children.append(TrailNode(
                     comp,
                     model_options=model_options,
-                    results=sub_results,
+                    results_and_weight=(sub_results, sub_weight),
                     _parent_depth=depths[comp_num]
                 ))
 

--- a/src/civerly/trail.py
+++ b/src/civerly/trail.py
@@ -241,9 +241,9 @@ class TrailNode:
                 prefix = f"X{comp_num}["
                 if hasattr(self.cipher_instance, 'sum_arr_milp'):
                     sub_weight = sum(
-                        -factor * results.get(f"X{comp_num}", {}).get(
+                        -factor * int(results.get(f"X{comp_num}", {}).get(
                             int(v[len(prefix):-1]), 0
-                        )
+                        ))
                         for factor, v in self.cipher_instance.sum_arr_milp
                         if v.startswith(prefix)
                     )

--- a/src/civerly/trail.py
+++ b/src/civerly/trail.py
@@ -414,6 +414,46 @@ class TrailNode:
                 string += "\n" + child.__repr__(_depth+1)
         return string
 
+    def __eq__(self, other) -> bool:
+        """
+        Compare self with other by checking whether all intermediate states
+        have the same values.
+
+        TESTS:
+
+            sage: # optional - cryptominisat, espresso
+            sage: from civerly.cipher_implementations.toy_ciphers.toy7 \
+            ....:   import Toy7
+            sage: from civerly.model_options import *
+            sage: import tempfile
+            sage: with tempfile.TemporaryDirectory() as tmpdir:
+            ....:   cipher = Toy7()
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.SAT,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:       sat_solver=CRYPTOMINISAT_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       number_of_solutions=2,
+            ....:       path=Path(tmpdir))
+            ....:   cipher.analyse(model_options=model_options)
+            ....:   t1, t2 = cipher.get_trail(model_options)
+            ...
+            [3, 3]
+            sage: t1 == t2
+            False
+
+            
+        """
+        return isinstance(other, TrailNode) and \
+            self.input == other.input and \
+            self.output == other.output and \
+            all([
+                c1 == c2 for c1, c2 in zip(self.children, other.children)
+            ])
+
     def to_latex(self, model_options) -> str:
         string = self.cipher_instance._latex_section(self, model_options)
         for child in self.children:

--- a/src/civerly/trail.py
+++ b/src/civerly/trail.py
@@ -14,7 +14,7 @@ class TrailNode:
         Initialize the recursive TrailNode structure, which contains the results 
         of the last analysis with CiVerLy.
         Called in :meth:`Cipher.analysis` and automatically adds
-        the `.result` attribute to `cipher_instance` and its subciphers.
+        the `.results` attribute to `cipher_instance` and its subciphers.
 
         INPUT:
 
@@ -59,7 +59,7 @@ class TrailNode:
             ....:    time_limit=None)
             ...
             sage: results, weight = cipher.read_results(model_options)
-            sage: cipher.result is None
+            sage: cipher.results == []
             True
             
         Initialize TrailNode:
@@ -67,7 +67,7 @@ class TrailNode:
             sage: # optional - cryptominisat # optional - espresso
             sage: from civerly.trail import TrailNode
             sage: node = TrailNode(cipher, model_options, results)
-            sage: cipher.result
+            sage: cipher.results[0]
             {'in': [...], 'out': [...]}
             sage: import shutil 
             sage: shutil.rmtree(tmpdir)

--- a/src/civerly/util.py
+++ b/src/civerly/util.py
@@ -712,8 +712,8 @@ def _to_dict(flat_results):
     return nested
 
 
-def translate_var(cipher, node, local_var):                                                                                                        
-    r"""                                                                                                                                    
+def translate_var(cipher, node, local_var):
+    r"""
     Translate a component-local model variable into the corresponding variable
     in the cipher's master model (``cipher.milp`` or ``cipher.sat``).
 
@@ -774,14 +774,6 @@ def translate_var(cipher, node, local_var):
         True
         sage: import shutil
         sage: shutil.rmtree(tmpdir)
-
-        
-
-    For SAT, the returned value is the master SAT variable integer, which can
-    be used directly in ``cipher.sat.add_clause``::
-
-        v = translate_var(cipher, cipher.nodes[1], cipher.nodes[1].SAT_IN[4])
-        cipher.sat.add_clause((-v, ))
 
     """                                                                                                                                     
     node_idx = node if isinstance(node, (int, Integer)) else cipher.nodes.index(node)                                                       

--- a/src/civerly/util.py
+++ b/src/civerly/util.py
@@ -712,6 +712,100 @@ def _to_dict(flat_results):
     return nested
 
 
+def translate_var(cipher, node, local_var):                                                                                                        
+    r"""                                                                                                                                    
+    Translate a component-local model variable into the corresponding variable
+    in the cipher's master model (``cipher.milp`` or ``cipher.sat``).
+
+    Variables on ``cipher.nodes[k]`` (``MILP_IN``, ``MILP_OUT``, ``SAT_IN``,
+    ``SAT_OUT``) are local to each component's sub-model and cannot be used
+    directly in the master model.  This function performs the remapping.
+
+    INPUT:
+
+        - ``cipher`` -- a modeled :class:`civerly.cipher.Cipher` or
+          :class:`civerly.sboxcipher.SBoxCipher`; must have been modeled
+          (i.e., ``cipher.milp`` / ``cipher.sat`` must exist)
+
+        - ``node`` -- the component owning the variable: either the component
+          instance itself or its integer index in ``cipher.nodes``
+
+        - ``local_var`` -- the component-local variable to translate:
+          an integer SAT variable (from ``SAT_IN`` / ``SAT_OUT``) or a
+          SageMath MILP variable (from ``MILP_IN`` / ``MILP_OUT``)
+
+    OUTPUT:
+
+        The corresponding variable in the master model: an integer for SAT,
+        or a SageMath MILP variable for MILP.
+
+    TESTS:
+        
+        sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
+        sage: from civerly.model_options import *
+        sage: import tempfile
+        sage: cipher = SKINNY_CVL(64, 64, R=3)
+        sage: with tempfile.TemporaryDirectory(delete=False) as tmpdir:
+        ....:   model_options = MODEL_OPTIONS(
+        ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+        ....:     optimization=OPTIMIZATION.MILP,
+        ....:     granularity=GRANULARITY.BITWISE,
+        ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+        ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+        ....:     milp_solver=SCIP_CVL(),
+        ....:     logic_minimizer=ESPRESSO_CVL(),
+        ....:     path=Path(tmpdir))
+        sage: # optional - scip
+        sage: cipher.analyse(model_options)
+        ...
+        10
+        sage: from civerly.util import translate_var
+        sage: first_word = [
+        ....:   translate_var(cipher, 0, cipher.nodes[0].MILP_IN[i])
+        ....: for i in range(4)]
+        sage: for v in first_word: cipher.milp.add_constraint(v == 1)
+        sage: model_options.overwrite = False
+        sage: cipher.analyse(model_options)
+        Using existing MILP model, make sure it is up to date!
+        ...
+        11
+        sage: trail = cipher.get_trail(model_options)
+        sage: trail.input[:4] == [1]*4
+        True
+        sage: import shutil
+        sage: shutil.rmtree(tmpdir)
+
+        
+
+    For SAT, the returned value is the master SAT variable integer, which can
+    be used directly in ``cipher.sat.add_clause``::
+
+        v = translate_var(cipher, cipher.nodes[1], cipher.nodes[1].SAT_IN[4])
+        cipher.sat.add_clause((-v, ))
+
+    """                                                                                                                                     
+    node_idx = node if isinstance(node, (int, Integer)) else cipher.nodes.index(node)                                                       
+
+    if isinstance(local_var, (int, Integer)):                                                                                               
+        # SAT case: local_var is a component-local SAT variable number.
+        sign = (-1)**(local_var < 0)
+        return sign * cipher.inv_dictionaries_sat[node_idx][abs(local_var)]
+    else:
+        # MILP case: local_var is a SageMath LinearFunction for one variable.
+        # .dict() maps backend variable index -> coefficient; for a pure
+        # variable there is exactly one entry with coefficient 1, and the
+        # backend index is the same key used by translate_milp_constraint to
+        # populate cipher.X[node_idx].
+        coeff_dict = local_var.dict()
+        if len(coeff_dict) != 1:
+            raise ValueError(
+                "translate_var expects a single MILP variable, "
+                f"not a linear combination ({local_var!r})"
+            )
+        backend_idx = next(iter(coeff_dict))
+        return cipher.X[node_idx][backend_idx]
+
+
 @contextlib.contextmanager
 def suppress_output():
     r"""

--- a/src/civerly/util.py
+++ b/src/civerly/util.py
@@ -43,9 +43,10 @@ TESTS:
 import warnings
 
 import contextlib
+import random
+import zlib
 import sys
 import os
-import zlib
 
 from sage.rings.integer_ring import ZZ
 from sage.rings.integer import Integer
@@ -712,98 +713,75 @@ def _to_dict(flat_results):
     return nested
 
 
-def translate_var(cipher, node, local_var):
-    r"""
-    Translate a component-local model variable into the corresponding variable
-    in the cipher's master model (``cipher.milp`` or ``cipher.sat``).
+def _find_path(cipher, node, path=()):
+    """
+    Helper function for ``translate_var``. Return the recursion path
+    taken to get to ``node``.
 
-    Variables on ``cipher.nodes[k]`` (``MILP_IN``, ``MILP_OUT``, ``SAT_IN``,
-    ``SAT_OUT``) are local to each component's sub-model and cannot be used
-    directly in the master model.  This function performs the remapping.
-
-    INPUT:
-
-        - ``cipher`` -- a modeled :class:`civerly.cipher.Cipher` or
-          :class:`civerly.sboxcipher.SBoxCipher`; must have been modeled
-          (i.e., ``cipher.milp`` / ``cipher.sat`` must exist)
-
-        - ``node`` -- the component owning the variable: either the component
-          instance itself or its integer index in ``cipher.nodes``
-
-        - ``local_var`` -- the component-local variable to translate:
-          an integer SAT variable (from ``SAT_IN`` / ``SAT_OUT``) or a
-          SageMath MILP variable (from ``MILP_IN`` / ``MILP_OUT``)
-
-    OUTPUT:
-
-        The corresponding variable in the master model: an integer for SAT,
-        or a SageMath MILP variable for MILP.
-
-    TESTS:
+        sage: from civerly.util import _find_path
+        sage: from civerly.cipher_implementations.ascon import ASCON_CVL
+        sage: ascon = ASCON_CVL(3)
+        sage: node = ascon.nodes[3].nodes[2].nodes[1]
+        sage: _find_path(ascon, node)
+        (3, 2, 1)
         
-        sage: from civerly.cipher_implementations.skinny import SKINNY_CVL
+    """
+    from civerly.cipher import Cipher
+    if id(cipher) == id(node):
+        return path
+    if not isinstance(cipher, Cipher):
+        return None
+    for i in range(len(cipher.nodes)):
+        sub_path = _find_path(cipher.nodes[i], node, path + (i, ))
+        if sub_path is not None:
+            return sub_path
+
+def translate_var(cipher, node, local_var):
+    """
+
+    TESTS::
+        
+        sage: from civerly.cipher_implementations.craft import CRAFT_CVL
         sage: from civerly.model_options import *
         sage: import tempfile
-        sage: cipher = SKINNY_CVL(64, 64, R=3)
-        sage: with tempfile.TemporaryDirectory(delete=False) as tmpdir:
+        sage: craft = CRAFT_CVL(3)
+        sage: # optional - espresso
+        sage: with tempfile.TemporaryDirectory() as tmpdir:
         ....:   model_options = MODEL_OPTIONS(
         ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
-        ....:     optimization=OPTIMIZATION.MILP,
+        ....:     optimization=OPTIMIZATION.SAT,
         ....:     granularity=GRANULARITY.BITWISE,
-        ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
         ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
-        ....:     milp_solver=SCIP_CVL(),
+        ....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+        ....:     sat_solver=CADICAL_CVL(),
         ....:     logic_minimizer=ESPRESSO_CVL(),
         ....:     path=Path(tmpdir))
-        sage: # optional - scip
-        sage: cipher.analyse(model_options)
-        ...
-        10
+        ....:   craft.model(model_options)
+        7488 variables and 17201 clauses were written to ...
         sage: from civerly.util import translate_var
-        sage: first_word = [
-        ....:   translate_var(cipher, 0, cipher.nodes[0].MILP_IN[i])
-        ....: for i in range(4)]
-        sage: for v in first_word: cipher.milp.add_constraint(v == 1)
-        sage: model_options.overwrite = False
-        sage: cipher.analyse(model_options)
-        Using existing MILP model, make sure it is up to date!
-        ...
-        11
-        sage: trail = cipher.get_trail(model_options)
-        sage: trail.input[:4] == [1]*4
-        True
-        sage: first_sbox_word = [
-        ....:   translate_var(
-        ....:       cipher, 0, cipher.nodes[1].nodes[1].nodes[j + 1].MILP_IN[i]
-        ....:   ) for i in range(4) for j in range(16)
-        ....: ]
-        sage: for v in first_sbox_word: cipher.milp.add_constraint(v == 1)
-        sage: model_options.overwrite = False
-        sage: cipher.analyse(model_options)
-        sage: import shutil
-        sage: shutil.rmtree(tmpdir)
+        sage: node = craft.nodes[1].nodes[2].nodes[1]
+        sage: translate_var(craft, node, node.SAT_IN[2])
+        643
 
-    """                                                                                                                                     
-    node_idx = node if isinstance(node, (int, Integer)) else cipher.nodes.index(node)                                                       
 
-    if isinstance(local_var, (int, Integer)):                                                                                               
-        # SAT case: local_var is a component-local SAT variable number.
-        sign = (-1)**(local_var < 0)
-        return sign * cipher.inv_dictionaries_sat[node_idx][abs(local_var)]
-    else:
-        # MILP case: local_var is a SageMath LinearFunction for one variable.
-        # .dict() maps backend variable index -> coefficient; for a pure
-        # variable there is exactly one entry with coefficient 1, and the
-        # backend index is the same key used by translate_milp_constraint to
-        # populate cipher.X[node_idx].
-        coeff_dict = local_var.dict()
-        if len(coeff_dict) != 1:
-            raise ValueError(
-                "translate_var expects a single MILP variable, "
-                f"not a linear combination ({local_var!r})"
-            )
-        backend_idx = next(iter(coeff_dict))
-        return cipher.X[node_idx][backend_idx]
+    """
+    index_path = _find_path(cipher, node)
+    var = local_var
+    # go backwards through the recursion tree
+    for depth in range(1, len(index_path)):
+        parent = cipher
+        for index in index_path[:len(index_path) - depth]:
+            parent = parent.nodes[index]
+        index = index_path[-depth]
+        # distinguish between SAT and MILP variable
+        if isinstance(local_var, (int, Integer)):
+            var = parent.inv_dictionaries_sat[index][var]
+        else:
+            var = parent.inv_dictionaries_milp[index][var]
+
+    return var
+
+
 
 
 @contextlib.contextmanager

--- a/src/civerly/util.py
+++ b/src/civerly/util.py
@@ -772,6 +772,14 @@ def translate_var(cipher, node, local_var):
         sage: trail = cipher.get_trail(model_options)
         sage: trail.input[:4] == [1]*4
         True
+        sage: first_sbox_word = [
+        ....:   translate_var(
+        ....:       cipher, 0, cipher.nodes[1].nodes[1].nodes[j + 1].MILP_IN[i]
+        ....:   ) for i in range(4) for j in range(16)
+        ....: ]
+        sage: for v in first_sbox_word: cipher.milp.add_constraint(v == 1)
+        sage: model_options.overwrite = False
+        sage: cipher.analyse(model_options)
         sage: import shutil
         sage: shutil.rmtree(tmpdir)
 

--- a/src/civerly/wordbasedcipher.py
+++ b/src/civerly/wordbasedcipher.py
@@ -52,14 +52,13 @@ class WordBasedCipher(Cipher):
                 Sub ciphers:
 
         """
+        self.__wordsize = wordsize
+        self._wrd = wordsize
         super().__init__(
             input_num_words * wordsize,
             output_num_words * wordsize,
             name
         )
-        self.__wordsize = wordsize
-        self._wrd = wordsize
-        self.IN.wordsize = wordsize
 
     @property
     def wordsize(self):


### PR DESCRIPTION
### Changes for the user:

- When setting the model option `number_of_solutions=N`, it is possible to receive the N best solutions. For N = 1, the workflow simplifies to the old workflow. Internally, a new method `Solver.solve_multiple` is used which iteratively solves the model, excludes the solution, reruns the solving, ... until N solutions are found. For Gurobi, the pooling-feature is used which does not require invoking the solver more than once.

- It is possible to directly access the models via `Cipher.sat` and `Cipher.milp`. This allows to customize the models, e.g. by restricting the trail search to specific activity patterns. In particular, **this opens up the possibility to model more advanced attacks** such as zero-correlation and impossible differential attacks.

- There is a new method `translate_var` in util.py in order to address the correct MILP/SAT variables more easily (see below)

- New method `Cipher.exclude_solution(model_options, results)` which imposes a new constraint onto `Cipher.{milp, sat}`, excluding the solution described in `results`.

```
sage: from civerly.cipher_implementations.present import PRESENT_CVL
sage: from civerly.model_options import *
sage: import tempfile
sage: with tempfile.TemporaryDirectory(delete=False) as tmpdir: 
....:   present_cipher = PRESENT_CVL(R=3)
....:   model_options = MODEL_OPTIONS(
....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
....:     optimization=OPTIMIZATION.MILP,
....:     granularity=GRANULARITY.BITWISE,
....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
....:     sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
....:     milp_solver=SCIP_CVL(),
....:     logic_minimizer=ESPRESSO_CVL(),
....:     path=Path(tmpdir))
sage: present_cipher.analyse(model_options)
4112 variables and 6593 constraints were written to '[...]/PRESENT.mps'
8
```
Set all input bits to active and analyse:
```
sage: from civerly.util import translate_var
sage: for i in range(64):
....:     var = translate_var(present_cipher, present_cipher.nodes[0], present_cipher.nodes[0].MILP_OUT[i])
....:     present_cipher.milp.add_constraint(var == 1)
sage: present_cipher.analyse(model_options)
Using existing MILP model, make sure it is up to date!
4112 variables and 6657 constraints were written to '[...]/PRESENT.mps'
42
sage: present_cipher.get_trail(model_options)
-> PRESENT : ffffffffffffffff -> ...
	-> present_round : ffffffffffffffff -> ...
		-> SBoxLayer : ffffffffffffffff -> ...
        ...
```
