### PR TITLE
Fix export load

### DIFF
--- a/docs/source/user_manual/export_trail.rst
+++ b/docs/source/user_manual/export_trail.rst
@@ -14,7 +14,9 @@ See the following example to understand how to export and load Cipher objects.
     sage: # First, analyse some cipher
     sage: from civerly.cipher_implementations.present import PRESENT_CVL
     sage: from civerly.model_options import *
+    sage: import tempfile
     sage: cipher = PRESENT_CVL(4)
+    sage: tmpdir = tempfile.mkdtemp()
     sage: model_options = MODEL_OPTIONS(
     ....:     optimization=OPTIMIZATION.MILP,
     ....:     cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
@@ -23,25 +25,26 @@ See the following example to understand how to export and load Cipher objects.
     ....:     milp_solver=SCIP_CVL(),
     ....:     linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
     ....:     logic_minimizer=ESPRESSO_CVL(),
-    ....:     path=Path("export-example")
+    ....:     path=Path(tmpdir),
     ....: )
     sage: cipher.analyse(model_options)
-    5312 variables and 8641 constraints were written to 'export-example/PRESENT.mps'
+    5312 variables and 8641 constraints were written to ...
     12
     sage: input_difference = cipher.results[0]['in']
     sage: output_difference = cipher.results[0]['out']
     sage: # Export the cipher together with its results
-    sage: import tempfile
-    sage: f = tempfile.NamedTemporaryFile(suffix='.json', delete=False)
-    sage: tmpfile_name = f.name
-    sage: cipher.export(tmpfile_name)
+    sage: cipher.export(model_options.path)
+    Writing problem data to...
+    31602 records were written
     Object 'PRESENT' has been exported to ...
     sage: # Load the cipher from scratch
-    sage: loaded = cipher.load(tmpfile_name)
+    sage: loaded = cipher.load(model_options.path)
     sage: # The results are still the same
     sage: loaded.results[0]['in'] == input_difference
     True
     sage: loaded.results[0]['out'] == output_difference
     True
+    sage: import shutil
+    sage: shutil.rmtree(tmpdir)
 
 

--- a/docs/source/user_manual/export_trail.rst
+++ b/docs/source/user_manual/export_trail.rst
@@ -33,16 +33,20 @@ See the following example to understand how to export and load Cipher objects.
     sage: input_difference = cipher.results[0]['in']
     sage: output_difference = cipher.results[0]['out']
     sage: # Export the cipher together with its results
-    sage: cipher.export(model_options.path)
+    sage: export_file = model_options.path / f"{cipher.name}.json"
+    sage: cipher.export(export_file)
     Writing problem data to...
     31602 records were written
     Object 'PRESENT' has been exported to ...
     sage: # Load the cipher from scratch
-    sage: loaded = cipher.load(model_options.path)
+    sage: loaded = cipher.load(export_file)
     sage: # The results are still the same
     sage: loaded.results[0]['in'] == input_difference
     True
     sage: loaded.results[0]['out'] == output_difference
+    True
+    sage: # Overall, the ciphers are entirely the same
+    sage: sorted(loaded.__dict__) == sorted(cipher.__dict__)
     True
     sage: import shutil
     sage: shutil.rmtree(tmpdir)

--- a/src/civerly/aeslike.py
+++ b/src/civerly/aeslike.py
@@ -156,4 +156,12 @@ class AESlike(WordSBoxCipher):
 
     @classmethod
     def _init_from_dict(cls, d):
+        """
+        Used in :meth:`self.load` in order to build this object from the loaded `.json` file.
+        """
+        if "rows" not in d.keys() or "cols" not in d.keys():
+            raise TypeError(
+                "The json dictionary does not contain the attribute 'wordsize', "
+                "meaning that the exported cipher was not a subclass of AESlike."
+            )
         return cls(d["wordsize"], d["rows"], d["cols"], name=d["name"])

--- a/src/civerly/aeslike.py
+++ b/src/civerly/aeslike.py
@@ -161,7 +161,7 @@ class AESlike(WordSBoxCipher):
         """
         if "rows" not in d.keys() or "cols" not in d.keys():
             raise TypeError(
-                "The json dictionary does not contain the attribute 'wordsize', "
+                "The json dictionary does not contain the attributes 'rows' and'cols', "
                 "meaning that the exported cipher was not a subclass of AESlike."
             )
         return cls(d["wordsize"], d["rows"], d["cols"], name=d["name"])

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -1863,7 +1863,7 @@ class Cipher:
             "inv_dictionaries_sat": getattr(self, "inv_dictionaries_sat", None),
         }
 
-    def export(self, path):
+    def export(self, file):
         r"""
         Write ``self`` to a directory at ``path``.
 
@@ -1880,7 +1880,7 @@ class Cipher:
 
         INPUT:
 
-            - ``path`` -- string or path-like; Destination directory path.
+            - ``file`` -- string or path; Specifies file to be written to.
 
         EXAMPLES::
 
@@ -1899,13 +1899,14 @@ class Cipher:
             sage: cipher.add_output([(node0, (i, i)) for i in range(3)])
             sage: cipher.add_output([(node1, (i, i + 3)) for i in range(3)])
             sage: cipher.add_output([(node2, (i, i + 6)) for i in range(3)])
+
+        Before analysis, ``results`` is ``[]`` for both ``cipher`` and ``loaded``::
+
             sage: tmp = tempfile.mkdtemp()
-
-        Before analysis, ``results`` is ``[]`` and round-trips as such::
-
-            sage: cipher.export(tmp)
+            sage: export_file = Path(tmp) / f"{cipher.name}.json"
+            sage: cipher.export(export_file)
             Object 'test' has been exported to ...
-            sage: loaded = Cipher.load(tmp)
+            sage: loaded = Cipher.load(export_file)
             sage: cipher == loaded and loaded.results == []
             True
 
@@ -1925,45 +1926,54 @@ class Cipher:
             sage: cipher.analyse(model_options)
             ...
             2
-            sage: cipher.export(tmp)
+            sage: cipher.export(export_file)
             Object 'test' has been exported to ...
-            sage: loaded = Cipher.load(tmp)
-            sage: import shutil; shutil.rmtree(tmp)
+            sage: loaded = Cipher.load(export_file)
+            sage: import shutil
+            sage: shutil.rmtree(export_file.parent)
             sage: cipher == loaded and loaded.results == cipher.results
             True
 
         Again with a different cipher type::
 
             sage: import tempfile
+            sage: from pathlib import Path
             sage: from civerly.cipher import Cipher
             sage: from civerly.cipher_implementations.aes import AES_CVL
             sage: aes = AES_CVL(4)
             sage: tmp = tempfile.mkdtemp()
-            sage: aes.export(tmp)
+            sage: export_file = Path(tmp) / f"{aes.name}.json"
+            sage: aes.export(export_file)
             Object 'AES' has been exported to ...
-            sage: loaded = Cipher.load(tmp)
-            sage: import shutil; shutil.rmtree(tmp)
+            sage: loaded = Cipher.load(export_file)
+            sage: import shutil
+            sage: shutil.rmtree(tmp)
             sage: aes == loaded
             True
 
         """
-        export_dir = Path(path)
-        if not export_dir.exists():
-            export_dir.mkdir(parents=True, exist_ok=True)
+        json_file_name = Path(file)
+        assert json_file_name.suffix == ".json", (
+            f"File suffix must be '.json', not {json_file_name.suffix}!"
+        )
+        if not json_file_name.parent.exists():
+            json_file_name.parent.mkdir(parents=True, exist_ok=True)
 
         # Write JSON bundle (everything that is plain-Python serialisable)
-        with open(export_dir / "cipher.json", "w") as f:
+        with open(json_file_name, "w") as f:
             json.dump(self._to_dict(), f, default=lambda obj: int(obj))
 
         # Write MILP model if present
         if self.milp is not None:
-            self.milp.write_mps(str(export_dir / "cipher.mps"))
+            mps_path = json_file_name.parent / f"{json_file_name.stem}.mps"
+            self.milp.write_mps(str(mps_path))
 
         # Write SAT model if present
         if self.sat is not None:
-            self.sat.write(str(export_dir / "cipher.cnf"))
+            cnf_path = json_file_name.parent / f"{json_file_name.stem}.cnf"
+            self.sat.write(str(cnf_path))
 
-        print(f"Object '{self.name}' has been exported to {export_dir}.")
+        print(f"Object '{self.name}' has been exported to {json_file_name.parent}.")
 
     @classmethod
     def _init_from_dict(cls, d):
@@ -2023,7 +2033,7 @@ class Cipher:
 
         # Restore the IN node's result (index 0)
         cipher.nodes[0].results = d["nodes"][0]["results"]
-        w = 1 if type(cipher) == Cipher else cipher.wordsize
+        w = 1 if type(cipher) in (Cipher, SBoxCipher) else cipher.wordsize
 
         for node_idx, nd in enumerate(d["nodes"][1:], start=1):
             component = node_from_dict(nd)
@@ -2084,14 +2094,14 @@ class Cipher:
         return cipher
 
     @classmethod
-    def load(cls, path):
+    def load(cls, file):
         r"""
         Load and return a :class:`Cipher` from the export directory at
-        ``path`` that was previously written by :meth:`export`.
+        ``file`` that was previously written by :meth:`export`.
 
         INPUT:
 
-            - ``path`` -- string or path-like; Path to the export directory.
+            - ``file`` -- string or path; Specifies file to be written to.
 
         OUTPUT: A reconstructed :class:`Cipher` instance.
 
@@ -2118,15 +2128,16 @@ class Cipher:
             sage: cipher.analyse(model_options)
             5312 variables and 8641 constraints were written to '...'
             12
-            sage: cipher.export(tmp)
+            sage: export_file = model_options.path / f"{cipher.name}.json"
+            sage: cipher.export(export_file)
             Writing problem data to...
             31602 records were written
             Object 'PRESENT' has been exported to ...
-            sage: loaded = WordSBoxCipher.load(tmp)
+            sage: loaded = WordSBoxCipher.load(export_file)
             sage: sorted(loaded.__dict__) == sorted(cipher.__dict__)
             True
             sage: import shutil
-            sage: shutil.rmtree(tmp)
+            sage: shutil.rmtree(model_options.path)
 
         Same with SAT:
 
@@ -2149,15 +2160,16 @@ class Cipher:
             sage: cipher.analyse(model_options)
             5312 variables and 13441 clauses were written to...
             12
-            sage: cipher.export(tmp)
+            sage: export_file = model_options.path / f"{cipher.name}.json"
+            sage: cipher.export(export_file)
             Object 'PRESENT' has been exported to ...
-            sage: loaded = Cipher.load(tmp)
+            sage: loaded = Cipher.load(export_file)
             sage: loaded.analyse(model_options)
             Using existing SAT model, make sure it is up to date!
             ...
             12
             sage: import shutil
-            sage: shutil.rmtree(tmp)
+            sage: shutil.rmtree(model_options.path)
             
 
             sage: # optional - cadical, espresso
@@ -2179,26 +2191,26 @@ class Cipher:
             sage: cipher.analyse(model_options)
             5312 variables and 13441 clauses were written to...
             12
-            sage: cipher.export(tmp)
+            sage: export_file = model_options.path / f"{cipher.name}.json"
+            sage: cipher.export(export_file)
             Object 'PRESENT' has been exported to ...
-            sage: loaded = Cipher.load(tmp)
+            sage: loaded = Cipher.load(export_file)
             sage: loaded.get_trail(model_options) == cipher.get_trail(model_options)
             True
             sage: loaded == cipher
             True
             sage: import shutil
-            sage: shutil.rmtree(tmp)
+            sage: shutil.rmtree(model_options.path)
 
         """
-
-        export_dir = Path(path)
-        with open(export_dir / "cipher.json") as f:
+        cipher_file = Path(file)
+        with open(cipher_file) as f:
             d = json.load(f)
 
         cipher = cls._from_dict(d)
 
         # Reconstruct MILP from MPS file when present
-        mps_path = export_dir / "cipher.mps"
+        mps_path = cipher_file.parent / f"{cipher_file.stem}.mps"
         if mps_path.exists() and d.get("has_milp"):
             cipher.milp = _read_mps(str(mps_path))
             backend = cipher.milp.get_backend()
@@ -2249,7 +2261,7 @@ class Cipher:
                 cipher.MILP_OUT = milp_out_dict
 
         # Reconstruct SAT from CNF file when present
-        cnf_path = export_dir / "cipher.cnf"
+        cnf_path = cipher_file.parent / f"{cipher_file.stem}.cnf"
         if cnf_path.exists() and d["has_sat"]:
 
             sat = DIMACS()

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -1971,7 +1971,8 @@ class Cipher:
 
         """
         export_dir = Path(path)
-        export_dir.mkdir(parents=True, exist_ok=True)
+        if not export_dir.exists():
+            export_dir.mkdir(parents=True, exist_ok=True)
 
         # Write JSON bundle (everything that is plain-Python serialisable)
         with open(export_dir / "cipher.json", "w") as f:

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -1556,6 +1556,7 @@ class Cipher:
                     model_options, self.sat
                 )
             if self._return_immediately_:
+                self._return_immediately_ = False
                 return
             if model_options.number_of_solutions > 1:
                 all_results = model_options.sat_solver.solve_multiple(
@@ -2379,7 +2380,7 @@ class Cipher:
                 STRING += f"\t\\draw (#1, #2 + {rw}) -- (#1 + {self.cols}, #2 + {rw});\n"
             STRING += "}\n"
 
-        scale = sqrt((-0.75 + self._wrd/4) * 4)
+        scale = sqrt(self._wrd)
 
         STRING += "\\begin{center}\n"
         if isinstance(self, AESlike):

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -2100,7 +2100,7 @@ class Cipher:
 
             sage: # optional - scip, espresso
             sage: import tempfile
-            sage: from civerly.cipher import Cipher
+            sage: from civerly.wordsboxcipher import WordSBoxCipher
             sage: from civerly.model_options import *
             sage: from civerly.cipher_implementations.present import PRESENT_CVL
             sage: cipher = PRESENT_CVL(4)
@@ -2121,10 +2121,8 @@ class Cipher:
             Writing problem data to...
             31602 records were written
             Object 'PRESENT' has been exported to ...
-            sage: loaded = Cipher.load(tmp)
-            sage: loaded.get_trail(model_options) == cipher.get_trail(model_options)
-            True
-            sage: loaded == cipher
+            sage: loaded = WordSBoxCipher.load(tmp)
+            sage: sorted(loaded.__dict__) == sorted(cipher.__dict__)
             True
             sage: import shutil
             sage: shutil.rmtree(tmp)
@@ -2239,7 +2237,7 @@ class Cipher:
                         milp_out_dict[idx] = lf
                     else:
                         node_idx = _before_brackets(var_name)
-                        # x_dicts.setdefault(node_idx, {})
+                        x_dicts.setdefault(node_idx, {})
                         x_dicts[node_idx][idx] = lf
 
                 # add attributes X, MILP_IN, MILP_OUT.

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -446,6 +446,9 @@ class Cipher:
         # Used by generate_report() and get_trail() to avoid re-reading
         # solution files.
         self.trail_nodes = []
+
+        # flag to stop when a model needs to be solved externally
+        self._return_immediately_ = False
         
         self.milp = None
         self.sat = None
@@ -1252,8 +1255,6 @@ class Cipher:
         model_options_ = replace(model_options, write_to_file=False)
         model_options, model_options_ = model_options_, model_options
 
-        # flag to stop when a model needs to be solved externally
-        self._return_immediately_ = False
 
         # ------------------------------------------------------------------------
         cnf_file_name = (

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -60,31 +60,6 @@ from civerly.solvers import NoSolverWarning
 from civerly.component import Component
 from civerly.trail import TrailNode
 
-
-class _LinearFuncDict:
-    r"""
-    Minimal ``MIPVariable``-compatible wrapper built from a pre-populated
-    ``{int_key: LinearFunction}`` dict.  Used when reconstructing a MILP
-    from an MPS file so that ``X[i][j]`` / ``MILP_IN[k]`` return the correct
-    ``LinearFunction`` without allocating new backend variables.
-    """
-
-    def __init__(self, d):
-        self._d = d
-
-    def __getitem__(self, key):
-        return self._d[key]
-
-    def __iter__(self):
-        return iter(self._d.values())
-
-    def __len__(self):
-        return len(self._d)
-
-    def items(self):
-        return self._d.items()
-
-
 class CipherNotValidException(Exception):
     def __init__(self):
         r"""
@@ -2121,6 +2096,8 @@ class Cipher:
 
         TESTS::
 
+        Reconstruct a cipher after analysing with MILP:
+
             sage: # optional - scip, espresso
             sage: import tempfile
             sage: from civerly.cipher import Cipher
@@ -2152,6 +2129,37 @@ class Cipher:
             sage: import shutil
             sage: shutil.rmtree(tmp)
 
+        Same with SAT:
+
+            sage: # optional - cadical, espresso
+            sage: import tempfile
+            sage: from civerly.cipher import Cipher
+            sage: from civerly.model_options import *
+            sage: from civerly.cipher_implementations.present import PRESENT_CVL
+            sage: cipher = PRESENT_CVL(4)
+            sage: tmp = tempfile.mkdtemp()
+            sage: model_options = MODEL_OPTIONS(
+            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:   optimization=OPTIMIZATION.SAT,
+            ....:   granularity=GRANULARITY.BITWISE,
+            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:   sat_solver=CADICAL_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
+            ....:   path=Path(tmp))
+            sage: cipher.analyse(model_options)
+            5312 variables and 13441 clauses were written to...
+            12
+            sage: cipher.export(tmp)
+            Object 'PRESENT' has been exported to ...
+            sage: loaded = Cipher.load(tmp)
+            sage: loaded.analyse(model_options)
+            Using existing SAT model, make sure it is up to date!
+            ...
+            12
+            sage: import shutil
+            sage: shutil.rmtree(tmp)
+            
 
             sage: # optional - cadical, espresso
             sage: import tempfile
@@ -2196,23 +2204,27 @@ class Cipher:
             cipher.milp = _read_mps(str(mps_path))
             backend = cipher.milp.get_backend()
 
-            # Rebuild self.X, self.MILP_IN, self.MILP_OUT as _LinearFuncDict
-            # wrappers so callers can use X[i][j] exactly as before.
+            # Rebuild the attributes self.X, self.MILP_IN, self.MILP_OUT
+            # from self.milp
             lf_parent = cipher.milp.linear_functions_parent()
             name_to_col = {
                 backend.col_name(j): j for j in range(backend.ncols())
             }
 
             def _lf(col_name):
+                """
+                translates the variable name to the actual MIPVariable,
+                by constructing a (trivial) linear function with this variable.
+
+                Example: X6[62] -> x_5119
+                """
                 return lf_parent({name_to_col[col_name]: 1})
 
-            # dictionaries_milp maps "X5[3]" -> "IN[0]"; its keys cover every
-            # backend variable, so we can reconstruct X, MILP_IN, MILP_OUT.
+            # reconstruct X, MILP_IN, MILP_OUT from dictionaries_milp
             if hasattr(cipher, "dictionaries_milp") and \
                     cipher.dictionaries_milp is not None:
 
-                # X is a list indexed by node number; each entry is a
-                # _LinearFuncDict mapping bit-index -> LinearFunction.
+                # X is a list indexed by node number
                 x_dicts = {}
                 milp_in_dict = {}
                 milp_out_dict = {}
@@ -2227,11 +2239,15 @@ class Cipher:
                         milp_out_dict[idx] = lf
                     else:
                         node_idx = _before_brackets(var_name)
-                        x_dicts.setdefault(node_idx, {})[idx] = lf
+                        # x_dicts.setdefault(node_idx, {})
+                        x_dicts[node_idx][idx] = lf
 
-                cipher.X = list(map(_LinearFuncDict, x_dicts))
-                cipher.MILP_IN    = _LinearFuncDict(milp_in_dict)
-                cipher.MILP_OUT   = _LinearFuncDict(milp_out_dict)
+                # add attributes X, MILP_IN, MILP_OUT.
+                # These are not MIPVariable objects, but rather
+                # just dictionaries of linear functions (so functionality-wise the absolute same)
+                cipher.X = x_dicts
+                cipher.MILP_IN  = milp_in_dict
+                cipher.MILP_OUT = milp_out_dict
 
         # Reconstruct SAT from CNF file when present
         cnf_path = export_dir / "cipher.cnf"

--- a/src/civerly/cipher.py
+++ b/src/civerly/cipher.py
@@ -47,15 +47,42 @@ from copy import deepcopy
 import subprocess
 import json
 import glob
+from pathlib import Path
 
+from civerly.util import _before_brackets, _between_brackets
 from civerly.util import translate_sat_clause
 from civerly.util import suppress_output
+from civerly.util import _read_mps
 from civerly.model_options import InvalidModelOptionException
 from civerly.model_options import OPTIMIZATION, GRANULARITY
 from civerly.model_options import CRYPTANALYSIS
 from civerly.solvers import NoSolverWarning
 from civerly.component import Component
 from civerly.trail import TrailNode
+
+
+class _LinearFuncDict:
+    r"""
+    Minimal ``MIPVariable``-compatible wrapper built from a pre-populated
+    ``{int_key: LinearFunction}`` dict.  Used when reconstructing a MILP
+    from an MPS file so that ``X[i][j]`` / ``MILP_IN[k]`` return the correct
+    ``LinearFunction`` without allocating new backend variables.
+    """
+
+    def __init__(self, d):
+        self._d = d
+
+    def __getitem__(self, key):
+        return self._d[key]
+
+    def __iter__(self):
+        return iter(self._d.values())
+
+    def __len__(self):
+        return len(self._d)
+
+    def items(self):
+        return self._d.items()
 
 
 class CipherNotValidException(Exception):
@@ -1475,11 +1502,13 @@ class Cipher:
             sat.add_clause(tup)
 
         if model_options.write_to_file:
-            sat.write()
+            cnf_target = str(
+                model_options.path / (self.name.replace(' ', '_') + ".cnf")
+            )
+            sat.write(cnf_target)
             print(
                 f"{sat.nvars()} variables and {len(sat.clauses())} clauses "
-                "were written to "
-                f"'{str(model_options.path / (self.name + '.cnf'))}'"
+                f"were written to '{cnf_target}'"
             )
 
         self.sat = sat
@@ -1842,18 +1871,39 @@ class Cipher:
             "edges": edge_dicts,
             "outputs": output_dicts,
             "results": self.results,
+            # Model state flags
+            "has_milp": self.milp is not None,
+            "has_sat": self.sat is not None,
+            # MILP auxiliary state (set after Cipher.model())
+            "sum_arr_milp": getattr(self, "sum_arr_milp", None),
+            "dictionaries_milp": getattr(self, "dictionaries_milp", None),
+            "inv_dictionaries_milp": getattr(self, "inv_dictionaries_milp", None),
+            # SAT auxiliary state (set after Cipher.model())
+            "sum_arr_sat": getattr(self, "sum_arr_sat", None),
+            "SAT_IN": getattr(self, "SAT_IN", None),
+            "SAT_OUT": getattr(self, "SAT_OUT", None),
+            "dictionaries_sat": getattr(self, "dictionaries_sat", None),
+            "inv_dictionaries_sat": getattr(self, "inv_dictionaries_sat", None),
         }
 
     def export(self, path):
         r"""
-        Write ``self`` to a JSON file at ``path``.
+        Write ``self`` to a directory at ``path``.
 
-        The file can be loaded back with :meth:`Cipher.load`.
+        The directory is created if it does not exist.  It will contain:
+
+        - ``cipher.json``  — all JSON-serialisable attributes plus flags
+          indicating whether a MILP or SAT model was present.
+        - ``cipher.mps``   — (optional) MILP model in MPS format, written
+          only when ``self.milp`` is not ``None``.
+        - ``cipher.cnf``   — (optional) SAT model in DIMACS CNF format,
+          written only when ``self.sat`` is not ``None``.
+
+        The bundle can be reloaded with :meth:`Cipher.load`.
 
         INPUT:
 
-            - ``path`` -- string or path-like; Destination file path.
-              The ``.json`` extension is conventional but not enforced.
+            - ``path`` -- string or path-like; Destination directory path.
 
         EXAMPLES::
 
@@ -1872,8 +1922,7 @@ class Cipher:
             sage: cipher.add_output([(node0, (i, i)) for i in range(3)])
             sage: cipher.add_output([(node1, (i, i + 3)) for i in range(3)])
             sage: cipher.add_output([(node2, (i, i + 6)) for i in range(3)])
-            sage: with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
-            ....:     tmp = f.name
+            sage: tmp = tempfile.mkdtemp()
 
         Before analysis, ``results`` is ``[]`` and round-trips as such::
 
@@ -1884,7 +1933,7 @@ class Cipher:
             True
 
         After analysis, ``results`` holds the trail bit-patterns and is
-        preserved verbatim through the JSON file::
+        preserved verbatim through the export bundle::
 
             sage: from civerly.model_options import *
             sage: model_options = MODEL_OPTIONS(
@@ -1902,27 +1951,41 @@ class Cipher:
             sage: cipher.export(tmp)
             Object 'test' has been exported to ...
             sage: loaded = Cipher.load(tmp)
-            sage: os.unlink(tmp)
+            sage: import shutil; shutil.rmtree(tmp)
             sage: cipher == loaded and loaded.results == cipher.results
             True
 
         Again with a different cipher type::
+
             sage: import tempfile
             sage: from civerly.cipher import Cipher
             sage: from civerly.cipher_implementations.aes import AES_CVL
             sage: aes = AES_CVL(4)
-            sage: with tempfile.NamedTemporaryFile(suffix='.json') as f:
-            ....:   tmp = f.name
-            ....:   aes.export(tmp)
-            ....:   loaded = Cipher.load(tmp)
-            ....:   aes == loaded
+            sage: tmp = tempfile.mkdtemp()
+            sage: aes.export(tmp)
             Object 'AES' has been exported to ...
+            sage: loaded = Cipher.load(tmp)
+            sage: import shutil; shutil.rmtree(tmp)
+            sage: aes == loaded
             True
 
         """
-        with open(path, "w") as f:
+        export_dir = Path(path)
+        export_dir.mkdir(parents=True, exist_ok=True)
+
+        # Write JSON bundle (everything that is plain-Python serialisable)
+        with open(export_dir / "cipher.json", "w") as f:
             json.dump(self._to_dict(), f, default=lambda obj: int(obj))
-        print(f"Object '{self.name}' has been exported to {path}.")
+
+        # Write MILP model if present
+        if self.milp is not None:
+            self.milp.write_mps(str(export_dir / "cipher.mps"))
+
+        # Write SAT model if present
+        if self.sat is not None:
+            self.sat.write(str(export_dir / "cipher.cnf"))
+
+        print(f"Object '{self.name}' has been exported to {export_dir}.")
 
     @classmethod
     def _init_from_dict(cls, d):
@@ -2006,6 +2069,32 @@ class Cipher:
 
         cipher.results = d["results"]
 
+        # Restore MILP auxiliary state (plain Python, stored in JSON)
+        if d.get("sum_arr_milp") is not None:
+            cipher.sum_arr_milp = d["sum_arr_milp"]
+        if d.get("dictionaries_milp") is not None:
+            cipher.dictionaries_milp = d["dictionaries_milp"]
+        if d.get("inv_dictionaries_milp") is not None:
+            cipher.inv_dictionaries_milp = d["inv_dictionaries_milp"]
+
+        # Restore SAT auxiliary state (plain Python, stored in JSON)
+        # dictionaries_sat / inv_dictionaries_sat have integer keys that
+        # become strings in JSON — convert them back.
+        if d.get("sum_arr_sat") is not None:
+            cipher.sum_arr_sat = d["sum_arr_sat"]
+        if d.get("SAT_IN") is not None:
+            cipher.SAT_IN = d["SAT_IN"]
+        if d.get("SAT_OUT") is not None:
+            cipher.SAT_OUT = d["SAT_OUT"]
+        if d.get("dictionaries_sat") is not None:
+            cipher.dictionaries_sat = [{
+                int(k): v for k, v in dd.items()
+            } for dd in d["dictionaries_sat"]]
+        if d.get("inv_dictionaries_sat") is not None:
+            cipher.inv_dictionaries_sat = [{
+                int(k): v for k, v in dd.items()
+            } for dd in d["inv_dictionaries_sat"]]
+
     @classmethod
     def _from_dict(cls, d):
         r"""
@@ -2019,18 +2108,138 @@ class Cipher:
     @classmethod
     def load(cls, path):
         r"""
-        Load and return a :class:`Cipher` from the JSON file at ``path``
-        that was previously written by :meth:`export`.
+        Load and return a :class:`Cipher` from the export directory at
+        ``path`` that was previously written by :meth:`export`.
 
         INPUT:
 
-            - ``path`` -- string or path-like; Path to the JSON file.
+            - ``path`` -- string or path-like; Path to the export directory.
 
         OUTPUT: A reconstructed :class:`Cipher` instance.
+
+        TESTS::
+
+            sage: # optional - scip, espresso
+            sage: import tempfile
+            sage: from civerly.cipher import Cipher
+            sage: from civerly.model_options import *
+            sage: from civerly.cipher_implementations.present import PRESENT_CVL
+            sage: cipher = PRESENT_CVL(4)
+            sage: tmp = tempfile.mkdtemp()
+            sage: model_options = MODEL_OPTIONS(
+            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:   optimization=OPTIMIZATION.MILP,
+            ....:   granularity=GRANULARITY.BITWISE,
+            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:   milp_solver=SCIP_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
+            ....:   path=Path(tmp))
+            sage: cipher.analyse(model_options)
+            5312 variables and 8641 constraints were written to '...'
+            12
+            sage: cipher.export(tmp)
+            Writing problem data to...
+            31602 records were written
+            Object 'PRESENT' has been exported to ...
+            sage: loaded = Cipher.load(tmp)
+            sage: loaded.get_trail(model_options) == cipher.get_trail(model_options)
+            True
+            sage: loaded == cipher
+            True
+            sage: import shutil
+            sage: shutil.rmtree(tmp)
+
+
+            sage: # optional - cadical, espresso
+            sage: import tempfile
+            sage: from civerly.cipher import Cipher
+            sage: from civerly.model_options import *
+            sage: from civerly.cipher_implementations.present import PRESENT_CVL
+            sage: cipher = PRESENT_CVL(4)
+            sage: tmp = tempfile.mkdtemp()
+            sage: model_options = MODEL_OPTIONS(
+            ....:   cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:   optimization=OPTIMIZATION.SAT,
+            ....:   granularity=GRANULARITY.BITWISE,
+            ....:   linear_layer_modeling=LINEAR_LAYER_MODELING.EXCLUDE_ODD,
+            ....:   sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:   sat_solver=CADICAL_CVL(),
+            ....:   logic_minimizer=ESPRESSO_CVL(),
+            ....:   path=Path(tmp))
+            sage: cipher.analyse(model_options)
+            5312 variables and 13441 clauses were written to...
+            12
+            sage: cipher.export(tmp)
+            Object 'PRESENT' has been exported to ...
+            sage: loaded = Cipher.load(tmp)
+            sage: loaded.get_trail(model_options) == cipher.get_trail(model_options)
+            True
+            sage: loaded == cipher
+            True
+            sage: import shutil
+            sage: shutil.rmtree(tmp)
+
         """
-        with open(path) as f:
+
+        export_dir = Path(path)
+        with open(export_dir / "cipher.json") as f:
             d = json.load(f)
-        return cls._from_dict(d)
+
+        cipher = cls._from_dict(d)
+
+        # Reconstruct MILP from MPS file when present
+        mps_path = export_dir / "cipher.mps"
+        if mps_path.exists() and d.get("has_milp"):
+            cipher.milp = _read_mps(str(mps_path))
+            backend = cipher.milp.get_backend()
+
+            # Rebuild self.X, self.MILP_IN, self.MILP_OUT as _LinearFuncDict
+            # wrappers so callers can use X[i][j] exactly as before.
+            lf_parent = cipher.milp.linear_functions_parent()
+            name_to_col = {
+                backend.col_name(j): j for j in range(backend.ncols())
+            }
+
+            def _lf(col_name):
+                return lf_parent({name_to_col[col_name]: 1})
+
+            # dictionaries_milp maps "X5[3]" -> "IN[0]"; its keys cover every
+            # backend variable, so we can reconstruct X, MILP_IN, MILP_OUT.
+            if hasattr(cipher, "dictionaries_milp") and \
+                    cipher.dictionaries_milp is not None:
+
+                # X is a list indexed by node number; each entry is a
+                # _LinearFuncDict mapping bit-index -> LinearFunction.
+                x_dicts = {}
+                milp_in_dict = {}
+                milp_out_dict = {}
+
+                for var_name in name_to_col:
+                    prefix = var_name[:var_name.index("[")]
+                    idx = _between_brackets(var_name)
+                    lf = _lf(var_name)
+                    if prefix == "IN":
+                        milp_in_dict[idx] = lf
+                    elif prefix == "OUT":
+                        milp_out_dict[idx] = lf
+                    else:
+                        node_idx = _before_brackets(var_name)
+                        x_dicts.setdefault(node_idx, {})[idx] = lf
+
+                cipher.X = list(map(_LinearFuncDict, x_dicts))
+                cipher.MILP_IN    = _LinearFuncDict(milp_in_dict)
+                cipher.MILP_OUT   = _LinearFuncDict(milp_out_dict)
+
+        # Reconstruct SAT from CNF file when present
+        cnf_path = export_dir / "cipher.cnf"
+        if cnf_path.exists() and d["has_sat"]:
+
+            sat = DIMACS()
+            sat.read(str(cnf_path))
+            cipher.sat = sat
+
+        return cipher
 
     def _latex_header(self, model_options, objective_value) -> str:
         r"""

--- a/src/civerly/cipher_implementations/toy_ciphers/toy9.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy9.py
@@ -76,6 +76,8 @@ class Toy9:
             ....:       logic_minimizer=ESPRESSO_CVL(),
             ....:       path=Path(tmpdir))
             sage: cipher.analyse(model_options)
+            36 variables and 85 constraints were written to...
+            1.4150374993
             sage: export_path = model_options.path / f"{cipher.name}.json"
             sage: cipher.export(export_path)
             Writing problem data to ...

--- a/src/civerly/cipher_implementations/toy_ciphers/toy9.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy9.py
@@ -57,6 +57,37 @@ class Toy9:
             [  0 ,  1] (trying w =   0) : UNSAT
             1
 
+        Testing workflow of `Cipher.load`:
+
+            sage: # optional - scip # optional - espresso
+            sage: from civerly.cipher_implementations.toy_ciphers.toy9 \
+            ....:   import Toy9
+            sage: from civerly.model_options import *
+            sage: from pathlib import Path
+            sage: import tempfile
+            sage: cipher = Toy9()
+            sage: with tempfile.TemporaryDirectory(delete=False) as tmpdir:
+            ....:   model_options = MODEL_OPTIONS(
+            ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+            ....:       optimization=OPTIMIZATION.MILP,
+            ....:       granularity=GRANULARITY.BITWISE,
+            ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+            ....:       milp_solver=SCIP_CVL(),
+            ....:       logic_minimizer=ESPRESSO_CVL(),
+            ....:       path=Path(tmpdir))
+            sage: cipher.analyse(model_options)
+            sage: export_path = model_options.path / f"{cipher.name}.json"
+            sage: cipher.export(export_path)
+            Writing problem data to ...
+            335 records were written
+            Object 'toy9' has been exported to ...
+            sage: from civerly.sboxcipher import SBoxCipher
+            sage: from civerly.wordsboxcipher import WordSBoxCipher
+            sage: loaded1 = SBoxCipher.load(export_path)
+        
+            
+            sage: import shutil
+            sage: shutil.rmtree(model_options.path)
         """
 
         cipher = SBoxCipher(4, 4, name="toy9")

--- a/src/civerly/cipher_implementations/toy_ciphers/toy9.py
+++ b/src/civerly/cipher_implementations/toy_ciphers/toy9.py
@@ -84,8 +84,6 @@ class Toy9:
             sage: from civerly.sboxcipher import SBoxCipher
             sage: from civerly.wordsboxcipher import WordSBoxCipher
             sage: loaded1 = SBoxCipher.load(export_path)
-        
-            
             sage: import shutil
             sage: shutil.rmtree(model_options.path)
         """

--- a/src/civerly/util.py
+++ b/src/civerly/util.py
@@ -781,10 +781,9 @@ def translate_var(cipher, node, local_var):
 
     return var
 
-@staticmethod
 def _read_mps(path):
     r"""
-    Parse a fixed-format MPS file written by
+    Parse an MPS file written by
     :meth:`MixedIntegerLinearProgram.write_mps` and return a
     :class:`sage.numerical.mip.MixedIntegerLinearProgram` containing
     the variables, constraints, and objective from the file.
@@ -793,108 +792,184 @@ def _read_mps(path):
     :class:`sage.numerical.backends.glpk_backend.GLPKBackend` does not
     have a ``read_mps`` method implemented.
 
+    An MPS file contains the following information:
+    
+    - ROWS: The constraints of the MILP. Each row equals one constraint.
+        - 'N': The objective row
+        - 'E': A row with equality '=='
+        - 'L': A row with '<='
+        - 'G': A row with '>='
+
+    - COLUMNS: Contains variable name, each row in which it appears + the coefficients
+        - example: 'X14[21]  R0001484    1   R0001474    -1'
+        
+    - RHS: Specifies the rhs value of each row. If row is not included, the rhs-value is 0.
+        - example: 'RHS1    R0002580    4   R0002581    3'
+
     INPUT:
 
         - ``path`` -- string or path-like; path to the ``.mps`` file.
 
     OUTPUT:
 
-        A :class:`~sage.numerical.mip.MixedIntegerLinearProgram` instance
+        A :class:`sage.numerical.mip.MixedIntegerLinearProgram` instance
         (minimization, GLPK solver) ready to be solved.
-    """
-    from sage.numerical.mip import MixedIntegerLinearProgram
 
+    TESTS:
+
+        sage: # optional - espresso
+        sage: from civerly.cipher_implementations.toy_ciphers.toy3 \
+        ....:   import Toy3
+        sage: from civerly.model_options import *
+        sage: cipher = Toy3()
+        sage: import tempfile
+        sage: with tempfile.TemporaryDirectory(delete=False) as tmpdir:
+        ....:   model_options = MODEL_OPTIONS(
+        ....:       cryptanalysis=CRYPTANALYSIS.DIFFERENTIAL,
+        ....:       optimization=OPTIMIZATION.MILP,
+        ....:       granularity=GRANULARITY.BITWISE,
+        ....:       linear_layer_modeling=LINEAR_LAYER_MODELING.MORE_DUMMIES,
+        ....:       sbox_modeling=SBOX_MODELING.LOGICAL_COND_ESPRESSO,
+        ....:       logic_minimizer=ESPRESSO_CVL(),
+        ....:       path=Path(tmpdir))
+        sage: cipher.model(model_options)
+        854 variables and 2993 constraints were written to ...
+        Boolean Program (minimization, 854 variables, 2993 constraints)
+        sage: from civerly.util import _read_mps
+        sage: _read_mps(model_options.path / f"{cipher.name}.mps")
+        Boolean Program (minimization, 854 variables, 2993 constraints)
+        sage: import shutil
+        sage: shutil.rmtree(tmpdir)
+
+
+    """
+    
+    # stores current section inside MPS file.
+    # is one of 'ROWS', 'COLUMNS', 'RHS', 'BOUNDS'.
     section = None
-    obj_row = None         # name of the N-type (objective) row
-    row_order = []         # [(row_name, row_type), ...] for constraint rows
-    var_order = []         # variable names in order of first appearance
-    var_seen = set()
-    var_coeffs = {}        # var_name -> {row_name: float}
-    rhs = {}               # row_name -> float
-    bounds_data = {}       # var_name -> {'lower': float|None, 'upper': float|None}
-    var_integer = set()    # variables declared inside an INTORG…INTEND block
+    
+    # name of the objective row
+    obj_row = None
+    
+    # contains the constraint rows: [(R0001253, E), ...]
+    row_order = []
+
+    # variable names in order of first appearance
+    variables = []
+    
+    # dictionary mapping variable to row of occurence (+ coefficient)
+    # example: 'X3[12]' -> {R0002653: 1.0}
+    var_coeffs = {}
+
+    # Contains the constant part (rhs) of each row
+    # {R0001351: -10.0, ...}
+    rhs = {}
+    
+    # var_name -> {'lower': float|None, 'upper': float|None}
+    bounds_data = {}
+    
+    # variables declared inside an INTORG...INTEND block,
+    # i.e. integer variables inside this MILP.
+    # -> ['X1[2]', ..., 'X4[21]']
+    integer_vars = []
+
     in_integer_block = False
 
-    with open(path) as fh:
-        for raw in fh:
-            line = raw.rstrip('\n')
-            if not line or line[0] in ('*', '$'):
+    # parse the MPS file
+    with open(path) as f:
+        for line in f.readlines():
+            if line[0] in ('*', '$'):
                 continue  # blank line or comment
 
-            # Section headers start at column 0 (no leading whitespace)
-            if line[0] not in (' ', '\t'):
+            # Section headers start at column 0 (no leading whitespace or empty lines)
+            if line[0] not in (' ', '\t', '\n'):
                 section = line.split()[0].upper()
                 continue
 
             tokens = line.split()
-            if not tokens:
-                continue
-
+            # ------------------------------------------------
+            # collect all rows in row_order
             if section == 'ROWS':
-                rtype, rname = tokens[0].upper(), tokens[1]
+                assert len(tokens) == 2, (
+                    "MPS file is formatted wrongly in section ROWS"
+                )
+                rtype, rname = tokens
+                # there is only one 'N'-row (containing the objective)
                 if rtype == 'N':
-                    if obj_row is None:
-                        obj_row = rname
+                    obj_row = rname
                 else:
                     row_order.append((rname, rtype))
-
+            # ------------------------------------------------
             elif section == 'COLUMNS':
+                # if current line is the header of the COLUMNS table
                 if len(tokens) >= 3 and tokens[1] == "'MARKER'":
                     in_integer_block = (tokens[2] == "'INTORG'")
                     continue
+
                 vname = tokens[0]
-                if vname not in var_seen:
-                    var_order.append(vname)
-                    var_seen.add(vname)
+                if vname not in variables:
+                    variables.append(vname)
                     var_coeffs[vname] = {}
                     if in_integer_block:
-                        var_integer.add(vname)
+                        integer_vars.append(vname)
+                
+                # parse occurences into var_coeffs
                 i = 1
                 while i + 1 < len(tokens):
                     var_coeffs[vname][tokens[i]] = float(tokens[i + 1])
                     i += 2
-
+            # ------------------------------------------------
             elif section == 'RHS':
                 i = 1
                 while i + 1 < len(tokens):
                     rhs[tokens[i]] = float(tokens[i + 1])
                     i += 2
-
+            # ------------------------------------------------
             elif section == 'BOUNDS':
+                assert len(tokens) == 4, (
+                    "MPS file is formatted wrongly in section BOUNDS"
+                )
                 btype = tokens[0].upper()
                 vname = tokens[2]
                 val = float(tokens[3]) if len(tokens) > 3 else None
                 if vname not in bounds_data:
                     bounds_data[vname] = {'lower': 0.0, 'upper': None}
                 b = bounds_data[vname]
-                if btype == 'UP':
+                if btype == 'UP':   # upper
                     b['upper'] = val
-                elif btype == 'LO':
+                elif btype == 'LO': # lower
                     b['lower'] = val
-                elif btype == 'FX':
-                    b['lower'] = b['upper'] = val
-                elif btype == 'FR':
-                    b['lower'] = b['upper'] = None
+                elif btype == 'FX': # fix
+                    b['lower'] = val
+                    b['upper'] = val
+                elif btype == 'FR': # free
+                    b['lower'] = None
+                    b['upper'] = None
                 elif btype == 'MI':
                     b['lower'] = None
-                elif btype == 'BV':
+                elif btype == 'BV': # binary variable
                     b['lower'], b['upper'] = 0.0, 1.0
-                    var_integer.add(vname)
+            # ------------------------------------------------
+
 
     # --- Build the MILP from the parsed data ---
     milp = MixedIntegerLinearProgram(maximization=False, solver="GLPK")
     backend = milp.get_backend()
     var_to_col = {}
     obj_coeffs = []
-
-    for col_idx, vname in enumerate(var_order):
+    for col_idx, vname in enumerate(variables):
         b = bounds_data.get(vname, {'lower': 0.0, 'upper': None})
-        lower = b.get('lower', 0.0)
-        upper = b.get('upper', None)
-        is_int = vname in var_integer
+        lower, upper = b['lower'], b['upper']
+
+        # indicates whether current variable is an integer or binary
+        is_int = vname in integer_vars
         is_bin = is_int and lower == 0.0 and upper == 1.0
-        obj_coeff = var_coeffs[vname].get(obj_row, 0.0) if obj_row else 0.0
+        
+        # construct objective
+        # (by checking whether vname is part of the objective-row)
+        obj_coeff = var_coeffs[vname].get(obj_row, 0.0)
         obj_coeffs.append(obj_coeff)
+
         var_to_col[vname] = col_idx
         backend.add_variable(
             lower_bound=lower,
@@ -905,22 +980,27 @@ def _read_mps(path):
             name=vname,
         )
 
+    # set objective
     if obj_coeffs:
         backend.set_objective(obj_coeffs)
 
+    # add constraints back in
     for rname, rtype in row_order:
+        # construct coefficients vector
         coeffs = [
             (var_to_col[vname], var_coeffs[vname][rname])
-            for vname in var_order
+            for vname in variables
             if rname in var_coeffs[vname]
         ]
         rhs_val = rhs.get(rname, 0.0)
-        if rtype == 'L':
+        if rtype == 'L': # '<='
             lb, ub = None, rhs_val
-        elif rtype == 'G':
+        elif rtype == 'G': # '<='
             lb, ub = rhs_val, None
-        else:  # 'E'
+        else:  # 'E', '=='
             lb, ub = rhs_val, rhs_val
+
+        # add into backend
         backend.add_linear_constraint(coeffs, lb, ub, name=rname)
 
     return milp

--- a/src/civerly/util.py
+++ b/src/civerly/util.py
@@ -781,6 +781,149 @@ def translate_var(cipher, node, local_var):
 
     return var
 
+@staticmethod
+def _read_mps(path):
+    r"""
+    Parse a fixed-format MPS file written by
+    :meth:`MixedIntegerLinearProgram.write_mps` and return a
+    :class:`sage.numerical.mip.MixedIntegerLinearProgram` containing
+    the variables, constraints, and objective from the file.
+
+    This is needed because
+    :class:`sage.numerical.backends.glpk_backend.GLPKBackend` does not
+    have a ``read_mps`` method implemented.
+
+    INPUT:
+
+        - ``path`` -- string or path-like; path to the ``.mps`` file.
+
+    OUTPUT:
+
+        A :class:`~sage.numerical.mip.MixedIntegerLinearProgram` instance
+        (minimization, GLPK solver) ready to be solved.
+    """
+    from sage.numerical.mip import MixedIntegerLinearProgram
+
+    section = None
+    obj_row = None         # name of the N-type (objective) row
+    row_order = []         # [(row_name, row_type), ...] for constraint rows
+    var_order = []         # variable names in order of first appearance
+    var_seen = set()
+    var_coeffs = {}        # var_name -> {row_name: float}
+    rhs = {}               # row_name -> float
+    bounds_data = {}       # var_name -> {'lower': float|None, 'upper': float|None}
+    var_integer = set()    # variables declared inside an INTORG…INTEND block
+    in_integer_block = False
+
+    with open(path) as fh:
+        for raw in fh:
+            line = raw.rstrip('\n')
+            if not line or line[0] in ('*', '$'):
+                continue  # blank line or comment
+
+            # Section headers start at column 0 (no leading whitespace)
+            if line[0] not in (' ', '\t'):
+                section = line.split()[0].upper()
+                continue
+
+            tokens = line.split()
+            if not tokens:
+                continue
+
+            if section == 'ROWS':
+                rtype, rname = tokens[0].upper(), tokens[1]
+                if rtype == 'N':
+                    if obj_row is None:
+                        obj_row = rname
+                else:
+                    row_order.append((rname, rtype))
+
+            elif section == 'COLUMNS':
+                if len(tokens) >= 3 and tokens[1] == "'MARKER'":
+                    in_integer_block = (tokens[2] == "'INTORG'")
+                    continue
+                vname = tokens[0]
+                if vname not in var_seen:
+                    var_order.append(vname)
+                    var_seen.add(vname)
+                    var_coeffs[vname] = {}
+                    if in_integer_block:
+                        var_integer.add(vname)
+                i = 1
+                while i + 1 < len(tokens):
+                    var_coeffs[vname][tokens[i]] = float(tokens[i + 1])
+                    i += 2
+
+            elif section == 'RHS':
+                i = 1
+                while i + 1 < len(tokens):
+                    rhs[tokens[i]] = float(tokens[i + 1])
+                    i += 2
+
+            elif section == 'BOUNDS':
+                btype = tokens[0].upper()
+                vname = tokens[2]
+                val = float(tokens[3]) if len(tokens) > 3 else None
+                if vname not in bounds_data:
+                    bounds_data[vname] = {'lower': 0.0, 'upper': None}
+                b = bounds_data[vname]
+                if btype == 'UP':
+                    b['upper'] = val
+                elif btype == 'LO':
+                    b['lower'] = val
+                elif btype == 'FX':
+                    b['lower'] = b['upper'] = val
+                elif btype == 'FR':
+                    b['lower'] = b['upper'] = None
+                elif btype == 'MI':
+                    b['lower'] = None
+                elif btype == 'BV':
+                    b['lower'], b['upper'] = 0.0, 1.0
+                    var_integer.add(vname)
+
+    # --- Build the MILP from the parsed data ---
+    milp = MixedIntegerLinearProgram(maximization=False, solver="GLPK")
+    backend = milp.get_backend()
+    var_to_col = {}
+    obj_coeffs = []
+
+    for col_idx, vname in enumerate(var_order):
+        b = bounds_data.get(vname, {'lower': 0.0, 'upper': None})
+        lower = b.get('lower', 0.0)
+        upper = b.get('upper', None)
+        is_int = vname in var_integer
+        is_bin = is_int and lower == 0.0 and upper == 1.0
+        obj_coeff = var_coeffs[vname].get(obj_row, 0.0) if obj_row else 0.0
+        obj_coeffs.append(obj_coeff)
+        var_to_col[vname] = col_idx
+        backend.add_variable(
+            lower_bound=lower,
+            upper_bound=upper,
+            binary=is_bin,
+            integer=is_int and not is_bin,
+            obj=obj_coeff,
+            name=vname,
+        )
+
+    if obj_coeffs:
+        backend.set_objective(obj_coeffs)
+
+    for rname, rtype in row_order:
+        coeffs = [
+            (var_to_col[vname], var_coeffs[vname][rname])
+            for vname in var_order
+            if rname in var_coeffs[vname]
+        ]
+        rhs_val = rhs.get(rname, 0.0)
+        if rtype == 'L':
+            lb, ub = None, rhs_val
+        elif rtype == 'G':
+            lb, ub = rhs_val, None
+        else:  # 'E'
+            lb, ub = rhs_val, rhs_val
+        backend.add_linear_constraint(coeffs, lb, ub, name=rname)
+
+    return milp
 
 
 

--- a/src/civerly/wordbasedcipher.py
+++ b/src/civerly/wordbasedcipher.py
@@ -84,6 +84,56 @@ class WordBasedCipher(Cipher):
 
     @classmethod
     def _init_from_dict(cls, d):
+        """
+        Used in :meth:`self.load` in order to build this object from the loaded `.json` file.
+
+        TESTS::
+
+        Loading with any appropriate subclass of the cipher class of the exported
+        cipher restores it:
+
+            sage: from civerly.cipher_implementations.speck import SPECK_CVL
+            sage: from civerly.wordbasedcipher import WordBasedCipher
+            sage: from civerly.addrx import AddRX
+            sage: cipher = SPECK_CVL(128, 128)
+            sage: tmp = tempfile.mkdtemp()
+            sage: export_file = Path(tmp) / f"{cipher.name}.json"
+            sage: cipher.export(export_file)
+            Object 'speck' has been exported to ...
+            sage: loaded1 = WordBasedCipher.load(export_file)
+            sage: sorted(cipher.__dict__) == sorted(loaded1.__dict__)
+            True
+            sage: loaded2 = AddRX.load(export_file)
+            sage: sorted(cipher.__dict__) == sorted(loaded2.__dict__)
+            True
+            sage: import shutil
+            sage: shutil.rmtree(tmp)
+
+        However, if we try to load a cipher which is not a subclass of WordBasedCipher, 
+        the method fails:
+
+            sage: from civerly.cipher_implementations.toy_ciphers.toy4 import Toy4
+            sage: from civerly.wordbasedcipher import WordBasedCipher
+            sage: cipher = Toy4()
+            sage: tmp = tempfile.mkdtemp()
+            sage: export_file = Path(tmp) / f"{cipher.name}.json"
+            sage: cipher.export(export_file)
+            Object 'Toy4' has been exported to ...
+            sage: try: 
+            ....:   loaded1 = WordBasedCipher.load(export_file)
+            ....: except TypeError as e:
+            ....:   print(e)
+            The json dictionary does not contain the attribute 'wordsize', ...
+            sage: import shutil
+            sage: shutil.rmtree(tmp)
+
+        
+        """
+        if "wordsize" not in d.keys(): 
+            raise TypeError(
+                "The json dictionary does not contain the attribute 'wordsize', "
+                "meaning that the exported cipher was not a subclass of WordBasedCipher."
+            )
         ws = d["wordsize"]
         return cls(ws, d["input_length"] // ws, d["output_length"] // ws, name=d["name"])
 

--- a/src/civerly/wordbasedcipher.py
+++ b/src/civerly/wordbasedcipher.py
@@ -95,6 +95,7 @@ class WordBasedCipher(Cipher):
             sage: from civerly.cipher_implementations.speck import SPECK_CVL
             sage: from civerly.wordbasedcipher import WordBasedCipher
             sage: from civerly.addrx import AddRX
+            sage: import tempfile
             sage: cipher = SPECK_CVL(128, 128)
             sage: tmp = tempfile.mkdtemp()
             sage: export_file = Path(tmp) / f"{cipher.name}.json"


### PR DESCRIPTION
Fixes #15 . In particular, restores `self.milp`, `self.sat` and related attributes when executing `Cipher.load`

Changes:
- Add method `util._read_mps`, which reconstructs a `MixedIntegerLinearProgram` from an MPS file. Surprisingly, such a method does not exist in the sage implementation of `MixedIntegerLinearProgram`.
- `Cipher.export` now also writes the `self.sat`, `self.milp` attributes into files, so that `Cipher.load` recovers the entire state of `self`.
- Both methods now take in the json file name, which the cipher should be exported into / loaded from. Before, the directory was given, and the relevant files were just called `cipher.json`, `cipher.mps`, `cipher.cnf`.